### PR TITLE
perf(groupBy): improve performance of groupBy function

### DIFF
--- a/package/main/src/Array/groupBy.ts
+++ b/package/main/src/Array/groupBy.ts
@@ -12,15 +12,13 @@ export const groupBy = <T, K extends string | number>(
   array: T[],
   iteratee: (value: T, index: number, array: T[]) => K,
 ): Record<K, T[]> => {
-  return array.reduce(
-    (accumulator, value, index, array) => {
-      const key = iteratee(value, index, array);
-      if (!accumulator[key]) {
-        accumulator[key] = [];
-      }
-      accumulator[key].push(value);
-      return accumulator;
-    },
-    {} as Record<K, T[]>,
-  );
+  const result = Object.create(null);
+  const length = array.length;
+  for (let index = 0; index < length; index++) {
+    const value = array[index];
+    const key = iteratee(value, index, array);
+    // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
+    (result[key] || (result[key] = [])).push(value);
+  }
+  return result;
 };

--- a/package/main/src/tests/benchmark/array.groupBy-first-char.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-first-char.benchmark.ts
@@ -1,0 +1,127 @@
+import {
+  run,
+  bench,
+  summary,
+  lineplot,
+  do_not_optimize,
+  type k_state,
+} from "mitata";
+import { groupBy as customGroupBy } from "@/Array/groupBy";
+import { groupBy as lodashGroupBy } from "lodash";
+import { groupBy as esToolkitGroupBy } from "es-toolkit";
+
+const arraySizes = [1000, 10000, 100000, 1000000, 10000000];
+
+const sharedRandomStringsArraysByFirstChar = new Map<number, string[]>();
+
+for (const size of arraySizes) {
+  const chars = "abcdefghijklmnopqrstuvwxyz";
+  sharedRandomStringsArraysByFirstChar.set(
+    size,
+    Array.from(
+      { length: size },
+      (_, i) =>
+        chars.charAt(Math.floor(Math.random() * chars.length)) +
+        `item${i}-${Math.random().toString(36).substring(2)}`,
+    ),
+  );
+}
+
+const byFirstChar = (item: string): string => item[0];
+
+summary(() => {
+  lineplot(() => {
+    bench(
+      `customGroupBy strings by first char (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByFirstChar.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(customGroupBy(arr, byFirstChar));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `lodashGroupBy strings by first char (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByFirstChar.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(lodashGroupBy(arr, byFirstChar));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `esToolkitGroupBy strings by first char (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByFirstChar.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(esToolkitGroupBy(arr, byFirstChar));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `Object.groupBy strings by first char (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByFirstChar.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(Object.groupBy(arr, byFirstChar));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark for byFirstChar finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution (byFirstChar):", e);
+  }
+})();

--- a/package/main/src/tests/benchmark/array.groupBy-length.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-length.benchmark.ts
@@ -1,0 +1,124 @@
+import {
+  run,
+  bench,
+  summary,
+  lineplot,
+  do_not_optimize,
+  type k_state,
+} from "mitata";
+import { groupBy as customGroupBy } from "@/Array/groupBy";
+import { groupBy as lodashGroupBy } from "lodash";
+import { groupBy as esToolkitGroupBy } from "es-toolkit";
+
+const arraySizes = [1000, 10000, 100000, 1000000, 10000000];
+
+const sharedRandomStringsArraysByLength = new Map<number, string[]>();
+
+for (const size of arraySizes) {
+  sharedRandomStringsArraysByLength.set(
+    size,
+    Array.from(
+      { length: size },
+      (_, i) => `item${i}-${Math.random().toString(36).substring(2)}`,
+    ),
+  );
+}
+
+const byLength = (item: string): number => item.length;
+
+summary(() => {
+  lineplot(() => {
+    bench(
+      `customGroupBy strings by length (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByLength.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(customGroupBy(arr, byLength));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `lodashGroupBy strings by length (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByLength.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(lodashGroupBy(arr, byLength));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `esToolkitGroupBy strings by length (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByLength.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(esToolkitGroupBy(arr, byLength));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `Object.groupBy strings by length (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomStringsArraysByLength.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: string[]) {
+            do_not_optimize(Object.groupBy(arr, byLength));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark for byLength finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution (byLength):", e);
+  }
+})();

--- a/package/main/src/tests/benchmark/array.groupBy-math-floor.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-math-floor.benchmark.ts
@@ -1,0 +1,121 @@
+import {
+  run,
+  bench,
+  summary,
+  lineplot,
+  do_not_optimize,
+  type k_state,
+} from "mitata";
+import { groupBy as customGroupBy } from "@/Array/groupBy";
+import { groupBy as lodashGroupBy } from "lodash";
+import { groupBy as esToolkitGroupBy } from "es-toolkit";
+
+const arraySizes = [1000, 10000, 100000, 1000000, 10000000];
+
+const sharedRandomNumbersArrays = new Map<number, number[]>();
+
+for (const size of arraySizes) {
+  sharedRandomNumbersArrays.set(
+    size,
+    Array.from({ length: size }, (_, i) => Math.random() * 100 + i),
+  );
+}
+
+const byMathFloor = (item: number): number => Math.floor(item);
+
+summary(() => {
+  lineplot(() => {
+    bench(
+      `customGroupBy numbers by Math.floor (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomNumbersArrays.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(customGroupBy(arr, byMathFloor));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `lodashGroupBy numbers by Math.floor (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomNumbersArrays.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(lodashGroupBy(arr, byMathFloor));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `esToolkitGroupBy numbers by Math.floor (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomNumbersArrays.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(esToolkitGroupBy(arr, byMathFloor));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+
+    bench(
+      `Object.groupBy numbers by Math.floor (size: $size)`,
+      function* (state: k_state) {
+        const size = state.get("size") as number;
+        const originalArray = sharedRandomNumbersArrays.get(size);
+        if (!originalArray) {
+          throw new Error(`No shared array found for size: ${size}`);
+        }
+        yield {
+          [0]() {
+            return [...originalArray];
+          },
+          bench(arr: number[]) {
+            do_not_optimize(Object.groupBy(arr, byMathFloor));
+          },
+        };
+      },
+    )
+      .args("size", arraySizes)
+      .gc("inner");
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark for byMathFloor finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution (byMathFloor):", e);
+  }
+})();


### PR DESCRIPTION
Refactor groupBy to use a for loop instead of Array.prototype.reduce.

This change improves performance, particularly for large arrays, by
avoiding the overhead associated with reduce. The functional behavior remains unchanged.