### PR TITLE
🔄 Sync: Port `mapValues` to `umt_python`

### DIFF
--- a/package/umt_python/src/__init__.py
+++ b/package/umt_python/src/__init__.py
@@ -164,6 +164,7 @@ from .number import (
 from .object import (
     object_has,
     object_is_empty,
+    object_map_values,
     object_merge,
     object_merge_deep,
     object_omit,
@@ -389,6 +390,7 @@ __all__ = [
     "normalize_time_unit",
     "object_has",
     "object_is_empty",
+    "object_map_values",
     "object_merge",
     "object_merge_deep",
     "object_omit",

--- a/package/umt_python/src/object/__init__.py
+++ b/package/umt_python/src/object/__init__.py
@@ -1,6 +1,7 @@
 from .get_objects_common import get_objects_common
 from .object_has import object_has
 from .object_is_empty import object_is_empty
+from .object_map_values import object_map_values
 from .object_merge import object_merge
 from .object_merge_deep import object_merge_deep
 from .object_omit import object_omit
@@ -11,6 +12,7 @@ __all__ = [
     "get_objects_common",
     "object_has",
     "object_is_empty",
+    "object_map_values",
     "object_merge",
     "object_merge_deep",
     "object_omit",

--- a/package/umt_python/src/object/object_map_values.py
+++ b/package/umt_python/src/object/object_map_values.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def object_map_values(
+    obj: dict[str, T],
+    func: Callable[[T, str], R],
+) -> dict[str, R]:
+    """
+    Creates an object with the same keys as the given object, but
+    with values transformed by the provided function.
+
+    Args:
+        obj: The source object to map values from.
+        func: The function invoked per value. Receives (value, key).
+
+    Returns:
+        A new object with transformed values.
+
+    Example:
+        >>> object_map_values({"a": 1, "b": 2}, lambda v, k: v * 2)
+        {'a': 2, 'b': 4}
+    """
+    result: dict[str, R] = {}
+    for key, value in obj.items():
+        result[key] = func(value, key)
+    return result

--- a/package/umt_python/tests/unit/object/test_object_map_values.py
+++ b/package/umt_python/tests/unit/object/test_object_map_values.py
@@ -1,0 +1,36 @@
+from src.object import object_map_values
+
+
+def test_map_values_basic_transform():
+    result = object_map_values(
+        {"a": 1, "b": 2, "c": 3},
+        lambda value, _: value * 2,
+    )
+    assert result == {"a": 2, "b": 4, "c": 6}
+
+
+def test_map_values_pass_value_and_key():
+    result = object_map_values(
+        {"x": 10, "y": 20},
+        lambda value, key: f"{key}={value}",
+    )
+    assert result == {"x": "x=10", "y": "y=20"}
+
+
+def test_map_values_empty_object():
+    result = object_map_values({}, lambda value, _: value)
+    assert result == {}
+
+
+def test_map_values_not_modify_original():
+    original = {"a": 1, "b": 2}
+    object_map_values(original, lambda value, _: value * 2)
+    assert original == {"a": 1, "b": 2}
+
+
+def test_map_values_different_return_types():
+    result = object_map_values(
+        {"a": 1, "b": 2, "c": 3},
+        lambda value, _: value > 1,
+    )
+    assert result == {"a": False, "b": True, "c": True}


### PR DESCRIPTION
Ported the `mapValues` utility from `package/main` to `umt_python`.
The Python implementation is named `object_map_values` to align with the existing naming convention in `umt_python` (e.g., `object_pick`, `object_omit`).
Included comprehensive unit tests covering basic transformation, key access, empty objects, and immutability.

---
*PR created automatically by Jules for task [9743350308671473119](https://jules.google.com/task/9743350308671473119) started by @riya-amemiya*