### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/UMTWasmPluginPackageTest.yml
+++ b/.github/workflows/UMTWasmPluginPackageTest.yml
@@ -1,5 +1,7 @@
 # アクション名
 name: UMT Wasm Plugin Package Test
+permissions:
+  contents: read
 
 # タイミングを指定
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/riya-amemiya/UMT/security/code-scanning/10](https://github.com/riya-amemiya/UMT/security/code-scanning/10)

To fix the issue, add a `permissions` block at the root of the workflow file to define the least privileges required. Since the workflow only involves building and testing the code, it likely only needs `contents: read` permission. This ensures the workflow can access the repository contents without granting unnecessary write permissions.

The `permissions` block should be added at the top level of the workflow file, applying to all jobs. This avoids redundancy and ensures consistent permissions across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
