### PR TITLE
refactor: align object validator types and add SchemaToInterface

### DIFF
--- a/package/main/src/Validate/object/core.ts
+++ b/package/main/src/Validate/object/core.ts
@@ -4,7 +4,11 @@
  */
 
 import { isDictionaryObject } from "@/Validate/isDictionaryObject";
-import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
+import type {
+  Types,
+  ValidateCoreReturnType,
+  ValidateType,
+} from "@/Validate/type";
 
 /**
  * Creates an object validator with property-specific validation rules
@@ -23,14 +27,12 @@ export const object = <
   message?: string,
 ) => {
   return (
-    value: {
+    value: Types<{
       [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]>;
-    },
-  ): {
-    validate: boolean;
-    message: string;
-    type: { [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]> };
-  } => {
+    }>,
+  ): ValidateCoreReturnType<{
+    [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]>;
+  }> => {
     if (!isDictionaryObject(value)) {
       return {
         validate: false,

--- a/package/main/src/Validate/type.ts
+++ b/package/main/src/Validate/type.ts
@@ -49,3 +49,8 @@ export type ValidateType<T> = T extends "string"
     : T extends "boolean"
       ? boolean
       : T;
+
+export type SchemaToInterface<
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  T extends (value: any) => ValidateCoreReturnType<any>,
+> = ReturnType<T>["type"];

--- a/package/main/src/tests/integration/Tool/parseJson-and-Validate.test.ts
+++ b/package/main/src/tests/integration/Tool/parseJson-and-Validate.test.ts
@@ -2,6 +2,7 @@ import { parseJson } from "@/Tool/parseJson";
 import { boolean } from "@/Validate/boolean";
 import { number } from "@/Validate/number";
 import { object } from "@/Validate/object";
+import type { SchemaToInterface } from "@/Validate/type";
 
 /**
  * Integration tests for JSON parsing and validation
@@ -19,7 +20,7 @@ describe("Integration test for 'parseJson' and 'Validate' functions", () => {
       const schema = object({
         key: number(),
       });
-      const result = parseJson<ReturnType<typeof schema>["type"]>(jsonString);
+      const result = parseJson<SchemaToInterface<typeof schema>>(jsonString);
       const isValid = schema(result).validate;
       expect(isValid).toEqual(true);
       expect(result.key).toBe(123);
@@ -30,7 +31,7 @@ describe("Integration test for 'parseJson' and 'Validate' functions", () => {
       const schema = object({
         key: boolean(),
       });
-      const result = parseJson<ReturnType<typeof schema>["type"]>(jsonString);
+      const result = parseJson<SchemaToInterface<typeof schema>>(jsonString);
       const isValid = schema(result).validate;
       expect(isValid).toEqual(true);
       expect(result.key).toBe(true);
@@ -44,7 +45,7 @@ describe("Integration test for 'parseJson' and 'Validate' functions", () => {
           active: boolean(),
         }),
       });
-      const result = parseJson<ReturnType<typeof schema>["type"]>(jsonString);
+      const result = parseJson<SchemaToInterface<typeof schema>>(jsonString);
       const isValid = schema(result).validate;
       expect(isValid).toEqual(true);
       expect(result.user.id).toBe(1);
@@ -63,7 +64,7 @@ describe("Integration test for 'parseJson' and 'Validate' functions", () => {
       const schema = object({
         key: number(),
       });
-      const result = parseJson<ReturnType<typeof schema>["type"]>(jsonString);
+      const result = parseJson<SchemaToInterface<typeof schema>>(jsonString);
       const isValid = schema(result).validate;
       expect(isValid).toEqual(false);
     });
@@ -74,7 +75,7 @@ describe("Integration test for 'parseJson' and 'Validate' functions", () => {
         id: number(),
         active: boolean(),
       });
-      const result = parseJson<ReturnType<typeof schema>["type"]>(jsonString);
+      const result = parseJson<SchemaToInterface<typeof schema>>(jsonString);
       const isValid = schema(result).validate;
       expect(isValid).toEqual(false);
     });


### PR DESCRIPTION
Refactored `Validate/object/core.ts` to utilize shared type definitions consistent with other validators.

This alignment facilitated the introduction of the new `SchemaToInterface` utility type. This type simplifies deriving TypeScript interfaces directly from validation schemas, improving code readability and type consistency across the validation module.