### PR TITLE
Sync: Port predicate/some to python

### DIFF
--- a/package/umt_python/src/predicate/__init__.py
+++ b/package/umt_python/src/predicate/__init__.py
@@ -1,3 +1,4 @@
 from .every import every
+from .some import some
 
-__all__ = ["every"]
+__all__ = ["every", "some"]

--- a/package/umt_python/src/predicate/some.py
+++ b/package/umt_python/src/predicate/some.py
@@ -1,0 +1,34 @@
+from collections.abc import Callable
+from typing import ParamSpec
+
+P = ParamSpec("P")
+
+
+def some(*predicates: Callable[P, bool]) -> Callable[P, bool]:
+    """
+    Creates a predicate that returns true when at least one of
+    the given predicates returns true, using short-circuit evaluation.
+
+    Args:
+        *predicates: The predicates to combine
+
+    Returns:
+        A combined predicate
+
+    Example:
+        >>> is_zero_or_negative = some(
+        ...   lambda n: n == 0,
+        ...   lambda n: n < 0,
+        ... )
+        >>> is_zero_or_negative(0)
+        True
+        >>> is_zero_or_negative(-1)
+        True
+        >>> is_zero_or_negative(1)
+        False
+    """
+
+    def combined(*args: P.args, **kwargs: P.kwargs) -> bool:
+        return any(predicate(*args, **kwargs) for predicate in predicates)
+
+    return combined

--- a/package/umt_python/tests/unit/predicate/test_some.py
+++ b/package/umt_python/tests/unit/predicate/test_some.py
@@ -1,0 +1,58 @@
+import unittest
+
+from src.predicate import some
+
+
+class TestSome(unittest.TestCase):
+    def test_some_all_pass(self):
+        is_zero_or_negative = some(
+            lambda n: n == 0,
+            lambda n: n < 0,
+        )
+        self.assertTrue(is_zero_or_negative(0))
+        self.assertTrue(is_zero_or_negative(-1))
+        self.assertFalse(is_zero_or_negative(1))
+
+    def test_some_fail(self):
+        is_zero_or_negative = some(
+            lambda n: n == 0,
+            lambda n: n < 0,
+        )
+        self.assertFalse(is_zero_or_negative(5))
+
+    def test_some_short_circuit(self):
+        second_called = False
+
+        def predicate2():
+            nonlocal second_called
+            second_called = True
+            return False
+
+        combined = some(
+            lambda: True,
+            predicate2,
+        )
+        combined()
+        self.assertFalse(second_called)
+
+    def test_some_single_predicate(self):
+        single = some(lambda n: n > 0)
+        self.assertTrue(single(1))
+        self.assertFalse(single(-1))
+
+    def test_some_no_predicates(self):
+        never = some()
+        self.assertFalse(never())
+
+    def test_some_multiple_arguments(self):
+        either_positive = some(
+            lambda a, b: a > 0,
+            lambda a, b: b > 0,
+        )
+        self.assertTrue(either_positive(1, -1))
+        self.assertTrue(either_positive(-1, 1))
+        self.assertFalse(either_positive(-1, -1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ported the `some` predicate function from `package/main` to `package/umt_python`. This implementation uses `any` for efficient short-circuit evaluation and includes comprehensive tests covering all edge cases, including short-circuit behavior and empty inputs. The code follows existing project conventions, including type hinting with `ParamSpec`.

---
*PR created automatically by Jules for task [13616453170147922636](https://jules.google.com/task/13616453170147922636) started by @riya-amemiya*