### PR TITLE
perf(ultraNumberSort): use self-comparison for NaN check

### DIFF
--- a/package/main/src/Array/ultraNumberSort.ts
+++ b/package/main/src/Array/ultraNumberSort.ts
@@ -35,7 +35,8 @@ export const ultraNumberSort = (
 
   for (let index = 0; index < length; index++) {
     const value = array[index];
-    if (Number.isNaN(value)) {
+    // biome-ignore lint/suspicious/noSelfCompare: <explanation>
+    if (value !== value) {
       hasNaN = true;
       break;
     }
@@ -112,10 +113,11 @@ const handleNaNSort = (array: number[], ascending: boolean): number[] => {
   let nanCount = 0;
 
   for (const element of array) {
-    if (Number.isNaN(element)) {
-      nanCount++;
-    } else {
+    // biome-ignore lint/suspicious/noSelfCompare: <explanation>
+    if (element === element) {
       valid.push(element);
+    } else {
+      nanCount++;
     }
   }
 


### PR DESCRIPTION
Using `value !== value` is generally faster for checking NaN than `Number.isNaN()`. This commit updates the NaN detection logic to leverage this performance characteristic.