### PR TITLE
Sync: Port TTLCache to Python

### DIFF
--- a/package/umt_python/src/data_structure/__init__.py
+++ b/package/umt_python/src/data_structure/__init__.py
@@ -1,7 +1,9 @@
 from .lru_cache import LRUCache
 from .priority_queue import PriorityQueue
+from .ttl_cache import TTLCache
 
 __all__ = [
     "LRUCache",
     "PriorityQueue",
+    "TTLCache",
 ]

--- a/package/umt_python/src/data_structure/ttl_cache.py
+++ b/package/umt_python/src/data_structure/ttl_cache.py
@@ -1,0 +1,130 @@
+import time
+from collections import OrderedDict
+from typing import Any, Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class TTLCache(Generic[K, V]):
+    """
+    A time-to-live (TTL) cache that automatically expires entries
+    after a configured duration.
+
+    Uses lazy deletion: expired entries are only removed
+    when accessed via get() or has().
+
+    Features:
+    - get(key): Retrieve a value (returns None if expired)
+    - set(key, value, ttl?): Insert with optional per-entry TTL
+    - has(key): Check if a non-expired key exists
+    - delete(key): Remove a specific entry
+    - clear(): Remove all entries
+    - size: Get the number of entries (including expired)
+    """
+
+    def __init__(self, default_ttl: int, max_size: int | None = None) -> None:
+        """
+        Creates a new TTLCache instance.
+
+        Args:
+            default_ttl: Default time-to-live in milliseconds for cache entries.
+            max_size: Optional maximum number of entries.
+        """
+        self.default_ttl = default_ttl
+        self.max_size = max_size
+        self._cache: OrderedDict[K, dict[str, Any]] = OrderedDict()
+
+    @property
+    def size(self) -> int:
+        """
+        Returns the number of entries in the cache
+        (including potentially expired entries).
+        """
+        return len(self._cache)
+
+    def get(self, key: K) -> V | None:
+        """
+        Retrieves a value by key. Returns None if the key
+        does not exist or has expired.
+
+        Args:
+            key: The key to look up.
+
+        Returns:
+            The value if found and not expired, or None.
+        """
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+
+        if time.time() * 1000 >= entry["expires_at"]:
+            del self._cache[key]
+            return None
+
+        return entry["value"]
+
+    def set(self, key: K, value: V, ttl: int | None = None) -> None:
+        """
+        Inserts or updates a key-value pair with an optional TTL override.
+        If max_size is configured and the cache is full, the oldest entry
+        is removed.
+
+        Args:
+            key: The key to set.
+            value: The value to cache.
+            ttl: Optional TTL in milliseconds (overrides default_ttl).
+        """
+        effective_ttl = ttl if ttl is not None else self.default_ttl
+        expires_at = time.time() * 1000 + effective_ttl
+
+        if key in self._cache:
+            self._cache[key] = {"value": value, "expires_at": expires_at}
+            return
+
+        if self.max_size is not None and len(self._cache) >= self.max_size:
+            self._cache.popitem(last=False)
+
+        self._cache[key] = {"value": value, "expires_at": expires_at}
+
+    def has(self, key: K) -> bool:
+        """
+        Checks whether a non-expired key exists in the cache.
+        Removes the entry if it has expired.
+
+        Args:
+            key: The key to check.
+
+        Returns:
+            True if the key exists and has not expired.
+        """
+        entry = self._cache.get(key)
+        if entry is None:
+            return False
+
+        if time.time() * 1000 >= entry["expires_at"]:
+            del self._cache[key]
+            return False
+
+        return True
+
+    def delete(self, key: K) -> bool:
+        """
+        Removes an entry from the cache by key.
+
+        Args:
+            key: The key to remove.
+
+        Returns:
+            True if the entry was found and removed.
+        """
+        if key in self._cache:
+            del self._cache[key]
+            return True
+        return False
+
+    def clear(self) -> None:
+        """
+        Removes all entries from the cache.
+        """
+        self._cache.clear()

--- a/package/umt_python/tests/unit/data_structure/test_ttl_cache.py
+++ b/package/umt_python/tests/unit/data_structure/test_ttl_cache.py
@@ -1,0 +1,199 @@
+from unittest.mock import patch
+
+from src.data_structure import TTLCache
+
+
+def test_constructor():
+    cache = TTLCache[str, int](default_ttl=5000)
+    assert cache.size == 0
+
+
+def test_set_and_get():
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    cache.set("b", 2)
+
+    assert cache.get("a") == 1
+    assert cache.get("b") == 2
+
+
+def test_get_missing_key():
+    cache = TTLCache[str, int](default_ttl=5000)
+    assert cache.get("missing") is None
+
+
+def test_update_existing_key():
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    cache.set("a", 10)
+    assert cache.get("a") == 10
+    assert cache.size == 1
+
+
+@patch("time.time")
+def test_ttl_expiration(mock_time):
+    mock_time.return_value = 1000.0  # Start time in seconds
+
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    assert cache.get("a") == 1
+
+    # Advance time by 5 seconds (5000ms)
+    mock_time.return_value = 1005.0
+
+    assert cache.get("a") is None
+
+
+@patch("time.time")
+def test_not_expire_before_ttl(mock_time):
+    mock_time.return_value = 1000.0
+
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+
+    # Advance time by 4.999 seconds
+    mock_time.return_value = 1004.999
+
+    assert cache.get("a") == 1
+
+
+@patch("time.time")
+def test_per_entry_ttl_override(mock_time):
+    mock_time.return_value = 1000.0
+
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("short", 1, ttl=1000)
+    cache.set("long", 2, ttl=10000)
+
+    # Advance 1 second
+    mock_time.return_value = 1001.0
+    assert cache.get("short") is None
+    assert cache.get("long") == 2
+
+    # Advance another 9 seconds (total 10s from start)
+    mock_time.return_value = 1010.0
+    assert cache.get("long") is None
+
+
+@patch("time.time")
+def test_expire_entries_checked_via_has(mock_time):
+    mock_time.return_value = 1000.0
+
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    assert cache.has("a") is True
+
+    # Advance 5 seconds
+    mock_time.return_value = 1005.0
+    assert cache.has("a") is False
+
+
+@patch("time.time")
+def test_cleanup_expired_entries_on_get(mock_time):
+    mock_time.return_value = 1000.0
+
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+
+    # Advance 5 seconds
+    mock_time.return_value = 1005.0
+
+    # Before get, size is 1 (lazy deletion)
+    assert cache.size == 1
+    cache.get("a")
+    assert cache.size == 0
+
+
+@patch("time.time")
+def test_cleanup_expired_entries_on_has(mock_time):
+    mock_time.return_value = 1000.0
+
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+
+    # Advance 5 seconds
+    mock_time.return_value = 1005.0
+
+    assert cache.size == 1
+    cache.has("a")
+    assert cache.size == 0
+
+
+def test_max_size_eviction():
+    cache = TTLCache[str, int](default_ttl=5000, max_size=2)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    assert cache.size == 2
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+
+
+def test_no_eviction_when_updating_existing_key():
+    cache = TTLCache[str, int](default_ttl=5000, max_size=2)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("a", 10)  # Updates 'a', but 'a' is still oldest inserted
+
+    assert cache.size == 2
+    assert cache.get("a") == 10
+    assert cache.get("b") == 2
+
+    # Add 'c', 'a' should be evicted because it's the oldest inserted
+    cache.set("c", 3)
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+
+
+def test_has():
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    assert cache.has("a") is True
+    assert cache.has("missing") is False
+
+
+def test_delete():
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    assert cache.delete("a") is True
+    assert cache.has("a") is False
+    assert cache.size == 0
+    assert cache.delete("missing") is False
+
+
+def test_clear():
+    cache = TTLCache[str, int](default_ttl=5000)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.clear()
+    assert cache.size == 0
+    assert cache.get("a") is None
+
+
+def test_max_size_1():
+    cache = TTLCache[str, int](default_ttl=5000, max_size=1)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    assert cache.size == 1
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+
+
+@patch("time.time")
+def test_ttl_zero(mock_time):
+    mock_time.return_value = 1000.0
+    cache = TTLCache[str, int](default_ttl=0)
+    cache.set("a", 1)
+
+    assert cache.get("a") is None
+
+
+def test_numeric_keys():
+    cache = TTLCache[int, str](default_ttl=5000)
+    cache.set(1, "one")
+    cache.set(2, "two")
+    assert cache.get(1) == "one"
+    assert cache.get(2) == "two"


### PR DESCRIPTION
Ported `TTLCache` from `package/main` to `package/umt_python` with full parity, including FIFO eviction policy and test coverage.

---
*PR created automatically by Jules for task [766825540140316202](https://jules.google.com/task/766825540140316202) started by @riya-amemiya*