### PR TITLE
perf(chunk): improve chunk function performance

### DIFF
--- a/package/main/bun.lock
+++ b/package/main/bun.lock
@@ -19,6 +19,7 @@
         "@typescript-eslint/parser": "^8.32.0",
         "bun-types": "^1.2.12",
         "dependency-cruiser": "^16.10.1",
+        "es-toolkit": "^1.37.2",
         "eslint": "^9.26.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-unicorn": "^59.0.1",
@@ -676,6 +677,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.37.2", "", {}, "sha512-ADDfk+pPFF0ofMpRAIc6on01p8heiuwuuJsYLzTP4UOjxVK9QsE2+0D1Q4J/zX2XBo6ac+27H5++YBIwmGAX/g=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/parser": "^8.32.0",
     "bun-types": "^1.2.12",
     "dependency-cruiser": "^16.10.1",
+    "es-toolkit": "^1.37.2",
     "eslint": "^9.26.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-unicorn": "^59.0.1",

--- a/package/main/src/Array/chunk.ts
+++ b/package/main/src/Array/chunk.ts
@@ -9,9 +9,13 @@ export const chunk = <T extends unknown[], N extends number>(
   array: T,
   n: N,
 ): ChunkArrayType<T, N> => {
-  const result: T[][] = [];
-  for (let index = 0; index < array.length; index += n) {
-    result.push(array.slice(index, index + n) as unknown as T[]);
+  const length = array.length;
+  // eslint-disable-next-line unicorn/no-new-array
+  const result = new Array(Math.ceil(length / n));
+
+  for (let index = 0, k = 0; index < length; index += n, k++) {
+    result[k] = array.slice(index, index + n) as unknown as T[];
   }
+
   return result as ChunkArrayType<T, N>;
 };

--- a/package/main/src/tests/benchmark/chunk.ts
+++ b/package/main/src/tests/benchmark/chunk.ts
@@ -1,0 +1,107 @@
+import {
+  run,
+  bench,
+  summary,
+  lineplot,
+  do_not_optimize,
+  type k_state,
+} from "mitata";
+import { chunk as customChunk } from "@/Array/chunk";
+import { chunk as lodashChunk } from "lodash";
+import { chunk as esToolkitChunk } from "es-toolkit";
+
+const arraySizes = [1000, 10000, 100000, 1000000, 10000000];
+const chunkSizes = [2, 5, 10, 20, 50, 100];
+
+const sharedRandomArrays = new Map<number, number[]>();
+for (const size of arraySizes) {
+  sharedRandomArrays.set(
+    size,
+    Array.from({ length: size }, () => Math.random() * size),
+  );
+}
+
+summary(() => {
+  lineplot(() => {
+    bench(
+      `customChunk(size: $size, chunkSize: $chunkSize)`,
+      function* customChunkBench(state: k_state) {
+        const size = state.get("size") as number;
+        const currentChunkSize = state.get("chunkSize") as number;
+        const original_array = sharedRandomArrays.get(size);
+
+        if (!original_array) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+
+        yield {
+          [0]() {
+            return [...original_array];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(customChunk(arr, currentChunkSize));
+          },
+        };
+      },
+    )
+      .args({ size: arraySizes, chunkSize: chunkSizes })
+      .gc("inner");
+
+    bench(
+      `lodashChunk(size: $size, chunkSize: $chunkSize)`,
+      function* lodashChunkBench(state: k_state) {
+        const size = state.get("size") as number;
+        const currentChunkSize = state.get("chunkSize") as number;
+        const original_array = sharedRandomArrays.get(size);
+
+        if (!original_array) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+
+        yield {
+          [0]() {
+            return [...original_array];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(lodashChunk(arr, currentChunkSize));
+          },
+        };
+      },
+    )
+      .args({ size: arraySizes, chunkSize: chunkSizes })
+      .gc("inner");
+
+    bench(
+      `esToolkitChunk(size: $size, chunkSize: $chunkSize)`,
+      function* esToolkitChunkBench(state: k_state) {
+        const size = state.get("size") as number;
+        const currentChunkSize = state.get("chunkSize") as number;
+        const original_array = sharedRandomArrays.get(size);
+
+        if (!original_array) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+
+        yield {
+          [0]() {
+            return [...original_array];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(esToolkitChunk(arr, currentChunkSize));
+          },
+        };
+      },
+    )
+      .args({ size: arraySizes, chunkSize: chunkSizes })
+      .gc("inner");
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution:", e);
+  }
+})();


### PR DESCRIPTION
The performance of the `chunk` function was inferior compared to `esToolkitChunk`. This change improves execution speed.

The main modification involves pre-allocating the result array to the appropriate size before the loop begins. This reduces the overhead associated with dynamic array resizing that occurred with the previous method of repeatedly calling `Array.prototype.push`, thereby enhancing performance, especially when handling large arrays.

Additionally, in the related benchmark tests, smaller values (10, 100) were removed from `arraySizes` to focus performance measurement on larger datasets.