### PR TITLE
🔄 Sync: Port getObjectsCommon to Python

### DIFF
--- a/package/umt_python/src/object/__init__.py
+++ b/package/umt_python/src/object/__init__.py
@@ -1,3 +1,4 @@
+from .get_objects_common import get_objects_common
 from .object_has import object_has
 from .object_is_empty import object_is_empty
 from .object_merge import object_merge
@@ -7,6 +8,7 @@ from .object_pick import object_pick
 from .object_pick_deep import object_pick_deep
 
 __all__ = [
+    "get_objects_common",
     "object_has",
     "object_is_empty",
     "object_merge",

--- a/package/umt_python/src/object/get_objects_common.py
+++ b/package/umt_python/src/object/get_objects_common.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+from ..validate.is_dictionary_object import is_dictionary_object
+
+
+def _is_strict_equal(a: object, b: object) -> bool:
+    # Handle differing types
+    if type(a) is not type(b):
+        # JS treats int and float as 'number', so 1 === 1.0 is true.
+        # Python treats them as distinct types, but 1 == 1.0 is true.
+        # We allow int/float comparison, but strictly separate bool.
+        if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+            if isinstance(a, bool) or isinstance(b, bool):
+                return False
+            return a == b
+        return False
+
+    # Same type
+    # Primitives: int, float, str, bool, None
+    if isinstance(a, (int, float, str, bool, type(None))):
+        return a == b
+
+    # Objects (list, dict, instances): use reference equality
+    return a is b
+
+
+def get_objects_common(obj: dict[str, Any], *objects: dict[str, Any]) -> dict[str, Any]:
+    """
+    Extract key-value pairs common to all input objects.
+
+    A key-value pair is considered common when the key exists in every object
+    and the value is strictly equal across all objects.
+    When all values for a key are plain objects, the function recurses to find
+    the common subset. If the recursive result is empty, the key is excluded.
+
+    Args:
+        obj: The first object.
+        *objects: Additional objects to compare.
+
+    Returns:
+        Object containing only the key-value pairs shared by all inputs.
+
+    Example:
+        >>> get_objects_common({ "a": 1, "b": 2 }, { "a": 1, "c": 3 })
+        {'a': 1}
+
+        >>> get_objects_common({ "a": { "b": 1, "c": 2 }, "d": 3 }, { "a": { "b": 1, "d": 4 }, "d": 3 })
+        {'a': {'b': 1}, 'd': 3}
+    """
+    if not objects:
+        return obj.copy()
+
+    result: dict[str, Any] = {}
+
+    for key, value in obj.items():
+        is_common = True
+        all_plain_objects = is_dictionary_object(value)
+
+        for other in objects:
+            if key not in other:
+                is_common = False
+                break
+
+            other_value = other[key]
+
+            if not is_dictionary_object(other_value):
+                all_plain_objects = False
+
+            if not all_plain_objects and not _is_strict_equal(value, other_value):
+                is_common = False
+                break
+
+        if not is_common:
+            continue
+
+        if all_plain_objects:
+            nested = get_objects_common(value, *[o[key] for o in objects])  # type: ignore
+
+            if nested:
+                result[key] = nested
+        else:
+            result[key] = value
+
+    return result

--- a/package/umt_python/tests/unit/object/test_get_objects_common.py
+++ b/package/umt_python/tests/unit/object/test_get_objects_common.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+from src.object.get_objects_common import get_objects_common
+
+
+def test_find_common_key_value_pairs_between_two_objects():
+    assert get_objects_common({"a": 1, "b": 2}, {"a": 1, "c": 3}) == {"a": 1}
+
+
+def test_find_common_key_value_pairs_among_three_objects():
+    assert get_objects_common(
+        {"a": 1, "b": 2, "c": 3},
+        {"a": 1, "b": 2, "d": 4},
+        {"a": 1, "e": 5},
+    ) == {"a": 1}
+
+
+def test_return_shallow_copy_for_single_object():
+    obj = {"a": 1, "b": 2}
+    result = get_objects_common(obj)
+    assert result == obj
+    assert result is not obj
+
+
+def test_return_empty_object_when_one_input_is_empty():
+    assert get_objects_common({"a": 1, "b": 2}, {}) == {}
+    assert get_objects_common({}, {"a": 1, "b": 2}) == {}
+
+
+def test_return_empty_object_when_all_inputs_are_empty():
+    assert get_objects_common({}, {}) == {}
+
+
+def test_return_empty_object_when_no_keys_are_common():
+    assert get_objects_common({"a": 1}, {"b": 2}) == {}
+
+
+def test_exclude_keys_with_different_values():
+    assert get_objects_common({"a": 1, "b": 2}, {"a": 1, "b": 5}) == {"a": 1}
+
+
+def test_handle_falsy_values_correctly():
+    obj = {"a": None, "b": 0, "c": False, "d": ""}
+    assert get_objects_common(obj, obj) == obj
+
+
+def test_handle_falsy_values_that_differ():
+    # 0 vs false
+    assert get_objects_common({"a": 0}, {"a": False}) == {}
+    # "" vs 0
+    assert get_objects_common({"a": ""}, {"a": 0}) == {}
+    # None vs False
+    assert get_objects_common({"a": None}, {"a": False}) == {}
+
+
+def test_find_common_nested_objects_recursively():
+    assert get_objects_common(
+        {"a": {"b": 1, "c": 2}, "d": 3},
+        {"a": {"b": 1, "d": 4}, "d": 3},
+    ) == {"a": {"b": 1}, "d": 3}
+
+
+def test_exclude_key_when_recursive_result_is_empty():
+    assert get_objects_common({"a": {"b": 1}}, {"a": {"c": 2}}) == {}
+
+
+def test_handle_deeply_nested_objects():
+    assert get_objects_common(
+        {"a": {"b": {"c": {"d": 1, "e": 2}}}},
+        {"a": {"b": {"c": {"d": 1, "f": 3}}}},
+    ) == {"a": {"b": {"c": {"d": 1}}}}
+
+
+def test_handle_nested_objects_among_three_objects():
+    assert get_objects_common(
+        {"a": {"b": 1, "c": 2, "d": 3}},
+        {"a": {"b": 1, "c": 2, "e": 4}},
+        {"a": {"b": 1, "f": 5}},
+    ) == {"a": {"b": 1}}
+
+
+def test_handle_mixed_nested_and_primitive_values():
+    assert get_objects_common({"a": {"b": 1}}, {"a": "hello"}) == {}
+
+
+def test_compare_arrays_by_reference():
+    arr = [1, 2, 3]
+    assert get_objects_common({"a": arr}, {"a": arr}) == {"a": arr}
+    assert get_objects_common({"a": [1, 2, 3]}, {"a": [1, 2, 3]}) == {}
+
+
+def test_compare_object_values_by_reference_when_not_plain_objects():
+    date = datetime(2024, 1, 1)
+    assert get_objects_common({"a": date}, {"a": date}) == {"a": date}
+    assert (
+        get_objects_common(
+            {"a": datetime(2024, 1, 1)},
+            {"a": datetime(2024, 1, 1)},
+        )
+        == {}
+    )
+
+
+def test_should_not_mutate_original_objects():
+    obj1 = {"a": 1, "b": {"c": 2}}
+    obj2 = {"a": 1, "b": {"c": 2, "d": 3}}
+    obj1_copy = {"a": 1, "b": {"c": 2}}
+    obj2_copy = {"a": 1, "b": {"c": 2, "d": 3}}
+
+    get_objects_common(obj1, obj2)
+
+    assert obj1 == obj1_copy
+    assert obj2 == obj2_copy


### PR DESCRIPTION
Ported `getObjectsCommon` from `package/main` to `package/umt_python`. This utility extracts key-value pairs common to all input objects, using strict equality checks that mirror JavaScript's `===` semantics (e.g., distinguishing booleans from integers, using reference equality for lists).

Key changes:
- Created `package/umt_python/src/object/get_objects_common.py`.
- Updated `package/umt_python/src/object/__init__.py`.
- Added `package/umt_python/tests/unit/object/test_get_objects_common.py`.
- Implemented `_is_strict_equal` helper to handle Python/JS type differences.

---
*PR created automatically by Jules for task [2010767212684883916](https://jules.google.com/task/2010767212684883916) started by @riya-amemiya*