### PR TITLE
feat(email): Enhance validation with RFC-compliant checks and expanded tests

### DIFF
--- a/package/main/src/Validate/string/email.ts
+++ b/package/main/src/Validate/string/email.ts
@@ -18,6 +18,11 @@ export const email = (message?: string): ValidateReturnType<string> => {
     type: "string",
     message,
     validate: (value) => {
+      // RFC 5322 length limitations
+      if (value.length > 998) {
+        return false;
+      }
+
       // Check for consecutive dots
       if (value.includes("..")) {
         return false;
@@ -27,6 +32,12 @@ export const email = (message?: string): ValidateReturnType<string> => {
       if (!(localPart && domainPart)) {
         return false;
       }
+
+      // RFC 5321 length limits: local part max 64 chars, domain part max 253 chars
+      if (localPart.length > 64 || domainPart.length > 253) {
+        return false;
+      }
+
       if (localPart.startsWith(".") || localPart.endsWith(".")) {
         return false;
       }

--- a/package/main/src/tests/unit/Validate/string/email.test.ts
+++ b/package/main/src/tests/unit/Validate/string/email.test.ts
@@ -144,4 +144,190 @@ describe("email", () => {
     const longLocal = `${"a".repeat(50)}@example.com`;
     expect(validateEmail(longLocal).validate).toBeTruthy();
   });
+
+  it("RFC 822 obsolete cases (historically valid, now obsolete)", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const obsoleteCases = [
+      {
+        email: "easy@example",
+        valid: false,
+        reason:
+          "RFC 822 allowed domains without dots, but RFC 2822 made this obsolete",
+      },
+    ];
+
+    for (const { email, valid } of obsoleteCases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
+
+  it("handles space-related edge cases (RFC 5322)", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const spaceCases = [
+      {
+        email: "what about spaces@example.com",
+        valid: false,
+        reason: "Spaces aren't allowed between words",
+      },
+      {
+        email: " maybe-like-this @example.com",
+        valid: false,
+        reason: "Current implementation doesn't handle spec-allowed spaces",
+      },
+      {
+        email: "fed-up-yet@ example.com ",
+        valid: false,
+        reason: "Domain part spaces not handled by current regex",
+      },
+    ];
+
+    for (const { email, valid } of spaceCases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
+
+  it("handles comment syntax (RFC 5322 comments in parentheses)", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const commentCases = [
+      {
+        email: "normal(wtf is this?)@example.com",
+        valid: false,
+        reason: "Comments technically valid in RFC 822, obsolete in RFC 5322",
+      },
+      {
+        email: "(@)@example.com",
+        valid: false,
+        reason: "Comments don't count as part of email address",
+      },
+    ];
+
+    for (const { email, valid } of commentCases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
+
+  it("handles quoted string syntax (RFC 5322)", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const quotedCases = [
+      {
+        email: '":(){|:&};:"@example.com',
+        valid: false,
+        reason:
+          "Quoted strings allow special characters but not supported by current regex",
+      },
+      {
+        email: '""@example.com',
+        valid: false,
+        reason: "Empty quoted local part technically valid but not supported",
+      },
+      {
+        email: '"@"@[@]',
+        valid: false,
+        reason: "Complex quoting not supported by current implementation",
+      },
+      {
+        email: "\"'()'\"(\"''\")@example.com",
+        valid: false,
+        reason: "Complex escaped quotes not supported",
+      },
+    ];
+
+    for (const { email, valid } of quotedCases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
+
+  it("handles IPv6 address literals (RFC 5321)", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const ipv6Cases = [
+      {
+        email: "magic@[::1]",
+        valid: false,
+        reason: "IPv6 addresses in brackets not supported by current regex",
+      },
+      {
+        email: "test@[127.0.0.1]",
+        valid: false,
+        reason: "IP literals not supported",
+      },
+    ];
+
+    for (const { email, valid } of ipv6Cases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
+
+  it("handles Unicode and internationalized email addresses (RFC 6532)", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const unicodeCases = [
+      {
+        email: "poop@[👀.👀]",
+        valid: false,
+        reason: "Unicode in domain brackets per RFC 6532 not supported",
+      },
+      {
+        email: "👉@👈",
+        valid: false,
+        reason: "Unicode domains not supported by current regex",
+      },
+      {
+        email: "c̷̨̈́i̵̮̅l̶̠̐͊͝ȁ̷̠̗̆̍̍n̷͖̘̯̍̈͒̅t̶͍͂͋ř̵̞͈̓ȯ̷̯̠-̸͚̖̟͋s̴͉̦̭̔̆̃͒û̵̥̪͆̒̕c̸̨̨̧̺̎k̵̼͗̀s̸̖̜͍̲̈́͋̂͠@example.com",
+        valid: false,
+        reason: "Zalgo text (Unicode combining characters) not supported",
+      },
+    ];
+
+    for (const { email, valid } of unicodeCases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
+
+  it("handles RFC 5322 length limitations", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const longLocalPart = "a".repeat(320);
+    const veryLongEmail = `${longLocalPart}@example.com`;
+
+    expect(validateEmail(veryLongEmail).validate).toBe(false);
+
+    const excessivelyLongLocal =
+      "according-to-all-known-laws-of-aviation-there-is-no-way-a-bee-should-be-able-to-fly-its-wings-are-too-small-to-get-its-fat-little-body-off-the-ground-the-bee-of-course-flies-anyway-because-bees-don-t-care-what-humans-think-is-impossible-yellow-black-yellow-black-yellow-black-yellow-black-ooh-black-and-yellow-let-s-shake-it-up-a-little-barry-breakfast-is-ready-coming-hang-on-a-second-hello-barry-adam-can-you-believe-this-is-happening-i-can-t-i-ll-pick-you-up-looking-sharp-use-the-stairs-your-father-paid-good-money-for-those-sorry-i-m-excited-here-s-the-graduate-we-re-very-proud-of-you-son-a-perfect-report-card-all-b-s-very-proud-ma-i-got-a-thing-going-here-you-got-lint-on-your-fuzz-ow-that-s-me-wave-to-us-we-ll-be-in-row-118-000-bye-barry-i-told-you-stop-flying-in-the-house-hey-adam-hey-barry-is-that-fuzz-gel-a-little-special-day-graduation-never-thought-i-d-make-it-three-days-grade-school-three-days-high-school-those-were-awkward-three-days-college-i-m-glad-i-took-a-day-and-hitchhiked-around-the-hive-you-did-come-back-different-hi-barry-artie-growing-a-mustache-looks-good-hear-about-frankie-yeah-you-going-to-the-funeral-no-i-m-not-going-everybody-knows-sting-someone-you-die-don-t-waste-it-on-a-squirrel-such-a-hothead-i-guess-he-could-have-just-gotten-out-of-the-way-i-love-this-incorporating-an-amusement-park-into-our-day-that-s-why-we-don-t-need-vacations-boy-quite-a-bit-of-pomp-under-the-circumstances-well-adam-today-we-are-men-we-are-bee-men-amen-hallelujah-students-faculty-distinguished-bees-please-welcome-dean-buzzwell-welcome-new-hive-city-graduating-class-of-9-15-that-concludes-our-ceremonies-and-begins-your-career-at-honex-industries-will-we-pick-our-job-today-i-heard-it-s-just-orientation-heads-up-here-we-go-keep-your-hands-and-antennas-inside-the-tram-at-all-times-wonder-what-it-ll-be-like-a-little-scary-welcome-to-honex-a-division-of-honesco-and-a-part-of-the-hexagon-group-this-is-it-wow-wow-we-know-that-you-as-a-bee-have-worked-your-whole-life-to-get-to-the-point-where-you-can-work-for-your-whole-life-honey-begins-when-our-valiant-pollen-jocks-bring-the-nectar-to-the-hive-our-top-secret-formula-is-automatically-color-corrected-scent-adjusted-and-bubble-contoured-into-this-soothing-sweet-syrup-with-its-distinctive-golden-glow-you-know-as-honey-that-girl-was-hot-she-s-my-cousin-she-is-yes-we-re-all-cousins-right-you-re-right-at-honex-we-constantly-strive-to-improve-every-aspect-of-bee-existence-these-bees-are-stress-testing-a-new-helmet-technology-what-do-you-think-he-makes-not-enough-here-we-have-our-latest-advancement-the-krelman-what-does-that-do-catches-that-little-strand-of-honey-that-hangs-after-you-pour-it-saves-us-millions-can-anyone-work-on-the-krelman-of-course-most-bee-jobs-are-small-ones@example.com";
+
+    expect(validateEmail(excessivelyLongLocal).validate).toBe(false);
+  });
+
+  it("documents current implementation limitations with detailed explanations", () => {
+    const emailValidator = email();
+    const validateEmail = string([emailValidator]);
+
+    const limitationCases = [
+      {
+        email: "trailing-dot.@example.com",
+        valid: false,
+        reason: "Local part cannot end with dot - correctly handled",
+      },
+      {
+        email: "i...wonder@example.com",
+        valid: false,
+        reason: "Consecutive dots not allowed - correctly handled",
+      },
+    ];
+
+    for (const { email, valid } of limitationCases) {
+      expect(validateEmail(email).validate).toBe(valid);
+    }
+  });
 });


### PR DESCRIPTION
Implements RFC 5322 and RFC 5321 length limitations for email addresses, including:
- Overall email length (max 998 characters).
- Local part length (max 64 characters).
- Domain part length (max 253 characters).

Expands the test suite significantly to cover a broader range of email syntax and edge cases defined in RFCs 5322, 5321, and 6532. This includes:
- Rejecting historically valid but obsolete formats.
- Handling space-related edge cases.
- Disallowing comment syntax.
- Not supporting complex quoted string syntax.
- Not supporting IPv6 address literals.
- Not supporting Unicode and internationalized email addresses.

The new tests clarify the current practical scope and limitations of the email validator.