### PR TITLE
feat: add Base32 and Base58 encoding/decoding to Crypto module

### DIFF
--- a/package/main/src/Crypto/decodeBase32.ts
+++ b/package/main/src/Crypto/decodeBase32.ts
@@ -1,0 +1,30 @@
+/**
+ * Decodes a Base32 string to Uint8Array
+ * @param {string} input - Base32 encoded string
+ * @returns {Uint8Array} Decoded bytes
+ * @example decodeBase32("JBSWY3DP"); // Uint8Array for "Hello"
+ */
+export const decodeBase32 = (input: string): Uint8Array => {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const cleanedInput = input.replaceAll("=", "");
+  const result: number[] = [];
+  let buffer = 0;
+  let bufferLength = 0;
+
+  for (const char of cleanedInput) {
+    const value = alphabet.indexOf(char);
+    if (value === -1) {
+      throw new Error(`Invalid base32 character: ${char}`);
+    }
+
+    buffer = (buffer << 5) | value;
+    bufferLength += 5;
+
+    if (bufferLength >= 8) {
+      bufferLength -= 8;
+      result.push((buffer >> bufferLength) & 0xff);
+    }
+  }
+
+  return new Uint8Array(result);
+};

--- a/package/main/src/Crypto/decodeBase32ToString.ts
+++ b/package/main/src/Crypto/decodeBase32ToString.ts
@@ -1,0 +1,11 @@
+import { decodeBase32 } from "./decodeBase32";
+
+/**
+ * Decodes a Base32 string to a UTF-8 string
+ * @param {string} input - Base32 encoded string
+ * @returns {string} Decoded string
+ * @example decodeBase32ToString("JBSWY3DP"); // "Hello"
+ */
+export const decodeBase32ToString = (input: string): string => {
+  return new TextDecoder().decode(decodeBase32(input));
+};

--- a/package/main/src/Crypto/decodeBase58.ts
+++ b/package/main/src/Crypto/decodeBase58.ts
@@ -1,0 +1,37 @@
+/**
+ * Decodes a Base58 string to Uint8Array
+ * @param {string} input - Base58 encoded string
+ * @returns {Uint8Array} Decoded bytes
+ * @example decodeBase58("9Ajdvzr"); // Uint8Array for "Hello"
+ */
+export const decodeBase58 = (input: string): Uint8Array => {
+  const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let bigNumber = BigInt(0);
+
+  for (const char of input) {
+    const value = alphabet.indexOf(char);
+    if (value === -1) {
+      throw new Error(`Invalid base58 character: ${char}`);
+    }
+    bigNumber = bigNumber * BigInt(58) + BigInt(value);
+  }
+
+  const bytes: number[] = [];
+  while (bigNumber > 0) {
+    bytes.unshift(Number(bigNumber % BigInt(256)));
+    bigNumber /= BigInt(256);
+  }
+
+  let leadingOnes = 0;
+  for (const char of input) {
+    if (char !== "1") {
+      break;
+    }
+    leadingOnes++;
+  }
+
+  return new Uint8Array([
+    ...(Array.from({ length: leadingOnes }).fill(0) as number[]),
+    ...bytes,
+  ]);
+};

--- a/package/main/src/Crypto/decodeBase58ToString.ts
+++ b/package/main/src/Crypto/decodeBase58ToString.ts
@@ -1,0 +1,11 @@
+import { decodeBase58 } from "./decodeBase58";
+
+/**
+ * Decodes a Base58 string to a UTF-8 string
+ * @param {string} input - Base58 encoded string
+ * @returns {string} Decoded string
+ * @example decodeBase58ToString("9Ajdvzr"); // "Hello"
+ */
+export const decodeBase58ToString = (input: string): string => {
+  return new TextDecoder().decode(decodeBase58(input));
+};

--- a/package/main/src/Crypto/encodeBase32.ts
+++ b/package/main/src/Crypto/encodeBase32.ts
@@ -1,0 +1,34 @@
+/**
+ * Encodes a string or Uint8Array to Base32 format
+ * @param {string | Uint8Array} input - The input to encode
+ * @returns {string} Base32 encoded string
+ * @example encodeBase32("Hello"); // "JBSWY3DP"
+ */
+export const encodeBase32 = (input: string | Uint8Array): string => {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const bytes =
+    typeof input === "string" ? new TextEncoder().encode(input) : input;
+
+  let result = "";
+  let buffer = 0;
+  let bufferLength = 0;
+
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bufferLength += 8;
+
+    while (bufferLength >= 5) {
+      bufferLength -= 5;
+      result += alphabet[(buffer >> bufferLength) & 0x1f];
+    }
+  }
+
+  if (bufferLength > 0) {
+    result += alphabet[(buffer << (5 - bufferLength)) & 0x1f];
+  }
+
+  const paddingLength = (8 - (result.length % 8)) % 8;
+  result += "=".repeat(paddingLength);
+
+  return result;
+};

--- a/package/main/src/Crypto/encodeBase58.ts
+++ b/package/main/src/Crypto/encodeBase58.ts
@@ -1,0 +1,34 @@
+/**
+ * Encodes a string or Uint8Array to Base58 format
+ * @param {string | Uint8Array} input - The input to encode
+ * @returns {string} Base58 encoded string
+ * @example encodeBase58("Hello"); // "9Ajdvzr"
+ */
+export const encodeBase58 = (input: string | Uint8Array): string => {
+  const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  const bytes =
+    typeof input === "string" ? new TextEncoder().encode(input) : input;
+
+  let encoded = "";
+  let bigNumber = BigInt(0);
+
+  for (const byte of bytes) {
+    bigNumber = bigNumber * BigInt(256) + BigInt(byte);
+  }
+
+  while (bigNumber > 0) {
+    const remainder = Number(bigNumber % BigInt(58));
+    encoded = alphabet[remainder] + encoded;
+    bigNumber /= BigInt(58);
+  }
+
+  let leadingZeros = 0;
+  for (const byte of bytes) {
+    if (byte !== 0) {
+      break;
+    }
+    leadingZeros++;
+  }
+
+  return "1".repeat(leadingZeros) + encoded;
+};

--- a/package/main/src/Crypto/index.ts
+++ b/package/main/src/Crypto/index.ts
@@ -1,0 +1,6 @@
+export * from "./decodeBase32";
+export * from "./decodeBase32ToString";
+export * from "./decodeBase58";
+export * from "./decodeBase58ToString";
+export * from "./encodeBase32";
+export * from "./encodeBase58";

--- a/package/main/src/index.ts
+++ b/package/main/src/index.ts
@@ -2,6 +2,7 @@ export * from "./Advance";
 export * from "./Array";
 export * from "./Color";
 export * from "./Consts";
+export * from "./Crypto";
 export * from "./Date";
 export * from "./Error";
 export * from "./Function";

--- a/package/main/src/tests/unit/Crypto/decodeBase32.test.ts
+++ b/package/main/src/tests/unit/Crypto/decodeBase32.test.ts
@@ -1,0 +1,48 @@
+import { decodeBase32 } from "@/Crypto/decodeBase32";
+
+describe("decodeBase32", () => {
+  test("decodes a simple string", () => {
+    const result = decodeBase32("JBSWY3DP");
+    expect(new TextDecoder().decode(result)).toBe("Hello");
+  });
+
+  test("decodes an empty string", () => {
+    const result = decodeBase32("");
+    expect(result.length).toBe(0);
+  });
+
+  test("decodes strings with padding", () => {
+    expect(new TextDecoder().decode(decodeBase32("MY======"))).toBe("f");
+    expect(new TextDecoder().decode(decodeBase32("MZXQ===="))).toBe("fo");
+    expect(new TextDecoder().decode(decodeBase32("MZXW6==="))).toBe("foo");
+    expect(new TextDecoder().decode(decodeBase32("MZXW6YQ="))).toBe("foob");
+    expect(new TextDecoder().decode(decodeBase32("MZXW6YTB"))).toBe("fooba");
+    expect(new TextDecoder().decode(decodeBase32("MZXW6YTBOI======"))).toBe(
+      "foobar",
+    );
+  });
+
+  test("throws error on invalid character", () => {
+    expect(() => decodeBase32("JBSWY3D@")).toThrow(
+      "Invalid base32 character: @",
+    );
+    expect(() => decodeBase32("JBSWY3D1")).toThrow(
+      "Invalid base32 character: 1",
+    );
+    expect(() => decodeBase32("JBSWY3D0")).toThrow(
+      "Invalid base32 character: 0",
+    );
+  });
+
+  test("decodes longer text", () => {
+    const encoded =
+      "KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWO===";
+    const result = new TextDecoder().decode(decodeBase32(encoded));
+    expect(result).toBe("The quick brown fox jumps over the lazy dog");
+  });
+
+  test("handles Base32 without padding", () => {
+    expect(new TextDecoder().decode(decodeBase32("JBSWY3DP"))).toBe("Hello");
+    expect(new TextDecoder().decode(decodeBase32("MZXW6YTB"))).toBe("fooba");
+  });
+});

--- a/package/main/src/tests/unit/Crypto/decodeBase32ToString.test.ts
+++ b/package/main/src/tests/unit/Crypto/decodeBase32ToString.test.ts
@@ -1,0 +1,38 @@
+import { decodeBase32ToString } from "@/Crypto/decodeBase32ToString";
+
+describe("decodeBase32ToString", () => {
+  test("decodes a simple string", () => {
+    expect(decodeBase32ToString("JBSWY3DP")).toBe("Hello");
+  });
+
+  test("decodes an empty string", () => {
+    expect(decodeBase32ToString("")).toBe("");
+  });
+
+  test("decodes strings with padding", () => {
+    expect(decodeBase32ToString("MY======")).toBe("f");
+    expect(decodeBase32ToString("MZXQ====")).toBe("fo");
+    expect(decodeBase32ToString("MZXW6===")).toBe("foo");
+    expect(decodeBase32ToString("MZXW6YQ=")).toBe("foob");
+    expect(decodeBase32ToString("MZXW6YTB")).toBe("fooba");
+    expect(decodeBase32ToString("MZXW6YTBOI======")).toBe("foobar");
+  });
+
+  test("decodes special characters", () => {
+    expect(decodeBase32ToString("4OAZHY4CSPRYDK7DQGQ6HANP")).toBe("こんにちは");
+  });
+
+  test("throws error on invalid character", () => {
+    expect(() => decodeBase32ToString("JBSWY3D@")).toThrow(
+      "Invalid base32 character: @",
+    );
+  });
+
+  test("decodes longer text", () => {
+    const encoded =
+      "KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWO===";
+    expect(decodeBase32ToString(encoded)).toBe(
+      "The quick brown fox jumps over the lazy dog",
+    );
+  });
+});

--- a/package/main/src/tests/unit/Crypto/decodeBase58.test.ts
+++ b/package/main/src/tests/unit/Crypto/decodeBase58.test.ts
@@ -1,0 +1,53 @@
+import { decodeBase58 } from "@/Crypto/decodeBase58";
+
+describe("decodeBase58", () => {
+  test("decodes a simple string", () => {
+    const result = decodeBase58("9Ajdvzr");
+    expect(new TextDecoder().decode(result)).toBe("Hello");
+  });
+
+  test("decodes an empty string", () => {
+    const result = decodeBase58("");
+    expect(result.length).toBe(0);
+  });
+
+  test("decodes single character strings", () => {
+    expect(new TextDecoder().decode(decodeBase58("2g"))).toBe("a");
+    expect(new TextDecoder().decode(decodeBase58("2h"))).toBe("b");
+    expect(new TextDecoder().decode(decodeBase58("2i"))).toBe("c");
+  });
+
+  test("handles leading ones (zeros)", () => {
+    const result = decodeBase58("119Ajdvzr");
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(0);
+    expect(new TextDecoder().decode(result.slice(2))).toBe("Hello");
+  });
+
+  test("throws error on invalid character", () => {
+    expect(() => decodeBase58("9Ajdvz0")).toThrow(
+      "Invalid base58 character: 0",
+    );
+    expect(() => decodeBase58("9AjdvzO")).toThrow(
+      "Invalid base58 character: O",
+    );
+    expect(() => decodeBase58("9AjdvzI")).toThrow(
+      "Invalid base58 character: I",
+    );
+    expect(() => decodeBase58("9Ajdvzl")).toThrow(
+      "Invalid base58 character: l",
+    );
+  });
+
+  test("decodes longer text", () => {
+    const encoded =
+      "7DdiPPYtxLjCD3wA1po2rvZHTDYjkZYiEtazrfiwJcwnKCizhGFhBGHeRdx";
+    const result = new TextDecoder().decode(decodeBase58(encoded));
+    expect(result).toBe("The quick brown fox jumps over the lazy dog");
+  });
+
+  test("decodes binary data", () => {
+    const result = decodeBase58("Vt9aq46");
+    expect(Array.from(result)).toEqual([255, 254, 253, 252, 251]);
+  });
+});

--- a/package/main/src/tests/unit/Crypto/decodeBase58ToString.test.ts
+++ b/package/main/src/tests/unit/Crypto/decodeBase58ToString.test.ts
@@ -1,0 +1,38 @@
+import { decodeBase58ToString } from "@/Crypto/decodeBase58ToString";
+
+describe("decodeBase58ToString", () => {
+  test("decodes a simple string", () => {
+    expect(decodeBase58ToString("9Ajdvzr")).toBe("Hello");
+  });
+
+  test("decodes an empty string", () => {
+    expect(decodeBase58ToString("")).toBe("");
+  });
+
+  test("decodes single character strings", () => {
+    expect(decodeBase58ToString("2g")).toBe("a");
+    expect(decodeBase58ToString("2h")).toBe("b");
+    expect(decodeBase58ToString("2i")).toBe("c");
+  });
+
+  test("decodes special characters", () => {
+    expect(decodeBase58ToString("7NAasPYBzpyEe5hmwr1KL")).toBe("こんにちは");
+  });
+
+  test("throws error on invalid character", () => {
+    expect(() => decodeBase58ToString("9Ajdvz0")).toThrow(
+      "Invalid base58 character: 0",
+    );
+    expect(() => decodeBase58ToString("9AjdvzO")).toThrow(
+      "Invalid base58 character: O",
+    );
+  });
+
+  test("decodes longer text", () => {
+    const encoded =
+      "7DdiPPYtxLjCD3wA1po2rvZHTDYjkZYiEtazrfiwJcwnKCizhGFhBGHeRdx";
+    expect(decodeBase58ToString(encoded)).toBe(
+      "The quick brown fox jumps over the lazy dog",
+    );
+  });
+});

--- a/package/main/src/tests/unit/Crypto/encodeBase32.test.ts
+++ b/package/main/src/tests/unit/Crypto/encodeBase32.test.ts
@@ -1,0 +1,36 @@
+import { encodeBase32 } from "@/Crypto/encodeBase32";
+
+describe("encodeBase32", () => {
+  test("encodes a simple string", () => {
+    expect(encodeBase32("Hello")).toBe("JBSWY3DP");
+  });
+
+  test("encodes an empty string", () => {
+    expect(encodeBase32("")).toBe("");
+  });
+
+  test("encodes a string with padding", () => {
+    expect(encodeBase32("f")).toBe("MY======");
+    expect(encodeBase32("fo")).toBe("MZXQ====");
+    expect(encodeBase32("foo")).toBe("MZXW6===");
+    expect(encodeBase32("foob")).toBe("MZXW6YQ=");
+    expect(encodeBase32("fooba")).toBe("MZXW6YTB");
+    expect(encodeBase32("foobar")).toBe("MZXW6YTBOI======");
+  });
+
+  test("encodes a Uint8Array", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+    expect(encodeBase32(bytes)).toBe("JBSWY3DP");
+  });
+
+  test("encodes special characters", () => {
+    expect(encodeBase32("こんにちは")).toBe("4OAZHY4CSPRYDK7DQGQ6HANP");
+  });
+
+  test("encodes longer text", () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    expect(encodeBase32(text)).toBe(
+      "KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWO===",
+    );
+  });
+});

--- a/package/main/src/tests/unit/Crypto/encodeBase58.test.ts
+++ b/package/main/src/tests/unit/Crypto/encodeBase58.test.ts
@@ -1,0 +1,43 @@
+import { encodeBase58 } from "@/Crypto/encodeBase58";
+
+describe("encodeBase58", () => {
+  test("encodes a simple string", () => {
+    expect(encodeBase58("Hello")).toBe("9Ajdvzr");
+  });
+
+  test("encodes an empty string", () => {
+    expect(encodeBase58("")).toBe("");
+  });
+
+  test("encodes single characters", () => {
+    expect(encodeBase58("a")).toBe("2g");
+    expect(encodeBase58("b")).toBe("2h");
+    expect(encodeBase58("c")).toBe("2i");
+  });
+
+  test("encodes a Uint8Array", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+    expect(encodeBase58(bytes)).toBe("9Ajdvzr");
+  });
+
+  test("handles leading zeros", () => {
+    const bytes = new Uint8Array([0, 0, 72, 101, 108, 108, 111]);
+    expect(encodeBase58(bytes)).toBe("119Ajdvzr");
+  });
+
+  test("encodes longer text", () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    expect(encodeBase58(text)).toBe(
+      "7DdiPPYtxLjCD3wA1po2rvZHTDYjkZYiEtazrfiwJcwnKCizhGFhBGHeRdx",
+    );
+  });
+
+  test("encodes special characters", () => {
+    expect(encodeBase58("こんにちは")).toBe("7NAasPYBzpyEe5hmwr1KL");
+  });
+
+  test("encodes binary data", () => {
+    const bytes = new Uint8Array([255, 254, 253, 252, 251]);
+    expect(encodeBase58(bytes)).toBe("Vt9aq46");
+  });
+});


### PR DESCRIPTION
- Implement encodeBase32/decodeBase32/decodeBase32ToString functions
- Implement encodeBase58/decodeBase58/decodeBase58ToString functions
- Add comprehensive unit tests with 100% coverage
- Follow existing codebase conventions (1 file per function, JSDoc)

🤖 Generated with [Claude Code](https://claude.ai/code)