### PR TITLE
ci: Scope main package CI runs

### DIFF
--- a/.github/workflows/MainPackageTest.yml
+++ b/.github/workflows/MainPackageTest.yml
@@ -6,7 +6,12 @@ on:
   pull_request:
     branches:
       - main
-      - develop
+      - feature/*
+    paths:
+      - 'package/main/**'
+  push:
+    branches:
+      - main
       - feature/*
     paths:
       - 'package/main/**'


### PR DESCRIPTION
Adds path filtering to the main package test workflow, ensuring it only runs when changes occur within the `package/main` directory. This optimizes CI run times by avoiding unnecessary executions.

Extends trigger branches to include `feature/*` for both pull requests and pushes, providing earlier feedback on feature development.