### PR TITLE
fix: Corrects type declaration file extension

### DIFF
--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -43,7 +43,7 @@
   "exports": {
     ".": {
       "import": "./module/index.js",
-      "types": "./module/index.d.js"
+      "types": "./module/index.d.ts"
     }
   },
   "files": [
@@ -80,6 +80,6 @@
     "ts-node": "bun run build && ts-node --project tmp/tsconfig.json tmp/src/index.ts"
   },
   "type": "commonjs",
-  "types": "module/index.d.js",
-  "version": "2.8.0"
+  "types": "module/index.d.ts",
+  "version": "2.9.1"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -43,7 +43,7 @@
   "exports": {
     ".": {
       "import": "./module/index.js",
-      "types": "./module/index.d.js"
+      "types": "./module/index.d.ts"
     }
   },
   "files": [
@@ -80,6 +80,6 @@
     "ts-node": "bun run build && ts-node --project tmp/tsconfig.json tmp/src/index.ts"
   },
   "type": "module",
-  "types": "module/index.d.js",
-  "version": "2.9.0"
+  "types": "module/index.d.ts",
+  "version": "2.9.1"
 }


### PR DESCRIPTION
Updates the `types` field and `exports` map to correctly point to `.d.ts` files for type definitions. Previously, these paths incorrectly referenced `.d.js` files, which could lead to issues with type resolution in consuming projects.