### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -6,5 +6,7 @@ on:
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/riya-amemiya/UMT/security/code-scanning/11](https://github.com/riya-amemiya/UMT/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with pull requests, it likely requires `pull-requests: write`. Other permissions should be set to `read` or omitted entirely if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`add-reviews`) to limit permissions to that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
