### PR TITLE
refactor(types): Remove graph definitions

### DIFF
--- a/package/main/src/types/graph/edge.ts
+++ b/package/main/src/types/graph/edge.ts
@@ -1,5 +1,0 @@
-export interface Edge<T> {
-  from: T;
-  to: T;
-  weight: number;
-}

--- a/package/main/src/types/graph/graph.ts
+++ b/package/main/src/types/graph/graph.ts
@@ -1,4 +1,0 @@
-export interface Graph<T> {
-  adjacencyList: Map<T, Map<T, number>>;
-  directed: boolean;
-}

--- a/package/main/src/types/graph/graphOptions.ts
+++ b/package/main/src/types/graph/graphOptions.ts
@@ -1,3 +1,0 @@
-export interface GraphOptions {
-  directed?: boolean;
-}

--- a/package/main/src/types/graph/graphTraversalOptions.ts
+++ b/package/main/src/types/graph/graphTraversalOptions.ts
@@ -1,4 +1,0 @@
-export interface GraphTraversalOptions<T> {
-  onVisit?: (node: T) => void;
-  maxDepth?: number;
-}

--- a/package/main/src/types/graph/heuristicFunction.ts
+++ b/package/main/src/types/graph/heuristicFunction.ts
@@ -1,1 +1,0 @@
-export type HeuristicFunction<T> = (node: T, goal: T) => number;

--- a/package/main/src/types/graph/index.ts
+++ b/package/main/src/types/graph/index.ts
@@ -1,6 +1,0 @@
-export type { Edge } from "./edge";
-export type { Graph } from "./graph";
-export type { GraphOptions } from "./graphOptions";
-export type { GraphTraversalOptions } from "./graphTraversalOptions";
-export type { HeuristicFunction } from "./heuristicFunction";
-export type { PathResult } from "./pathResult";

--- a/package/main/src/types/graph/pathResult.ts
+++ b/package/main/src/types/graph/pathResult.ts
@@ -1,4 +1,0 @@
-export interface PathResult<T> {
-  path: T[];
-  cost: number;
-}

--- a/package/main/src/types/index.ts
+++ b/package/main/src/types/index.ts
@@ -2,7 +2,6 @@ export * from "./array";
 export * from "./clock";
 export * from "./date";
 export * from "./enum";
-export * from "./graph";
 export * from "./int";
 export * from "./joke";
 export * from "./logic";


### PR DESCRIPTION
The graph-related type definitions, including `Edge`, `Graph`, `GraphOptions`, `GraphTraversalOptions`, `HeuristicFunction`, and `PathResult`, are no longer utilized within the codebase. Removing these unused types simplifies the project's type declarations and reduces maintenance overhead.