### PR TITLE
feat(benchmark): add sort algorithm benchmarks

### DIFF
--- a/package/main/bun.lock
+++ b/package/main/bun.lock
@@ -25,6 +25,7 @@
         "gh-pages": "^6.3.0",
         "jest": "^29.7.0",
         "lodash": "^4.17.21",
+        "mitata": "^1.0.34",
         "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
         "tsc-alias": "^1.8.16",
@@ -1077,6 +1078,8 @@
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -26,6 +26,7 @@
     "gh-pages": "^6.3.0",
     "jest": "^29.7.0",
     "lodash": "^4.17.21",
+    "mitata": "^1.0.34",
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.16",
@@ -67,7 +68,8 @@
     "lint:ci": "yarn eslint && biome ci . && tsc",
     "test": "jest",
     "test-debug": "cd test && tsc",
-    "ts-node": "yarn build && ts-node --project tmp/tsconfig.json tmp/src/index.ts"
+    "ts-node": "yarn build && ts-node --project tmp/tsconfig.json tmp/src/index.ts",
+    "benchmark": "bun run ./src/tests/benchmark/index.ts"
   },
   "type": "module",
   "types": "module/index.d.js",

--- a/package/main/src/tests/benchmark/index.ts
+++ b/package/main/src/tests/benchmark/index.ts
@@ -1,0 +1,100 @@
+import {
+  run,
+  bench,
+  summary,
+  lineplot,
+  do_not_optimize,
+  type k_state,
+} from "mitata";
+import { quickSort } from "@/Array/quickSort";
+import { dualPivotQuickSort } from "@/Array/dualPivotQuickSort";
+
+const compareFunction = (a: number, b: number): number => a - b;
+
+const arraySizes = [10, 100, 1000, 10000, 100000, 1000000, 10000000];
+
+const sharedRandomArrays = new Map<number, number[]>();
+for (const size of arraySizes) {
+  sharedRandomArrays.set(
+    size,
+    Array.from({ length: size }, () => Math.random() * size),
+  );
+}
+
+summary(() => {
+  lineplot(() => {
+    bench("quickSort($size)", function* quickSortBench(state: k_state) {
+      const size = state.get("size") as number;
+      const original_array = sharedRandomArrays.get(size);
+
+      if (!original_array) {
+        throw new Error(`No shared array found for size: ${size}`);
+      }
+
+      yield {
+        [0]() {
+          return [...original_array];
+        },
+        bench(arr: number[]) {
+          do_not_optimize(quickSort(arr, compareFunction));
+        },
+      };
+    })
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      "Array.prototype.sort($size)",
+      function* nativeSortBench(state: k_state) {
+        const size = state.get("size") as number;
+        const original_array = sharedRandomArrays.get(size);
+
+        if (!original_array) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+
+        yield {
+          [0]() {
+            return [...original_array];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(arr.sort(compareFunction));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+    bench(
+      "dualPivotQuickSort($size)",
+      function* dualPivotQuickSortBench(state: k_state) {
+        const size = state.get("size") as number;
+        const original_array = sharedRandomArrays.get(size);
+
+        if (!original_array) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+
+        yield {
+          [0]() {
+            return [...original_array];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(dualPivotQuickSort(arr, compareFunction));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark finished.");
+  } catch (e) {
+    console.error("Error during benchmark execution:", e);
+  }
+})();


### PR DESCRIPTION
Introduce benchmarking for various sorting algorithms.

This commit adds the 'mitata' library and necessary scripts to perform benchmark tests on `quickSort`, `dualPivotQuickSort`, and the native `Array.prototype.sort`.

These benchmarks will help in:
- Comparing the performance characteristics of different sorting implementations.
- Identifying potential bottlenecks or areas for optimization.
- Evaluating algorithm efficiency across various data sizes.