### PR TITLE
🔄 Sync: Port LRUCache to umt_python

### DIFF
--- a/package/umt_python/src/data_structure/__init__.py
+++ b/package/umt_python/src/data_structure/__init__.py
@@ -1,5 +1,7 @@
+from .lru_cache import LRUCache
 from .priority_queue import PriorityQueue
 
 __all__ = [
+    "LRUCache",
     "PriorityQueue",
 ]

--- a/package/umt_python/src/data_structure/lru_cache.py
+++ b/package/umt_python/src/data_structure/lru_cache.py
@@ -1,0 +1,104 @@
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LRUCache(Generic[K, V]):
+    """
+    A Least Recently Used (LRU) cache implementation
+    using an OrderedDict for O(1) get/set operations.
+
+    When the cache exceeds its capacity, the least recently used
+    entry is evicted.
+
+    Features:
+    - get(key): Retrieve a value (moves it to most recently used)
+    - set(key, value): Insert or update a value
+    - has(key): Check if a key exists
+    - delete(key): Remove a specific entry
+    - clear(): Remove all entries
+    - size: Get the number of entries
+    """
+
+    def __init__(self, capacity: int) -> None:
+        """
+        Creates a new LRUCache instance.
+
+        Args:
+            capacity: The maximum number of entries the cache can hold.
+        """
+        self._capacity = capacity
+        self._cache: OrderedDict[K, V] = OrderedDict()
+
+    @property
+    def size(self) -> int:
+        """
+        Returns the number of entries in the cache.
+        """
+        return len(self._cache)
+
+    def get(self, key: K) -> V | None:
+        """
+        Retrieves a value by key and marks it as most recently used.
+
+        Args:
+            key: The key to look up.
+
+        Returns:
+            The value if found, or None if not in cache.
+        """
+        if key not in self._cache:
+            return None
+        self._cache.move_to_end(key)
+        return self._cache[key]
+
+    def set(self, key: K, value: V) -> None:
+        """
+        Inserts or updates a key-value pair.
+        If the cache is at capacity, the least recently used entry is evicted.
+
+        Args:
+            key: The key to set.
+            value: The value to associate with the key.
+        """
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = value
+        if len(self._cache) > self._capacity:
+            self._cache.popitem(last=False)
+
+    def has(self, key: K) -> bool:
+        """
+        Checks whether a key exists in the cache.
+        Does not affect the recently-used order.
+
+        Args:
+            key: The key to check.
+
+        Returns:
+            True if the key exists in the cache.
+        """
+        return key in self._cache
+
+    def delete(self, key: K) -> bool:
+        """
+        Removes an entry from the cache by key.
+
+        Args:
+            key: The key to remove.
+
+        Returns:
+            True if the entry was found and removed.
+        """
+        if key in self._cache:
+            del self._cache[key]
+            return True
+        return False
+
+    def clear(self) -> None:
+        """
+        Removes all entries from the cache.
+        """
+        self._cache.clear()

--- a/package/umt_python/tests/unit/data_structure/test_lru_cache.py
+++ b/package/umt_python/tests/unit/data_structure/test_lru_cache.py
@@ -1,0 +1,192 @@
+from src.data_structure import LRUCache
+
+
+def test_constructor():
+    cache = LRUCache[str, int](3)
+    assert cache.size == 0
+
+
+def test_set_and_get():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    assert cache.get("a") == 1
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+
+
+def test_get_missing():
+    cache = LRUCache[str, int](3)
+    assert cache.get("missing") is None
+
+
+def test_update_existing_key():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("a", 10)
+    assert cache.get("a") == 10
+    assert cache.size == 1
+
+
+def test_eviction():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+    cache.set("d", 4)
+
+    assert cache.has("a") is False
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+    assert cache.get("d") == 4
+    assert cache.size == 3
+
+
+def test_promote_accessed_entries():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    cache.get("a")
+    cache.set("d", 4)
+
+    assert cache.has("a") is True
+    assert cache.has("b") is False
+    assert cache.has("c") is True
+    assert cache.has("d") is True
+
+
+def test_promote_updated_entries():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    cache.set("a", 10)
+    cache.set("d", 4)
+
+    assert cache.has("a") is True
+    assert cache.get("a") == 10
+    assert cache.has("b") is False
+
+
+def test_has():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    assert cache.has("a") is True
+    assert cache.has("missing") is False
+
+
+def test_delete():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+
+    assert cache.delete("a") is True
+    assert cache.has("a") is False
+    assert cache.size == 1
+
+
+def test_delete_missing():
+    cache = LRUCache[str, int](3)
+    assert cache.delete("missing") is False
+
+
+def test_delete_head_node():
+    # In this context, "head" refers to MRU in TS implementation terms,
+    # or just ensuring we can delete any node correctly.
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    assert cache.delete("c") is True
+    assert cache.size == 2
+    assert cache.get("a") == 1
+    assert cache.get("b") == 2
+
+
+def test_delete_tail_node():
+    # In this context, "tail" refers to LRU in TS implementation terms.
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    assert cache.delete("a") is True
+    assert cache.size == 2
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+
+
+def test_delete_only_entry():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    assert cache.delete("a") is True
+    assert cache.size == 0
+
+
+def test_clear():
+    cache = LRUCache[str, int](3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    cache.clear()
+
+    assert cache.size == 0
+    assert cache.get("a") is None
+    assert cache.get("b") is None
+    assert cache.get("c") is None
+
+
+def test_size_tracking():
+    cache = LRUCache[str, int](5)
+    assert cache.size == 0
+
+    cache.set("a", 1)
+    assert cache.size == 1
+
+    cache.set("b", 2)
+    assert cache.size == 2
+
+    cache.delete("a")
+    assert cache.size == 1
+
+
+def test_capacity_one():
+    cache = LRUCache[str, int](1)
+    cache.set("a", 1)
+    assert cache.get("a") == 1
+
+    cache.set("b", 2)
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    assert cache.size == 1
+
+
+def test_numeric_keys():
+    cache = LRUCache[int, str](3)
+    cache.set(1, "one")
+    cache.set(2, "two")
+    cache.set(3, "three")
+
+    assert cache.get(1) == "one"
+    assert cache.get(2) == "two"
+    assert cache.get(3) == "three"
+
+
+def test_many_operations():
+    cache = LRUCache[int, int](100)
+    for i in range(1000):
+        cache.set(i, i * 2)
+
+    assert cache.size == 100
+
+    for i in range(900, 1000):
+        assert cache.get(i) == i * 2
+
+    assert cache.get(0) is None


### PR DESCRIPTION
Ported `LRUCache` data structure from `package/main` to `package/umt_python`.
Implemented using `collections.OrderedDict` to ensure O(1) performance for get/set operations.
Added comprehensive unit tests mirroring the TypeScript test suite.
Verified with `ruff`, `pyright`, and `pytest`.

---
*PR created automatically by Jules for task [14607172922590763241](https://jules.google.com/task/14607172922590763241) started by @riya-amemiya*