### PR TITLE
⚡ Optimize is_prime_number Loop in Python

### DIFF
--- a/package/umt_python/src/math/is_prime_number.py
+++ b/package/umt_python/src/math/is_prime_number.py
@@ -25,5 +25,9 @@ def is_prime_number(n: int) -> bool:
     """
     if n <= 1 or not isinstance(n, int):
         return False
+    if n == 2:
+        return True
+    if n % 2 == 0:
+        return False
 
-    return all(n % index != 0 for index in range(2, int(math.sqrt(n)) + 1))
+    return all(n % index != 0 for index in range(3, int(math.sqrt(n)) + 1, 2))


### PR DESCRIPTION
💡 **What:** Optimized the `is_prime_number` function in Python to skip even numbers after checking 2.
🎯 **Why:** The previous implementation checked every integer from 2 to sqrt(n). By skipping even numbers, we reduce the number of iterations by half.
📊 **Measured Improvement:** Benchmarking with a large prime (15,485,863) showed a reduction in average execution time from ~0.000441s to ~0.000233s, representing a ~1.89x speedup.

---
*PR created automatically by Jules for task [5368187035845161854](https://jules.google.com/task/5368187035845161854) started by @riya-amemiya*