### PR TITLE
ci: GitHub Actionsのpull_requestトリガーを修正し、typesを追加

### DIFF
--- a/.github/workflows/MainPackageTest.yml
+++ b/.github/workflows/MainPackageTest.yml
@@ -11,7 +11,7 @@ on:
       - develop
       - feature/*
     paths:
-      - 'package/main/src/**'
+      - 'package/main/**'
   workflow_dispatch:
 permissions:
   pull-requests: write

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+    types: [opened]
   issue_comment:
 jobs:
   pr_agent_job:


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- GitHub Actionsの`pull_request`トリガーに`types: [opened]`を追加し、特定のイベントでのみワークフローが実行されるように修正


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>GitHub Actionsのpull_requestトリガーを修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml

- `pull_request`トリガーに`types: [opened]`を追加



</details>


  </td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/202/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

