### PR TITLE
feat(string): add unescapeHtml function for HTML entity decoding

### DIFF
--- a/package/main/.claude/commands/add-feature.md
+++ b/package/main/.claude/commands/add-feature.md
@@ -1,0 +1,66 @@
+---
+allowed-tools: Bash(*), Read(*), Write(*), Edit(*), MultiEdit(*), Glob(*), Grep(*), LS(*), Task(*)
+description: Add new feature to UMT project with comprehensive workflow (tests, lint, build, README)
+---
+
+# UMT Feature Addition Workflow
+
+Implement the new feature `$ARGUMENTS` following these strict requirements:
+
+## Project Configuration
+
+- Package info: @package.json
+- README overview: @README.md
+
+## Implementation Rules
+
+1. **Test Implementation**: Create comprehensive tests with 100% coverage
+2. **Lint Compliance**: `bun run lint` must pass
+3. **Build Success**: `bun run build` must pass
+4. **No External Dependencies**: Adding new dependencies is forbidden
+5. **Doc Comments Required**: Write JSDoc for all public functions
+6. **Runtime Agnostic**: No browser-only or Node.js-only implementations
+7. **README Update**: Update README.md after implementation
+
+## Implementation Steps
+
+### Phase 1: Research & Design
+
+1. Investigate existing codebase for similar functionality
+2. Determine appropriate module placement
+3. Consider type definitions in `src/types/` if needed
+
+### Phase 2: Implementation
+
+1. Implement main functionality in appropriate module directory
+2. Add type definitions if necessary
+3. Export from module's `index.ts`
+4. Export from main `src/index.ts`
+
+### Phase 3: Testing
+
+1. Create unit tests in `src/tests/unit/`
+2. Include comprehensive edge cases and error scenarios
+3. Verify `bun run test` passes completely
+
+### Phase 4: Quality Assurance
+
+1. Run and fix `bun run lint`
+2. Run and verify `bun run build`
+3. Validate generated module files
+
+### Phase 5: Documentation
+
+1. Add new feature to appropriate README.md section
+2. Include usage examples and API documentation
+
+## Code Quality Requirements
+
+- **Naming**: camelCase or PascalCase
+- **Import Order**: builtin → external → internal → parent → sibling → index
+- **Indentation**: 2 spaces
+- **Line Width**: 80 characters
+- **Array Types**: Use `T[]` format
+- **Error Handling**: Provide descriptive error messages
+
+Begin implementing feature `$ARGUMENTS` now.

--- a/package/main/.claude/commands/propose-tool.md
+++ b/package/main/.claude/commands/propose-tool.md
@@ -1,0 +1,84 @@
+---
+allowed-tools: Read(*), Glob(*), Grep(*), LS(*), Task(*), WebSearch(*)
+description: Propose new utility tools for UMT project based on gap analysis and modern best practices
+---
+
+# UMT Tool Proposal Generator
+
+Analyze the current UMT toolkit and propose new utility functions for category `$ARGUMENTS` based on:
+
+## Current Project Analysis
+
+- Package info: @package.json
+- README overview: @README.md
+- Main exports: @src/index.ts
+
+## Proposal Methodology
+
+### 1. Gap Analysis
+
+- Review existing functions in the specified category
+- Identify common JavaScript/TypeScript patterns not covered
+- Analyze popular utility libraries for inspiration (lodash, ramda, date-fns, etc.)
+
+### 2. Modern Standards Alignment
+
+- Consider ES2024+ features and patterns
+- Ensure TypeScript-first design with strong typing
+- Focus on functional programming principles where applicable
+
+### 3. UMT Compatibility Check
+
+- Zero external dependencies requirement
+- Runtime-agnostic implementation
+- Follows existing code style and patterns
+- Maintains consistent API design
+
+## Proposal Format
+
+For each proposed tool, provide:
+
+### Function Signature
+
+```typescript
+export function toolName(params: Types): ReturnType;
+```
+
+### Purpose & Use Cases
+
+- Clear description of what the function does
+- 2-3 practical use cases
+- Comparison with existing alternatives (if any)
+
+### Implementation Strategy
+
+- High-level approach without full code
+- Key algorithms or techniques to use
+- Type safety considerations
+
+### Testing Strategy
+
+- Edge cases to cover
+- Performance considerations
+- Expected test coverage areas
+
+## Categories to Consider
+
+- **Array**: sorting, grouping, transformation, statistical operations
+- **Object**: manipulation, transformation, validation, deep operations
+- **String**: parsing, formatting, validation, transformation
+- **Math**: calculations, conversions, statistical functions
+- **Date**: formatting, manipulation, calculation, timezone handling
+- **Function**: composition, memoization, debouncing, currying
+- **Type**: guards, assertions, utilities, validation
+- **Async**: promise utilities, async iteration, concurrency control
+
+## Output Requirements
+
+1. Propose 3-5 new utility functions for category `$ARGUMENTS`
+2. Ensure each proposal addresses a real development need
+3. Verify no overlap with existing UMT functions
+4. Consider implementation complexity vs utility value
+5. Prioritize proposals by impact and usefulness
+
+Begin analysis and proposal generation for category: `$ARGUMENTS`

--- a/package/main/README.md
+++ b/package/main/README.md
@@ -230,6 +230,7 @@ bun add umt
 | trimEndCharacters | `(string_: string, chars: string) => string` | Removes specified characters from the end of a string | `trimEndCharacters("hello!!!", "!"); // "hello"` |
 | trimStartCharacters | `(string_: string, chars: string) => string` | Removes specified characters from the start of a string | `trimStartCharacters("!!!hello", "!"); // "hello"` |
 | truncate | `(str: string, length: number, suffix?: string) => string` | Truncate a string to a specified length | `truncate("Hello World", 5); // "Hello..."` |
+| unescapeHtml | `(str: string) => string` | Unescapes HTML entities in a string | `unescapeHtml("&lt;script&gt;alert(&quot;Hello&quot;);&lt;/script&gt;"); // "<script>alert("Hello");</script>"` |
 
 ### Time
 

--- a/package/main/src/String/index.ts
+++ b/package/main/src/String/index.ts
@@ -20,3 +20,4 @@ export * from "./trimCharacters";
 export * from "./trimEndCharacters";
 export * from "./trimStartCharacters";
 export * from "./truncate";
+export * from "./unescapeHtml";

--- a/package/main/src/String/unescapeHtml.ts
+++ b/package/main/src/String/unescapeHtml.ts
@@ -1,0 +1,50 @@
+/**
+ * HTML entities map for unescaping
+ */
+const htmlUnescapeMap: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&#x27;": "'",
+  "&#x2F;": "/",
+  "&#x60;": "`",
+  "&#x3D;": "=",
+};
+
+/**
+ * Unescapes HTML entities in a string
+ * @param str - The string to unescape
+ * @returns The unescaped string with HTML entities converted back to their original characters
+ * @example
+ * ```typescript
+ * unescapeHtml("&lt;script&gt;alert(&quot;Hello&quot;);&lt;/script&gt;");
+ * // Returns: "<script>alert("Hello");</script>"
+ *
+ * unescapeHtml("Tom &amp; Jerry");
+ * // Returns: "Tom & Jerry"
+ *
+ * unescapeHtml("5 &lt; 10 &amp;&amp; 10 &gt; 5");
+ * // Returns: "5 < 10 && 10 > 5"
+ * ```
+ */
+export const unescapeHtml = (string_: string): string => {
+  let result = string_;
+
+  for (const [entity, character] of Object.entries(htmlUnescapeMap)) {
+    result = result.replaceAll(entity, character);
+  }
+
+  result = result.replaceAll(/&#(\d+);/g, (_, code) => {
+    const codePoint = Number.parseInt(code, 10);
+    return Number.isNaN(codePoint) ? _ : String.fromCodePoint(codePoint);
+  });
+
+  result = result.replaceAll(/&#x([0-9a-fA-F]+);/g, (_, code) => {
+    const codePoint = Number.parseInt(code, 16);
+    return Number.isNaN(codePoint) ? _ : String.fromCodePoint(codePoint);
+  });
+
+  return result;
+};

--- a/package/main/src/tests/unit/String/unescapeHtml.test.ts
+++ b/package/main/src/tests/unit/String/unescapeHtml.test.ts
@@ -1,0 +1,169 @@
+import { unescapeHtml } from "@/String/unescapeHtml";
+
+describe("unescapeHtml", () => {
+  it("should unescape ampersand", () => {
+    expect(unescapeHtml("Tom &amp; Jerry")).toBe("Tom & Jerry");
+  });
+
+  it("should unescape less than", () => {
+    expect(unescapeHtml("5 &lt; 10")).toBe("5 < 10");
+  });
+
+  it("should unescape greater than", () => {
+    expect(unescapeHtml("10 &gt; 5")).toBe("10 > 5");
+  });
+
+  it("should unescape double quotes", () => {
+    expect(unescapeHtml("Say &quot;Hello&quot;")).toBe('Say "Hello"');
+  });
+
+  it("should unescape single quotes", () => {
+    expect(unescapeHtml("It&#39;s working")).toBe("It's working");
+  });
+
+  it("should unescape hexadecimal single quotes", () => {
+    expect(unescapeHtml("It&#x27;s working")).toBe("It's working");
+  });
+
+  it("should unescape all basic entities", () => {
+    const input =
+      "&lt;script&gt;alert(&quot;XSS &amp; &#39;injection&#39;&quot;);&lt;/script&gt;";
+    const expected = `<script>alert("XSS & 'injection'");</script>`;
+
+    expect(unescapeHtml(input)).toBe(expected);
+  });
+
+  it("should handle empty string", () => {
+    expect(unescapeHtml("")).toBe("");
+  });
+
+  it("should handle string with no entities", () => {
+    expect(unescapeHtml("Hello World")).toBe("Hello World");
+  });
+
+  it("should handle string with only entities", () => {
+    expect(unescapeHtml("&amp;&lt;&gt;&quot;&#39;")).toBe("&<>\"'");
+  });
+
+  it("should handle repeated entities", () => {
+    expect(unescapeHtml("&amp;&amp;&amp;")).toBe("&&&");
+    expect(unescapeHtml("&lt;&lt;&lt;")).toBe("<<<");
+  });
+
+  it("should handle mixed content", () => {
+    const input = "User input: &lt;b&gt;Hello &amp; &#39;World&#39;&lt;/b&gt;";
+    const expected = "User input: <b>Hello & 'World'</b>";
+
+    expect(unescapeHtml(input)).toBe(expected);
+  });
+
+  it("should handle HTML attributes", () => {
+    const input =
+      "&lt;img src=&quot;test.jpg&quot; alt=&quot;Tom &amp; Jerry&#39;s picture&quot;&gt;";
+    const expected = `<img src="test.jpg" alt="Tom & Jerry's picture">`;
+
+    expect(unescapeHtml(input)).toBe(expected);
+  });
+
+  it("should handle JavaScript code", () => {
+    const input =
+      "if (x &lt; 5 &amp;&amp; y &gt; 3) { alert(&quot;Hello &#39;World&#39;&quot;); }";
+    const expected = `if (x < 5 && y > 3) { alert("Hello 'World'"); }`;
+
+    expect(unescapeHtml(input)).toBe(expected);
+  });
+
+  it("should handle decimal numeric character references", () => {
+    expect(unescapeHtml("&#65;")).toBe("A");
+    expect(unescapeHtml("&#8364;")).toBe("€");
+    expect(unescapeHtml("&#128512;")).toBe("😀");
+  });
+
+  it("should handle hexadecimal numeric character references", () => {
+    expect(unescapeHtml("&#x41;")).toBe("A");
+    expect(unescapeHtml("&#x20AC;")).toBe("€");
+    expect(unescapeHtml("&#x1F600;")).toBe("😀");
+  });
+
+  it("should handle mixed case hexadecimal references", () => {
+    expect(unescapeHtml("&#x41;")).toBe("A");
+    expect(unescapeHtml("&#X41;")).toBe("&#X41;"); // Should not match uppercase X
+    expect(unescapeHtml("&#x20ac;")).toBe("€");
+    expect(unescapeHtml("&#x20AC;")).toBe("€");
+  });
+
+  it("should handle extended entities", () => {
+    expect(unescapeHtml("&#x2F;")).toBe("/");
+    expect(unescapeHtml("&#x60;")).toBe("`");
+    expect(unescapeHtml("&#x3D;")).toBe("=");
+  });
+
+  it("should handle invalid numeric references gracefully", () => {
+    expect(unescapeHtml("&#;")).toBe("&#;");
+    expect(unescapeHtml("&#x;")).toBe("&#x;");
+    expect(unescapeHtml("&#invalid;")).toBe("&#invalid;");
+    expect(unescapeHtml("&#xinvalid;")).toBe("&#xinvalid;");
+  });
+
+  it("should handle malformed entities", () => {
+    expect(unescapeHtml("&lt")).toBe("&lt"); // Missing semicolon
+    expect(unescapeHtml("&unknown;")).toBe("&unknown;"); // Unknown entity
+    expect(unescapeHtml("&#")).toBe("&#"); // Incomplete
+  });
+
+  it("should handle complex HTML document", () => {
+    const input = `&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+    &lt;title&gt;Test &amp; Demo&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;p&gt;Hello &#39;World&#39; &amp; welcome!&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;`;
+
+    const expected = `<!DOCTYPE html>
+<html>
+<head>
+    <title>Test & Demo</title>
+</head>
+<body>
+    <p>Hello 'World' & welcome!</p>
+</body>
+</html>`;
+
+    expect(unescapeHtml(input)).toBe(expected);
+  });
+
+  it("should be inverse of escapeHtml", async () => {
+    const testCases = [
+      "Hello & World",
+      '<script>alert("test");</script>',
+      "It's a 'test' & more",
+      "5 < 10 > 3",
+      "",
+      "No special chars",
+    ];
+
+    // Note: We need to import escapeHtml to test roundtrip
+    const { escapeHtml } = await import("@/String/escapeHtml");
+
+    for (const testCase of testCases) {
+      const escaped = escapeHtml(testCase);
+      const unescaped = unescapeHtml(escaped);
+      expect(unescaped).toBe(testCase);
+    }
+  });
+
+  it("should handle Unicode characters in numeric references", () => {
+    expect(unescapeHtml("&#12354;")).toBe("あ"); // Japanese hiragana
+    expect(unescapeHtml("&#x3042;")).toBe("あ"); // Same character in hex
+    expect(unescapeHtml("&#8226;")).toBe("•"); // Bullet point
+    expect(unescapeHtml("&#x2022;")).toBe("•"); // Same in hex
+  });
+
+  it("should preserve already unescaped content", () => {
+    const input = "Already < unescaped & content with 'quotes'";
+    expect(unescapeHtml(input)).toBe(input);
+  });
+});


### PR DESCRIPTION
Add unescapeHtml function as complement to existing escapeHtml, supporting:
- Basic HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)
- Numeric character references (decimal and hexadecimal)
- Unicode characters including Japanese and emojis
- Graceful handling of malformed entities

🤖 Generated with [Claude Code](https://claude.ai/code)