### PR TITLE
🔄 Sync: Port to_kelvin to umt_python math module

### DIFF
--- a/package/umt_python/src/math/__init__.py
+++ b/package/umt_python/src/math/__init__.py
@@ -39,6 +39,7 @@ from .standard_deviation import standard_deviation
 from .subtraction import subtraction
 from .to_base_n import to_base_n
 from .to_celsius import to_celsius
+from .to_kelvin import to_kelvin
 from .uuidv7 import uuidv7
 from .value_swap import value_swap
 from .xoshiro256 import xoshiro256
@@ -88,6 +89,7 @@ __all__ = [
     "subtraction",
     "to_base_n",
     "to_celsius",
+    "to_kelvin",
     "uuidv7",
     "value_swap",
     "xoshiro256",

--- a/package/umt_python/src/math/to_kelvin.py
+++ b/package/umt_python/src/math/to_kelvin.py
@@ -1,0 +1,22 @@
+from .addition import addition
+
+
+def to_kelvin(celsius: float) -> float:
+    """
+    Converts temperature from Celsius to Kelvin.
+
+    Args:
+        celsius: Temperature in Celsius.
+
+    Returns:
+        Temperature in Kelvin.
+
+    Example:
+        >>> to_kelvin(26.85)
+        300.0
+        >>> to_kelvin(0)
+        273.15
+        >>> to_kelvin(-273.15)
+        0.0
+    """
+    return addition(celsius, 273.15)

--- a/package/umt_python/tests/unit/math/test_to_kelvin.py
+++ b/package/umt_python/tests/unit/math/test_to_kelvin.py
@@ -1,0 +1,25 @@
+import unittest
+
+from src.math import to_kelvin
+
+
+class TestToKelvin(unittest.TestCase):
+    def test_basic_cases(self):
+        self.assertEqual(to_kelvin(0), 273.15)
+        self.assertEqual(to_kelvin(26.85), 300)
+        self.assertEqual(to_kelvin(100), 373.15)
+
+    def test_handle_negative_celsius_values(self):
+        self.assertEqual(to_kelvin(-40), 233.15)
+        self.assertEqual(to_kelvin(-273.15), 0)
+
+    def test_handle_extreme_temperatures(self):
+        self.assertEqual(to_kelvin(1000), 1273.15)
+        self.assertEqual(to_kelvin(-300), -26.85)
+
+    def test_handle_decimal_values(self):
+        self.assertEqual(to_kelvin(25.5), 298.65)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ported `to_kelvin` from `package/main` (TypeScript) to `package/umt_python/src/math` to ensure module parity. The function converts Celsius to Kelvin using `addition` helper to mitigate floating point errors. Existing implementation in `src/unit` was left untouched to avoid breaking changes. Added comprehensive tests covering basic, negative, and extreme cases.

---
*PR created automatically by Jules for task [6055216457286603673](https://jules.google.com/task/6055216457286603673) started by @riya-amemiya*