### PR TITLE
Add conditional check to UMT publish workflow

### DIFF
--- a/.github/workflows/npm-publish-main.yml
+++ b/.github/workflows/npm-publish-main.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish-umt:
     name: Publish umt
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'main-')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary
Added a conditional guard to the `publish-umt` job in the npm publish workflow to control when the job executes.

## Changes
- Added `if` condition to the `publish-umt` job that restricts execution to:
  - Manual workflow dispatches (`workflow_dispatch` events)
  - Release events with tags starting with `main-` prefix

## Details
This change prevents the UMT publishing job from running on unintended triggers while allowing it to execute on explicit manual triggers or when creating releases with the `main-` tag naming convention. This provides better control over when UMT packages are published to npm.

https://claude.ai/code/session_01B2GVcXdwH7T1iUcmDiCxyt