### PR TITLE
🔄 Sync: Port isEmpty to Rust

### DIFF
--- a/package/umt_rust/src/object/is_empty.rs
+++ b/package/umt_rust/src/object/is_empty.rs
@@ -1,0 +1,25 @@
+use super::Value;
+use std::collections::HashMap;
+
+/// Checks if an object is empty (has no own properties).
+///
+/// # Arguments
+///
+/// * `object` - The object to check
+///
+/// # Returns
+///
+/// Returns true if the object is empty, false otherwise.
+///
+/// # Examples
+///
+/// ```
+/// use umt_rust::object::{umt_is_empty, Value};
+/// use std::collections::HashMap;
+///
+/// let obj = HashMap::new();
+/// assert!(umt_is_empty(&obj));
+/// ```
+pub fn umt_is_empty(object: &HashMap<String, Value>) -> bool {
+    object.is_empty()
+}

--- a/package/umt_rust/src/object/mod.rs
+++ b/package/umt_rust/src/object/mod.rs
@@ -1,5 +1,8 @@
 pub mod has;
 pub use has::*;
 
+pub mod is_empty;
+pub use is_empty::*;
+
 pub mod value;
 pub use value::*;

--- a/package/umt_rust/src/string/camel_case.rs
+++ b/package/umt_rust/src/string/camel_case.rs
@@ -29,10 +29,8 @@ pub fn umt_camel_case(s: &str) -> String {
             } else {
                 result.push(c);
             }
-        } else {
-            if first_letter_found {
-                capitalize_next = true;
-            }
+        } else if first_letter_found {
+            capitalize_next = true;
         }
     }
 

--- a/package/umt_rust/src/string/slugify.rs
+++ b/package/umt_rust/src/string/slugify.rs
@@ -29,11 +29,9 @@ pub fn umt_slugify(s: &str) -> String {
         if c.is_alphanumeric() {
             result.push(c.to_ascii_lowercase());
             prev_was_dash = false;
-        } else {
-            if !prev_was_dash {
-                result.push('-');
-                prev_was_dash = true;
-            }
+        } else if !prev_was_dash {
+            result.push('-');
+            prev_was_dash = true;
         }
     }
 

--- a/package/umt_rust/tests/object/test_is_empty.rs
+++ b/package/umt_rust/tests/object/test_is_empty.rs
@@ -1,22 +1,17 @@
 use std::collections::HashMap;
-use umt_rust::object::Value;
-
-/// Helper function to check if a HashMap is empty (mirrors the TypeScript isEmpty)
-fn is_empty(obj: &HashMap<String, Value>) -> bool {
-    obj.is_empty()
-}
+use umt_rust::object::{Value, umt_is_empty};
 
 #[test]
 fn test_should_return_true_for_empty_object() {
     let obj: HashMap<String, Value> = HashMap::new();
-    assert!(is_empty(&obj));
+    assert!(umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_properties() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::Int(1));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
@@ -25,47 +20,47 @@ fn test_should_return_false_for_object_with_multiple_properties() {
     obj.insert("a".to_string(), Value::Int(1));
     obj.insert("b".to_string(), Value::Int(2));
     obj.insert("c".to_string(), Value::Int(3));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_null_values() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::Null);
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_false_values() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::Bool(false));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_zero_values() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::Int(0));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_empty_string_values() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::String("".to_string()));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_empty_array_values() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::Array(vec![]));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }
 
 #[test]
 fn test_should_return_false_for_object_with_nested_empty_object_values() {
     let mut obj = HashMap::new();
     obj.insert("a".to_string(), Value::Object(HashMap::new()));
-    assert!(!is_empty(&obj));
+    assert!(!umt_is_empty(&obj));
 }


### PR DESCRIPTION
🔗 Source: `package/main/src/Object/isEmpty.ts`
🎯 Target: `package/umt_rust/src/object/is_empty.rs`
🛠 Implementation: Implemented `umt_is_empty` in Rust wrapping `HashMap::is_empty`. Updated `tests/object/test_is_empty.rs` to use the library function instead of a local helper. Also fixed unrelated linter warnings in `camel_case.rs` and `slugify.rs`.
✅ Verification: `cargo test` passed, specifically `object::test_is_empty`. `cargo clippy` passed.

---
*PR created automatically by Jules for task [3631115697984375585](https://jules.google.com/task/3631115697984375585) started by @riya-amemiya*