### PR TITLE
docs: Remove Graph module documentation

### DIFF
--- a/package/main/.serena/memories/codebase_structure.md
+++ b/package/main/.serena/memories/codebase_structure.md
@@ -17,7 +17,6 @@ src/
 ├── Object/                  # Object manipulation functions
 ├── Function/                # Function manipulation functions
 ├── Error/                   # Error handling functions
-├── Graph/                   # Graph algorithms and data structures
 ├── Tool/                    # Tool functions
 ├── DataStructure/           # Data structures
 ├── UA/                      # User Agent functions

--- a/package/main/AGENTS.md
+++ b/package/main/AGENTS.md
@@ -78,7 +78,6 @@ src/
 ├── Object/                  # Object manipulation functions
 ├── Function/                # Function manipulation functions
 ├── Error/                   # Error handling functions
-├── Graph/                   # Graph algorithms and data structures
 ├── Tool/                    # Tool functions
 ├── DataStructure/           # Data structures
 ├── UA/                      # User Agent functions

--- a/package/main/CLAUDE.md
+++ b/package/main/CLAUDE.md
@@ -80,7 +80,6 @@ src/
 ├── Object/                  # Object manipulation functions
 ├── Function/                # Function manipulation functions
 ├── Error/                   # Error handling functions
-├── Graph/                   # Graph algorithms and data structures
 ├── Tool/                    # Tool functions
 ├── DataStructure/           # Data structures
 ├── UA/                      # User Agent functions

--- a/package/main/README.md
+++ b/package/main/README.md
@@ -115,21 +115,6 @@ bun add umt
 |------|------|-------------|---------|
 | curry | `(func: (...args: unknown[]) => unknown) => Function` | Curries a function | `const add = (a, b, c) => a + b + c; curry(add)(1)(2)(3); // 6` |
 
-### Graph
-
-| name | type | description | example |
-|------|------|-------------|---------|
-| createGraph | `<T>(options?: GraphOptions) => Graph<T>` | Creates a new empty graph with specified options | `createGraph<string>({ directed: true }) // Creates a directed graph for string vertices` |
-| addEdge | `<T>(graph: Graph<T>, from: T, to: T, weight?: number) => Graph<T>` | Adds a weighted edge between two vertices in the graph | `addEdge(graph, "A", "B", 5) // Adds edge A -> B with weight 5` |
-| removeEdge | `<T>(graph: Graph<T>, from: T, to: T) => Graph<T>` | Removes an edge between two vertices in the graph | `removeEdge(graph, "A", "B") // Removes edge A -> B` |
-| bfs | `<T>(graph: Graph<T>, start: T, options?: GraphTraversalOptions<T>) => T[]` | Performs breadth-first search traversal on the graph | `bfs(graph, "A") // Returns vertices reachable from A in BFS order` |
-| dfs | `<T>(graph: Graph<T>, start: T, options?: GraphTraversalOptions<T>) => T[]` | Performs depth-first search traversal on the graph | `dfs(graph, "A") // Returns vertices reachable from A in DFS order` |
-| dijkstra | `<T>(graph: Graph<T>, start: T, goal: T) => PathResult<T>` | Finds the shortest path between two vertices using Dijkstra's algorithm | `dijkstra(graph, "A", "D") // Returns shortest path from A to D` |
-| aStar | `<T>(graph: Graph<T>, start: T, goal: T, heuristic: HeuristicFunction<T>) => PathResult<T>` | Finds the shortest path between two vertices using A* algorithm | `aStar(graph, "A", "D", (from, to) => manhattanDistance(from, to))` |
-| topoSort | `<T>(graph: Graph<T>) => T[]` | Performs topological sorting on a directed acyclic graph (DAG) | `topoSort(dagGraph) // Returns vertices in dependency order` |
-| connectedComponents | `<T>(graph: Graph<T>) => T[][]` | Finds all connected components in an undirected graph | `connectedComponents(graph) // Returns [[A, B], [C, D]] for two components` |
-| hasCycle | `<T>(graph: Graph<T>) => boolean` | Detects if the graph contains a cycle | `hasCycle(graph) // Returns true if graph has cycles` |
-
 ### IP
 
 | name | type | description | example |


### PR DESCRIPTION
Removes all documentation related to graph algorithms and data structures.

This update includes:
- Removing the 'Graph/' directory reference from codebase structure files.
- Deleting the comprehensive 'Graph' section from the main README, which detailed various graph functions like BFS, DFS, Dijkstra, A*, and topological sort.

This change reflects the removal of Graph functionality from the utility library.