### PR TITLE
feat(python): port is_double from package/main

### DIFF
--- a/.jules/sync.md
+++ b/.jules/sync.md
@@ -3,3 +3,7 @@
 ## 2025-02-21 - Logic Mismatch in `gcd` Implementation
 **Mismatch:** `gcd` in `package/umt_python` uses `float.as_integer_ratio()` and `math.lcm` for exact floating point handling and performance, whereas `package/main` uses string-based decimal place counting.
 **Resolution:** The Python implementation is optimized for performance and correctness using standard library features not present in JS/TS. Functionality remains equivalent for standard floating point inputs.
+
+## 2025-02-23 - Logic Mismatch in `is_double` for Lists
+**Mismatch:** `isDouble` in `package/main` (JS) implicitly coerces single-element arrays to numbers (e.g., `[1.5]` -> `1.5`), returning `true`.
+**Resolution:** In `package/umt_python`, `is_double` explicitly returns `False` for `list` and `dict` types to maintain idiomatic Python behavior and type safety, aligning with the precedent set by `is_number`.

--- a/package/umt_python/src/validate/__init__.py
+++ b/package/umt_python/src/validate/__init__.py
@@ -1,6 +1,7 @@
 from .is_array import is_array
 from .is_deep_equal import IsDeepEqualOptions, is_deep_equal
 from .is_dictionary_object import is_dictionary_object
+from .is_double import is_double
 from .is_equal import is_equal
 from .is_not_empty import is_not_empty
 from .is_number import is_number
@@ -25,6 +26,7 @@ __all__ = [
     "is_array",
     "is_deep_equal",
     "is_dictionary_object",
+    "is_double",
     "is_equal",
     "is_not_empty",
     "is_number",

--- a/package/umt_python/src/validate/is_double.py
+++ b/package/umt_python/src/validate/is_double.py
@@ -1,0 +1,37 @@
+import math
+
+
+def is_double(value: object, loose: bool = True) -> bool:
+    """
+    Determines if the value is a decimal number (has a fractional part).
+
+    Args:
+        value: Value to check.
+        loose: Whether to include string representations of decimal numbers (default: True).
+
+    Returns:
+        True if the value is a decimal number, False otherwise.
+
+    Example:
+        >>> is_double(1.5)
+        True
+        >>> is_double("1.5")
+        True
+        >>> is_double(1)
+        False
+    """
+    # Explicitly exclude non-numeric types that might be coerced or cause issues
+    if isinstance(value, (list, dict, bool)) or value is None:
+        return False
+
+    if loose:
+        try:
+            num = float(value)  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            return False
+    else:
+        if not isinstance(value, (float, int)):
+            return False
+        num = float(value)
+
+    return math.isfinite(num) and not num.is_integer()

--- a/package/umt_python/tests/unit/validate/test_is_double.py
+++ b/package/umt_python/tests/unit/validate/test_is_double.py
@@ -1,0 +1,51 @@
+import math
+import pytest
+from src.validate import is_double
+
+
+class TestIsDouble:
+    def test_should_return_true_for_valid_doubles(self):
+        assert is_double(1.5) is True
+        assert is_double(-1.5) is True
+        assert is_double(1.23e-4) is True
+        assert is_double("1.5") is True
+        assert is_double("1.5", False) is False
+
+    def test_should_return_false_for_invalid_doubles(self):
+        assert is_double(1) is False
+        assert is_double(1, False) is False
+        assert is_double("1") is False
+        assert is_double("1", False) is False
+
+        # Special float values
+        assert is_double(float("nan")) is False
+        assert is_double(float("inf")) is False
+        assert is_double(float("-inf")) is False
+
+        # Non-numeric types
+        assert is_double(None) is False
+        assert is_double(True) is False
+        assert is_double(False) is False
+        assert is_double({}) is False
+        assert is_double([]) is False
+
+        # Testing explicit false/None with loose=False
+        assert is_double(float("-inf"), False) is False
+        assert is_double(None, False) is False
+        assert is_double(True, False) is False
+        assert is_double(False, False) is False
+
+    def test_should_work_with_loose_mode(self):
+        # Additional checks for string inputs
+        assert is_double("3.14159") is True
+        assert is_double("-0.001") is True
+        assert is_double("invalid") is False
+        assert is_double("") is False
+
+    def test_type_separation(self):
+        # Ensure bools are not treated as numbers (Python specific parity check)
+        assert is_double(True) is False
+        assert is_double(False) is False
+
+        # Ensure lists/dicts are rejected (divergence from JS implicit coercion, documented)
+        assert is_double([1.5]) is False


### PR DESCRIPTION
Ported `is_double` validation function from `package/main` to `package/umt_python`.

Implementation details:
- Checks if a value is a number with a non-zero fractional part.
- Supports `loose` mode (default `True`) to parse string inputs.
- Explicitly rejects `bool`, `None`, `list`, `dict` to ensure type safety and avoid unwanted Python coercions (e.g., `float(True) == 1.0`).
- Divergence from JS: JS `isDouble([1.5])` is `true` due to implicit coercion. Python implementation returns `False` for lists, which is more idiomatic and safe. This is documented in `.jules/sync.md`.

Tests:
- Covered valid doubles, integers, strings, and edge cases (NaN, Inf, None, bool, etc.).
- Verified parity with `package/main` test cases, except for the documented list coercion.

---
*PR created automatically by Jules for task [10737481821592687953](https://jules.google.com/task/10737481821592687953) started by @riya-amemiya*