### PR TITLE
test(Color): 入力検証とエラーハンドリングのテストを追加

### DIFF
--- a/package/main/src/Color/cmykToRgba.ts
+++ b/package/main/src/Color/cmykToRgba.ts
@@ -6,13 +6,13 @@ import { roundOf } from "@/Math/roundOf";
 import { subtract } from "@/Math/subtract";
 
 /**
- * cmykをrgbaに変換する
- * @param {number} c
- * @param {number} m
- * @param {number} y
- * @param {number} k
- * @param {number} a
- * @returns { r: number; g: number; b: number; a: number; }
+ * Convert CMYK color values to RGBA color space
+ * @param {number} c Cyan percentage (0-100)
+ * @param {number} m Magenta percentage (0-100)
+ * @param {number} y Yellow percentage (0-100)
+ * @param {number} k Key/Black percentage (0-100)
+ * @param {number} a Alpha value (0-1)
+ * @returns {Object} RGBA values (r, g, b as 0-255, a as 0-1)
  * @example cmykToRgba(100, 100, 0, 60.78) // { r: 0, g: 0, b: 100, a: 1 }
  */
 export const cmykToRgba = (
@@ -22,19 +22,19 @@ export const cmykToRgba = (
   k: number,
   a = 1,
 ): { r: number; g: number; b: number; a: number } => {
-  // CMYKの値を0から100の範囲に制限
+  // Clamp CMYK values to 0-100 range
   const clampedC = max(0, min(100, c));
   const clampedM = max(0, min(100, m));
   const clampedY = max(0, min(100, y));
   const clampedK = max(0, min(100, k));
 
-  // CMYKの値を0から1の範囲に変換
+  // Convert CMYK values to 0-1 range
   const cPercentage = division(clampedC, 100);
   const mPercentage = division(clampedM, 100);
   const yPercentage = division(clampedY, 100);
   const kPercentage = division(clampedK, 100);
 
-  // RGBの値を計算
+  // Calculate RGB values
   const r = multiplication(
     255,
     subtract(1, cPercentage),
@@ -51,12 +51,12 @@ export const cmykToRgba = (
     subtract(1, kPercentage),
   );
 
-  // RGBの値を0から255の範囲に丸める
+  // Round RGB values to 0-255 range
   const roundedR = roundOf(r);
   const roundedG = roundOf(g);
   const roundedB = roundOf(b);
 
-  // アルファ値を0から1の範囲に制限
+  // Clamp alpha value to 0-1 range
   const clampedA = max(0, min(1, a));
 
   return {

--- a/package/main/src/Color/hexaToRgba.ts
+++ b/package/main/src/Color/hexaToRgba.ts
@@ -1,9 +1,11 @@
 import { division } from "@/Math/division";
+import { roundOf } from "@/Math/roundOf";
 /**
- * hexaをrgbaに変換する
- * @param hex
- * @returns { r: number; g: number; b: number; a: number; }
+ * Convert hexadecimal color code to RGBA color values
+ * @param hex Hexadecimal color code (3, 6, or 8 digits with #)
+ * @returns {Object} RGBA values (r, g, b as 0-255, a as 0-1)
  * @example hexToRgba("#00000000") // { r: 0, g: 0, b: 0, a: 0 }
+ * @throws {Error} If the hex code format is invalid
  */
 export const hexaToRgba = (
   hex: string,
@@ -13,15 +15,28 @@ export const hexaToRgba = (
   b: number;
   a: number;
 } => {
-  // hex形式かどうかのチェック
+  // Validate hex code format
   if (/^#([\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i.test(hex) === false) {
     throw new Error("Invalid hex code");
   }
 
-  const hexCode = hex.replace("#", "");
+  let hexCode = hex.replace("#", "");
+
+  // Convert 3-digit hex to 6-digit format
+  if (hexCode.length === 3) {
+    hexCode = hexCode
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+
   const r = Number.parseInt(hexCode.slice(0, 2), 16);
   const g = Number.parseInt(hexCode.slice(2, 4), 16);
   const b = Number.parseInt(hexCode.slice(4, 6), 16);
-  const a = division(Number.parseInt(hexCode.slice(6, 8), 16), 255);
-  return { r, g, b, a: Number.isNaN(a) ? 1 : a };
+  const alphaValue =
+    hexCode.length === 8 ? Number.parseInt(hexCode.slice(6, 8), 16) : 255;
+  const a = roundOf(division(alphaValue, 255), 2);
+
+  // NaN check is not necessary since validation ensures valid hex values
+  return { r, g, b, a };
 };

--- a/package/main/src/Color/hslaToRgba.ts
+++ b/package/main/src/Color/hslaToRgba.ts
@@ -7,13 +7,14 @@ import { roundOf } from "@/Math/roundOf";
 import { subtract } from "@/Math/subtract";
 
 /**
- * hslaをrgbaに変換する
- * @param h 色相 (0から360の範囲)
- * @param s 彩度 (0から100の範囲)
- * @param l 明度 (0から100の範囲)
- * @param a アルファ値 (0から1の範囲)
- * @returns { r: number; g: number; b: number; a: number; }
+ * Convert HSLA color values to RGBA color space
+ * @param h Hue angle in degrees (0-360)
+ * @param s Saturation percentage (0-100)
+ * @param l Lightness percentage (0-100)
+ * @param a Alpha value (0-1)
+ * @returns {Object} RGBA values (r, g, b as 0-255, a as 0-1)
  * @example hslaToRgba(120, 50, 50, 1) // { r: 64, g: 191, b: 64, a: 1 }
+ * @throws {Error} If any input values are out of their valid ranges
  */
 export const hslaToRgba = (
   h: number,
@@ -21,17 +22,18 @@ export const hslaToRgba = (
   l: number,
   a = 1,
 ): { r: number; g: number; b: number; a: number } => {
-  if (
-    h < 0 ||
-    h > 360 ||
-    s < 0 ||
-    s > 100 ||
-    l < 0 ||
-    l > 100 ||
-    a < 0 ||
-    a > 1
-  ) {
-    return { r: 0, g: 0, b: 0, a: 1 };
+  // Validate input ranges
+  if (h < 0 || h > 360) {
+    throw new Error("Hue must be between 0 and 360 degrees");
+  }
+  if (s < 0 || s > 100) {
+    throw new Error("Saturation must be between 0 and 100 percent");
+  }
+  if (l < 0 || l > 100) {
+    throw new Error("Lightness must be between 0 and 100 percent");
+  }
+  if (a < 0 || a > 1) {
+    throw new Error("Alpha must be between 0 and 1");
   }
 
   const hue = division(division(h, 360, false)[1], 360);

--- a/package/main/src/Color/rgbaToCmyk.ts
+++ b/package/main/src/Color/rgbaToCmyk.ts
@@ -3,9 +3,9 @@ import { roundOf } from "@/Math/roundOf";
 import { subtract } from "@/Math/subtract";
 
 /**
- * rgbaをcmykに変換する
- * @param rgba
- * @returns { c: number, m: number, y: number, k: number, a: number }
+ * Convert RGBA color to CMYK color model
+ * @param rgba Object containing r, g, b values (0-255) and optional a (0-1)
+ * @returns {Object} CMYK values (c, m, y, k as percentages 0-100) and alpha channel
  * @example rgbaToCmyk({ r: 0, g: 0, b: 0, a: 1 }); // { c: 0, m: 0, y: 0, k: 100, a: 1 }
  */
 export const rgbaToCmyk = ({
@@ -19,6 +19,20 @@ export const rgbaToCmyk = ({
   b: number;
   a?: number;
 }): { c: number; m: number; y: number; k: number; a: number } => {
+  // Validate RGBA values
+  if (
+    r < 0 ||
+    r > 255 ||
+    g < 0 ||
+    g > 255 ||
+    b < 0 ||
+    b > 255 ||
+    a < 0 ||
+    a > 1
+  ) {
+    throw new Error("Invalid rgba value");
+  }
+
   const rPrime = division(r, 255);
   const gPrime = division(g, 255);
   const bPrime = division(b, 255);

--- a/package/main/src/Color/rgbaToHexA.ts
+++ b/package/main/src/Color/rgbaToHexA.ts
@@ -3,10 +3,10 @@ const hex = (x: number) => {
   return hexCode.length === 1 ? `0${hexCode}` : hexCode;
 };
 /**
- * rgbaを16進数に変換
- * @param rgba
- * @returns {string} 16進数の色コード
- * @example rgbaToHexA({ r: 0, g: 0, b: 0, a: 1 }); // "#000000"
+ * Convert RGBA color to hexadecimal color code
+ * @param rgba Object containing r, g, b values (0-255) and optional a (0-1)
+ * @returns {string} Hexadecimal color code including alpha channel
+ * @example rgbaToHexA({ r: 0, g: 0, b: 0, a: 1 }); // "#000000ff"
  */
 export const rgbaToHexA = ({
   r,
@@ -19,7 +19,7 @@ export const rgbaToHexA = ({
   b: number;
   a?: number;
 }): string => {
-  // rgba形式かどうかのチェック
+  // Validate RGBA values
   if (
     r < 0 ||
     r > 255 ||

--- a/package/main/src/Color/rgbaToHsla.ts
+++ b/package/main/src/Color/rgbaToHsla.ts
@@ -5,10 +5,11 @@ import { roundOf } from "@/Math/roundOf";
 import { subtract } from "@/Math/subtract";
 
 /**
- * rgbaをhslaに変換する
- * @param rgba
- * @returns { h: number; s: number; l: number; a: number; }
+ * Convert RGBA color values to HSLA color space
+ * @param rgba Object containing r, g, b values (0-255) and optional a (0-1)
+ * @returns {Object} HSLA values (h as 0-360, s and l as 0-100, a as 0-1)
  * @example rgbaToHsla({ r: 100, g: 100, b: 100, a: 1 }); // { h: 0, s: 0, l: 39.22, a: 1 }
+ * @throws {Error} If any input values are out of their valid ranges
  */
 export const rgbaToHsla = ({
   r,
@@ -21,6 +22,20 @@ export const rgbaToHsla = ({
   b: number;
   a?: number;
 }): { h: number; s: number; l: number; a: number } => {
+  // Validate RGBA values
+  if (
+    r < 0 ||
+    r > 255 ||
+    g < 0 ||
+    g > 255 ||
+    b < 0 ||
+    b > 255 ||
+    a < 0 ||
+    a > 1
+  ) {
+    throw new Error("Invalid rgba value");
+  }
+
   const rPrime = division(r, 255);
   const gPrime = division(g, 255);
   const bPrime = division(b, 255);

--- a/package/main/src/tests/unit/Color/hexaToRgba.test.ts
+++ b/package/main/src/tests/unit/Color/hexaToRgba.test.ts
@@ -1,7 +1,7 @@
 import { hexaToRgba } from "@/Color/hexaToRgba";
 
 describe("hexaToRgba", () => {
-  it("should convert valid hex code to rgba", () => {
+  it("should convert 6-digit hex code to rgba", () => {
     expect(hexaToRgba("#FF0000")).toEqual({ r: 255, g: 0, b: 0, a: 1 });
     expect(hexaToRgba("#00FF00")).toEqual({ r: 0, g: 255, b: 0, a: 1 });
     expect(hexaToRgba("#0000FF")).toEqual({ r: 0, g: 0, b: 255, a: 1 });
@@ -9,6 +9,20 @@ describe("hexaToRgba", () => {
     expect(hexaToRgba("#000000")).toEqual({ r: 0, g: 0, b: 0, a: 1 });
     expect(hexaToRgba("#FFA500")).toEqual({ r: 255, g: 165, b: 0, a: 1 });
     expect(hexaToRgba("#FFA50099")).toEqual({ r: 255, g: 165, b: 0, a: 0.6 });
+  });
+
+  it("should convert 3-digit hex code to rgba", () => {
+    expect(hexaToRgba("#F00")).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+    expect(hexaToRgba("#0F0")).toEqual({ r: 0, g: 255, b: 0, a: 1 });
+    expect(hexaToRgba("#00F")).toEqual({ r: 0, g: 0, b: 255, a: 1 });
+    expect(hexaToRgba("#FFF")).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(hexaToRgba("#000")).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+  });
+
+  it("should convert 8-digit hex code to rgba", () => {
+    expect(hexaToRgba("#FF0000FF")).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+    expect(hexaToRgba("#FF000080")).toEqual({ r: 255, g: 0, b: 0, a: 0.5 });
+    expect(hexaToRgba("#FF000000")).toEqual({ r: 255, g: 0, b: 0, a: 0 });
   });
 
   it("should throw an error for invalid hex code", () => {

--- a/package/main/src/tests/unit/Color/hslaToRgba.test.ts
+++ b/package/main/src/tests/unit/Color/hslaToRgba.test.ts
@@ -41,14 +41,39 @@ describe("hslaToRgba function", () => {
     },
   );
 
-  it("should handle invalid values", () => {
-    expect(hslaToRgba(-60, 100, 50, 1)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(420, 100, 50, 1)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(0, -50, 50, 1)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(0, 150, 50, 1)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(0, 100, -20, 1)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(0, 100, 120, 1)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(0, 100, 50, -0.5)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
-    expect(hslaToRgba(0, 100, 50, 1.5)).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+  it("should throw error for invalid hue values", () => {
+    expect(() => hslaToRgba(-60, 100, 50, 1)).toThrow(
+      "Hue must be between 0 and 360 degrees",
+    );
+    expect(() => hslaToRgba(420, 100, 50, 1)).toThrow(
+      "Hue must be between 0 and 360 degrees",
+    );
+  });
+
+  it("should throw error for invalid saturation values", () => {
+    expect(() => hslaToRgba(0, -50, 50, 1)).toThrow(
+      "Saturation must be between 0 and 100 percent",
+    );
+    expect(() => hslaToRgba(0, 150, 50, 1)).toThrow(
+      "Saturation must be between 0 and 100 percent",
+    );
+  });
+
+  it("should throw error for invalid lightness values", () => {
+    expect(() => hslaToRgba(0, 100, -20, 1)).toThrow(
+      "Lightness must be between 0 and 100 percent",
+    );
+    expect(() => hslaToRgba(0, 100, 120, 1)).toThrow(
+      "Lightness must be between 0 and 100 percent",
+    );
+  });
+
+  it("should throw error for invalid alpha values", () => {
+    expect(() => hslaToRgba(0, 100, 50, -0.5)).toThrow(
+      "Alpha must be between 0 and 1",
+    );
+    expect(() => hslaToRgba(0, 100, 50, 1.5)).toThrow(
+      "Alpha must be between 0 and 1",
+    );
   });
 });

--- a/package/main/src/tests/unit/Color/rgbaToCmyk.test.ts
+++ b/package/main/src/tests/unit/Color/rgbaToCmyk.test.ts
@@ -1,6 +1,33 @@
 import { rgbaToCmyk } from "@/Color/rgbaToCmyk";
 
 describe("rgbaToCmyk", () => {
+  it("should throw an error for invalid rgba values", () => {
+    expect(() => rgbaToCmyk({ r: -1, g: 0, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 256, g: 0, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 0, g: -1, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 0, g: 256, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 0, g: 0, b: -1, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 0, g: 0, b: 256, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 0, g: 0, b: 0, a: -0.1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToCmyk({ r: 0, g: 0, b: 0, a: 1.1 })).toThrow(
+      "Invalid rgba value",
+    );
+  });
+
   it.each([
     [
       { r: 255, g: 255, b: 255, a: 1 },

--- a/package/main/src/tests/unit/Color/rgbaToHsla.test.ts
+++ b/package/main/src/tests/unit/Color/rgbaToHsla.test.ts
@@ -1,6 +1,50 @@
 import { rgbaToHsla } from "@/Color/rgbaToHsla";
 
 describe("rgbaToHsla", () => {
+  it("should throw error for invalid rgba values", () => {
+    expect(() => rgbaToHsla({ r: -1, g: 0, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 256, g: 0, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 0, g: -1, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 0, g: 256, b: 0, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 0, g: 0, b: -1, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 0, g: 0, b: 256, a: 1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 0, g: 0, b: 0, a: -0.1 })).toThrow(
+      "Invalid rgba value",
+    );
+    expect(() => rgbaToHsla({ r: 0, g: 0, b: 0, a: 1.1 })).toThrow(
+      "Invalid rgba value",
+    );
+  });
+
+  it("should handle edge cases correctly", () => {
+    // Black
+    expect(rgbaToHsla({ r: 0, g: 0, b: 0 })).toEqual({
+      h: 0,
+      s: 0,
+      l: 0,
+      a: 1,
+    });
+    // White
+    expect(rgbaToHsla({ r: 255, g: 255, b: 255 })).toEqual({
+      h: 0,
+      s: 0,
+      l: 100,
+      a: 1,
+    });
+  });
+
   it.each([
     [
       { r: 100, g: 100, b: 100 },


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced color conversion functions with input validation.

- Improved documentation for color conversion functions.

- Added unit tests for error handling in color conversions.

- Refactored tests to cover more edge cases.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>cmykToRgba.ts</strong><dd><code>Improve documentation and validation for CMYK to RGBA conversion</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-a3733e029f61a702268dc4d0b6f3fe5fa76e96c0fb6556472f0b3d6c586c896b">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>hexaToRgba.ts</strong><dd><code>Add validation and improve documentation for Hex to RGBA conversion</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-f5c7e5fae30baf137fac5baf419705b0994793a0a316397076cccb87b183d030">+22/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hslaToRgba.ts</strong><dd><code>Add input validation and improve documentation for HSLA to RGBA </code><br><code>conversion</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-8fd5bb4caef4fecf03f072ba2910e084f48ec6fddc4568f510873790e069b141">+19/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rgbaToCmyk.ts</strong><dd><code>Add validation and improve documentation for RGBA to CMYK conversion</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-90c63929bc91cb3b011cbf5c5c18dcd19b1be2da364996fd374418f0dd83e584">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rgbaToHexA.ts</strong><dd><code>Improve documentation and validation for RGBA to Hex conversion</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-5c12356e28ddc8f81eeeb92bbc998ad500bd5639d712004dc1b01fe5b434611d">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rgbaToHsla.ts</strong><dd><code>Add validation and improve documentation for RGBA to HSLA conversion</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-b67dda3bdd391bec5a445413b20b2c38e831de691313679d19008c90ee23173a">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>hexaToRgba.test.ts</strong><dd><code>Add tests for Hex to RGBA conversion with error handling</code>&nbsp; </dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-2e5eeb3287cbdab331d16fca7fc867aee7ceee33ad6f236ba70312e225009426">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hslaToRgba.test.ts</strong><dd><code>Add tests for HSLA to RGBA conversion with error handling</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-f4847b2ab1a9bae921c4272dcfab6fb62d429e73251929fa966c16e2e894ee71">+34/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rgbaToCmyk.test.ts</strong><dd><code>Add tests for RGBA to CMYK conversion with error handling</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-0468409ab8d9f3a3217b4e7c492e917a03dcee0b88d72dc171fcc3ddbe6eccb6">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rgbaToHsla.test.ts</strong><dd><code>Add tests for RGBA to HSLA conversion with error handling</code></dd></td>
  <td><a href="https://github.com/riya-amemiya/UMT/pull/237/files#diff-fe93147af3b90457ca1db46b6cf8d6d4b82600e32577495a30ba6393da42a022">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>