### PR TITLE
Handle invalid inputs in random_string utility

### DIFF
--- a/package/umt_python/src/random_string.py
+++ b/package/umt_python/src/random_string.py
@@ -15,6 +15,9 @@ def random_string(size: int = 8, char_pool: str = DEFAULT_RANDOM_STRING_CHARS) -
 
     Returns:
         Random string.
+    
+    Raises:
+        ValueError: If size is negative or char_pool is empty (when size > 0).
 
     Example:
         >>> len(random_string()) == 8
@@ -24,8 +27,10 @@ def random_string(size: int = 8, char_pool: str = DEFAULT_RANDOM_STRING_CHARS) -
         >>> all(c in 'abc' for c in random_string(5, 'abc'))
         True
     """
+    if size < 0:
+        raise ValueError("size must be non-negative")
     if size == 0:
         return ""
-    # When char_pool is empty and size > 0, random.choice will raise IndexError.
-    # This is the expected behavior for the tests.
+    if not char_pool:
+        raise ValueError("char_pool cannot be empty")
     return "".join(random.choice(char_pool) for _ in range(size))

--- a/package/umt_python/src/random_string.py
+++ b/package/umt_python/src/random_string.py
@@ -32,5 +32,5 @@ def random_string(size: int = 8, char_pool: str = DEFAULT_RANDOM_STRING_CHARS) -
     if size == 0:
         return ""
     if not char_pool:
-        raise ValueError("char_pool cannot be empty")
+        raise ValueError("char_pool cannot be empty when size > 0")
     return "".join(random.choice(char_pool) for _ in range(size))

--- a/package/umt_python/src/random_string.py
+++ b/package/umt_python/src/random_string.py
@@ -15,7 +15,7 @@ def random_string(size: int = 8, char_pool: str = DEFAULT_RANDOM_STRING_CHARS) -
 
     Returns:
         Random string.
-    
+
     Raises:
         ValueError: If size is negative or char_pool is empty (when size > 0).
 

--- a/package/umt_python/tests/test_string_utils.py
+++ b/package/umt_python/tests/test_string_utils.py
@@ -235,9 +235,12 @@ class TestRandomString(unittest.TestCase):
         self.assertTrue(all(c in custom_chars for c in s))
 
     def test_empty_char_pool(self):
-        # random.choice will raise IndexError if char_pool is empty
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError):
             random_string(char_pool="")
+
+    def test_negative_size(self):
+        with self.assertRaises(ValueError):
+            random_string(size=-1)
 
     def test_size_zero(self):
         s = random_string(size=0)
@@ -275,7 +278,7 @@ class TestRandomStringInitialization(unittest.TestCase):
 
     def test_callable_with_empty_pool_raises_error(self):
         generator = random_string_initialization(char_pool="")
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError):
             generator(5)
 
     def test_docstring_example(self):


### PR DESCRIPTION
## Summary
- add explicit validation in `random_string` for negative size and empty character pool
- expand tests for `random_string` and update expectations in `random_string_initialization`

## Testing
- `cd package/umt_python && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73670ec3083249e8105b2446bac9b