### PR TITLE
Update dependency-cruiser comment to avoid hack terminology

### DIFF
--- a/package/main/.dependency-cruiser.js
+++ b/package/main/.dependency-cruiser.js
@@ -292,7 +292,7 @@ module.exports = {
     /* List of strings you have in use in addition to cjs/ es6 requires
        & imports to declare module dependencies. Use this e.g. if you've
        re-declared require, use a require-wrapper or use window.require as
-       a hack.
+       a workaround.
     */
     // exoticRequireStrings: [],
     /* options to pass on to enhanced-resolve, the package dependency-cruiser


### PR DESCRIPTION
Updated `.dependency-cruiser.js` to replace the word "hack" with "workaround" in a comment. This change is purely documentation/configuration and does not affect runtime behavior. Verified with `biome check`.

---
*PR created automatically by Jules for task [8751324202513669815](https://jules.google.com/task/8751324202513669815) started by @riya-amemiya*