### PR TITLE
🔄 Sync: Port toPercentage to Python

### DIFF
--- a/package/umt_python/src/number/__init__.py
+++ b/package/umt_python/src/number/__init__.py
@@ -1,3 +1,4 @@
 from .to_ordinal import to_ordinal
+from .to_percentage import to_percentage
 
-__all__ = ["to_ordinal"]
+__all__ = ["to_ordinal", "to_percentage"]

--- a/package/umt_python/src/number/to_percentage.py
+++ b/package/umt_python/src/number/to_percentage.py
@@ -1,0 +1,35 @@
+import math
+
+
+def to_percentage(value: float | int, total: float | int, decimals: int = 2) -> float:
+    """
+    Calculates the percentage of a value relative to a total.
+
+    Returns 0 when the total is 0 to avoid division by zero.
+
+    Args:
+        value: The partial value.
+        total: The total value.
+        decimals: The number of decimal places (default 2).
+
+    Returns:
+        The percentage value.
+
+    Example:
+        >>> to_percentage(25, 100)
+        25.0
+        >>> to_percentage(1, 3)
+        33.33
+        >>> to_percentage(1, 3, 0)
+        33.0
+        >>> to_percentage(0, 0)
+        0.0
+        >>> to_percentage(50, 200, 1)
+        25.0
+    """
+    if total == 0:
+        return 0.0
+
+    factor = 10**decimals
+    # Mimic JS Math.round(x) behavior: floor(x + 0.5)
+    return math.floor((value / total) * 100 * factor + 0.5) / factor

--- a/package/umt_python/tests/unit/number/test_to_percentage.py
+++ b/package/umt_python/tests/unit/number/test_to_percentage.py
@@ -1,0 +1,76 @@
+from src.number.to_percentage import to_percentage
+
+
+def test_calculate_basic_percentage():
+    assert to_percentage(25, 100) == 25.0
+    assert to_percentage(50, 100) == 50.0
+    assert to_percentage(100, 100) == 100.0
+
+
+def test_return_result_with_2_decimal_places_by_default():
+    assert to_percentage(1, 3) == 33.33
+    assert to_percentage(2, 3) == 66.67
+
+
+def test_respect_custom_decimal_places():
+    assert to_percentage(1, 3, 0) == 33.0
+    assert to_percentage(1, 3, 1) == 33.3
+    assert to_percentage(1, 3, 4) == 33.3333
+
+
+def test_return_0_when_total_is_0():
+    assert to_percentage(0, 0) == 0.0
+    assert to_percentage(5, 0) == 0.0
+    assert to_percentage(-5, 0) == 0.0
+
+
+def test_handle_0_value():
+    assert to_percentage(0, 100) == 0.0
+
+
+def test_handle_values_greater_than_total():
+    assert to_percentage(150, 100) == 150.0
+    assert to_percentage(200, 100) == 200.0
+
+
+def test_handle_negative_values():
+    assert to_percentage(-25, 100) == -25.0
+
+
+def test_handle_negative_half_rounding():
+    # JS Math.round(-1.5) -> -1
+    # JS Math.round(-2.5) -> -2
+
+    # -1.5 / 1 * 100 * 1 = -150? No.
+    # to_percentage(val, total, decimals)
+    # val=-1.5, total=1, decimals=0
+    # (-1.5 / 1) * 100 = -150.
+    # factor = 1.
+    # round(-150) = -150.
+    # result = -150.
+
+    # Wait, to test rounding behavior I need the number just before rounding to end in .5
+    # e.g. result before rounding is -1.5
+
+    # val = -0.015, total = 1.
+    # (-0.015 / 1) * 100 = -1.5.
+    # factor = 1.
+    # round(-1.5) = -1.
+    assert to_percentage(-0.015, 1, 0) == -1.0
+
+    # val = -0.025, total = 1.
+    # (-0.025 / 1) * 100 = -2.5.
+    # factor = 1.
+    # round(-2.5) = -2.
+    assert to_percentage(-0.025, 1, 0) == -2.0
+
+    # Test .5 rounding behavior for positive numbers
+    # val = 0.015, total = 1.
+    # (0.015 / 1) * 100 = 1.5.
+    # round(1.5) = 2.
+    assert to_percentage(0.015, 1, 0) == 2.0
+
+    # val = 0.025, total = 1.
+    # (0.025 / 1) * 100 = 2.5.
+    # round(2.5) = 3.
+    assert to_percentage(0.025, 1, 0) == 3.0


### PR DESCRIPTION
Ported the `toPercentage` utility from `package/main` to `package/umt_python`. This ensures parity in number formatting utilities. Special care was taken to replicate JavaScript's `Math.round` behavior for negative numbers ending in .5, which differs from Python's `round` function (banker's rounding). Tests were added to verify this specific behavior.

---
*PR created automatically by Jules for task [3521391235667325071](https://jules.google.com/task/3521391235667325071) started by @riya-amemiya*