### PR TITLE
Refactor email validation tests to remove misleading 'bugs' label

### DIFF
--- a/package/main/src/tests/unit/Validate/string/email.test.ts
+++ b/package/main/src/tests/unit/Validate/string/email.test.ts
@@ -58,23 +58,12 @@ describe("email", () => {
       "user@example,com",
       "",
       " ",
-    ];
-
-    for (const email of invalidEmails) {
-      expect(emailValidator(email).validate).toBeFalsy();
-    }
-  });
-
-  it("documents regex limitations as bugs", () => {
-    const emailValidator = string([validateEmail()]);
-
-    const buggyEmails = [
       "user@example..com",
       "user@.example.com",
       "user@example.com.",
     ];
 
-    for (const email of buggyEmails) {
+    for (const email of invalidEmails) {
       expect(emailValidator(email).validate).toBeFalsy();
     }
   });


### PR DESCRIPTION
Refactored `package/main/src/tests/unit/Validate/string/email.test.ts` to remove the confusing "documents regex limitations as bugs" test block. The emails listed there (`user@example..com`, `user@.example.com`, `user@example.com.`) are invalid according to standard RFCs and are correctly rejected by the validator. I moved these cases into the `rejects various invalid email formats` list to preserve coverage while correcting the test documentation. Verified that all 14 tests pass and assertion counts are consistent.

---
*PR created automatically by Jules for task [18373089788190445316](https://jules.google.com/task/18373089788190445316) started by @riya-amemiya*