### PR TITLE
🔄 Sync: Port `inRange` to Rust

### DIFF
--- a/package/umt_rust/src/math/in_range.rs
+++ b/package/umt_rust/src/math/in_range.rs
@@ -1,0 +1,23 @@
+/// Checks if a number is within a given range.
+///
+/// This function checks if the value is between the start and end values.
+/// The range is [min(start, end), max(start, end)).
+///
+/// # Arguments
+///
+/// * `value` - The number to check.
+/// * `start` - The start of the range.
+/// * `end` - The end of the range.
+///
+/// # Returns
+///
+/// True if the value is within the range, false otherwise.
+#[inline]
+pub fn umt_in_range(value: f64, start: f64, end: f64) -> bool {
+    if value.is_nan() || start.is_nan() || end.is_nan() {
+        return false;
+    }
+    let lower = start.min(end);
+    let upper = start.max(end);
+    value >= lower && value < upper
+}

--- a/package/umt_rust/src/math/mod.rs
+++ b/package/umt_rust/src/math/mod.rs
@@ -43,6 +43,8 @@ pub mod division;
 pub use division::*;
 pub mod flexible_number_conversion;
 pub use flexible_number_conversion::*;
+pub mod in_range;
+pub use in_range::*;
 pub mod math_converter;
 pub use math_converter::*;
 pub mod max;

--- a/package/umt_rust/tests/math/test_in_range.rs
+++ b/package/umt_rust/tests/math/test_in_range.rs
@@ -1,0 +1,63 @@
+use umt_rust::math::umt_in_range;
+
+#[test]
+fn test_in_range_two_args() {
+    // Porting "should return true when value is within [0, end)"
+    assert!(umt_in_range(3.0, 0.0, 5.0));
+
+    // Porting "should return false when value equals end (two-arg form)"
+    assert!(!umt_in_range(5.0, 0.0, 5.0));
+
+    // Porting "should return true when value equals 0 (two-arg form)"
+    assert!(umt_in_range(0.0, 0.0, 5.0));
+
+    // Porting "should return false for negative value (two-arg form)"
+    assert!(!umt_in_range(-1.0, 0.0, 5.0));
+}
+
+#[test]
+fn test_in_range_three_args() {
+    // Porting "should return true when value is within [start, end)"
+    assert!(umt_in_range(3.0, 2.0, 5.0));
+
+    // Porting "should swap start and end if start > end"
+    assert!(umt_in_range(3.0, 5.0, 2.0));
+
+    // Porting "should return false when value equals the upper bound"
+    assert!(!umt_in_range(5.0, 2.0, 5.0));
+
+    // Porting "should return true when value equals the lower bound"
+    assert!(umt_in_range(2.0, 2.0, 5.0));
+}
+
+#[test]
+fn test_in_range_negative_ranges() {
+    // Porting "should handle negative ranges"
+    assert!(umt_in_range(-3.0, -5.0, -1.0));
+    assert!(umt_in_range(-5.0, -5.0, -1.0));
+    assert!(!umt_in_range(-1.0, -5.0, -1.0));
+}
+
+#[test]
+fn test_in_range_floating_point() {
+    // Porting "should handle floating point values"
+    assert!(umt_in_range(0.5, 0.0, 1.0));
+    assert!(!umt_in_range(1.5, 0.0, 1.0));
+}
+
+#[test]
+fn test_in_range_negative_two_args() {
+    // Porting "should handle negative ranges (two-arg form)"
+    // inRange(-3, -5) -> start=-5, end=undefined -> lower=-5, upper=0
+    assert!(umt_in_range(-3.0, 0.0, -5.0));
+    assert!(!umt_in_range(0.0, 0.0, -5.0));
+    assert!(umt_in_range(-5.0, 0.0, -5.0));
+}
+
+#[test]
+fn test_in_range_nan() {
+    // New test for parity with NaN handling
+    assert!(!umt_in_range(3.0, f64::NAN, 5.0));
+    assert!(!umt_in_range(3.0, 5.0, f64::NAN));
+    assert!(!umt_in_range(f64::NAN, 2.0, 5.0));
+}

--- a/package/umt_rust/tests/tests.rs
+++ b/package/umt_rust/tests/tests.rs
@@ -95,6 +95,7 @@ mod math {
     mod test_flexible_number_conversion;
     mod test_gcd;
     mod test_get_decimal_length;
+    mod test_in_range;
     mod test_lcm;
     mod test_linear_congruential_generator;
     mod test_math_converter;


### PR DESCRIPTION
Ported the `inRange` utility function from `package/main` to `package/umt_rust`.

Implementation details:
- Created `package/umt_rust/src/math/in_range.rs` with `umt_in_range` function.
- `umt_in_range` accepts 3 arguments: `value`, `start`, `end`.
- It explicitly checks for `NaN` inputs and returns `false` to match JS behavior (where `Math.min(NaN, ...)` results in NaN comparison yielding false).
- It calculates `lower` and `upper` bounds using `min/max` to handle swapped start/end, matching `package/main` logic.
- Registered the new module in `package/umt_rust/src/math/mod.rs`.

Verification:
- Created `package/umt_rust/tests/math/test_in_range.rs` with ported tests.
- Adapted 2-argument tests from TS to use explicit `0.0` as the start value in Rust (`umt_in_range(val, 0.0, end)`).
- Validated all tests pass with `cargo test`.

---
*PR created automatically by Jules for task [12169918124373001206](https://jules.google.com/task/12169918124373001206) started by @riya-amemiya*