### PR TITLE
Update rand crate imports and fix range function signature

### DIFF
--- a/package/umt_rust/src/array/generate_number_array.rs
+++ b/package/umt_rust/src/array/generate_number_array.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 /// Generates an array of numbers with the specified length.
 ///

--- a/package/umt_rust/src/array/random_select.rs
+++ b/package/umt_rust/src/array/random_select.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::collections::HashSet;
 
 /// Randomly selects a specified number of elements from an array.

--- a/package/umt_rust/src/array/shuffle.rs
+++ b/package/umt_rust/src/array/shuffle.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 /// Randomly shuffles the elements of an array using the Fisher-Yates algorithm.
 ///

--- a/package/umt_rust/src/array/shuffle_2d_array.rs
+++ b/package/umt_rust/src/array/shuffle_2d_array.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 /// Shuffles all elements in a 2D array while maintaining the row lengths.
 ///

--- a/package/umt_rust/src/math/random.rs
+++ b/package/umt_rust/src/math/random.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 /// Generates a random integer between min and max (inclusive).
 ///

--- a/package/umt_rust/src/math/uuidv7.rs
+++ b/package/umt_rust/src/math/uuidv7.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Generates a UUID v7 (Universally Unique Identifier version 7).

--- a/package/umt_rust/src/string/random_string.rs
+++ b/package/umt_rust/src/string/random_string.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 const DEFAULT_CHARS: &str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 

--- a/package/umt_wasm/src/lib.rs
+++ b/package/umt_wasm/src/lib.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn range(min: i32, max: i32) -> Vec<i32> {
-    umt_range(min, max)
+    umt_range(min, Some(max), None)
 }
 
 // math functions


### PR DESCRIPTION
## Summary
This PR updates the codebase to use the correct `rand` crate trait import and fixes the `range` function signature in the WASM bindings to match the updated API.

## Key Changes
- **Rand trait import**: Updated all imports from `use rand::Rng` to `use rand::RngExt` across 7 modules:
  - `array/generate_number_array.rs`
  - `array/random_select.rs`
  - `array/shuffle.rs`
  - `array/shuffle_2d_array.rs`
  - `math/random.rs`
  - `math/uuidv7.rs`
  - `string/random_string.rs`

- **WASM range function**: Updated the `range` function call in `wasm/lib.rs` to pass the correct parameters:
  - Changed from: `umt_range(min, max)`
  - Changed to: `umt_range(min, Some(max), None)`
  - This aligns with the updated `umt_range` function signature that now accepts optional parameters

## Implementation Details
The `RngExt` trait is the correct extension trait from the `rand` crate that provides the necessary random number generation methods. The WASM binding update reflects a change in the underlying `umt_range` function to support optional step parameter, with the second parameter now wrapped in `Some()` and a third parameter for step set to `None`.

https://claude.ai/code/session_01GXLmBGo4mvwmzF6tR4wbMd