### PR TITLE
🔄 Sync: Port [toPercentage] to [Rust]

### DIFF
--- a/package/umt_rust/src/number/mod.rs
+++ b/package/umt_rust/src/number/mod.rs
@@ -1,2 +1,5 @@
 mod to_ordinal;
 pub use to_ordinal::umt_to_ordinal;
+
+mod to_percentage;
+pub use to_percentage::{umt_to_percentage, umt_to_percentage_default};

--- a/package/umt_rust/src/number/to_percentage.rs
+++ b/package/umt_rust/src/number/to_percentage.rs
@@ -1,0 +1,37 @@
+/// Calculates the percentage of a value relative to a total.
+///
+/// Returns 0.0 when the total is 0.0 to avoid division by zero.
+///
+/// # Arguments
+///
+/// * `value` - The partial value
+/// * `total` - The total value
+/// * `decimals` - The number of decimal places
+///
+/// # Returns
+///
+/// * The percentage value
+pub fn umt_to_percentage(value: f64, total: f64, decimals: i32) -> f64 {
+    if total == 0.0 {
+        return 0.0;
+    }
+
+    let factor = 10_f64.powi(decimals);
+    ((value / total) * 100.0 * factor + 0.5).floor() / factor
+}
+
+/// Calculates the percentage of a value relative to a total with 2 decimal places by default.
+///
+/// Returns 0.0 when the total is 0.0 to avoid division by zero.
+///
+/// # Arguments
+///
+/// * `value` - The partial value
+/// * `total` - The total value
+///
+/// # Returns
+///
+/// * The percentage value
+pub fn umt_to_percentage_default(value: f64, total: f64) -> f64 {
+    umt_to_percentage(value, total, 2)
+}

--- a/package/umt_rust/tests/number/mod.rs
+++ b/package/umt_rust/tests/number/mod.rs
@@ -1,1 +1,2 @@
 mod test_to_ordinal;
+mod test_to_percentage;

--- a/package/umt_rust/tests/number/test_to_percentage.rs
+++ b/package/umt_rust/tests/number/test_to_percentage.rs
@@ -1,0 +1,49 @@
+use umt_rust::number::{umt_to_percentage, umt_to_percentage_default};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_calculate_basic_percentage() {
+        assert_eq!(umt_to_percentage_default(25.0, 100.0), 25.0);
+        assert_eq!(umt_to_percentage_default(50.0, 100.0), 50.0);
+        assert_eq!(umt_to_percentage_default(100.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn should_return_result_with_2_decimal_places_by_default() {
+        assert_eq!(umt_to_percentage_default(1.0, 3.0), 33.33);
+        assert_eq!(umt_to_percentage_default(2.0, 3.0), 66.67);
+    }
+
+    #[test]
+    fn should_respect_custom_decimal_places() {
+        assert_eq!(umt_to_percentage(1.0, 3.0, 0), 33.0);
+        assert_eq!(umt_to_percentage(1.0, 3.0, 1), 33.3);
+        assert_eq!(umt_to_percentage(1.0, 3.0, 4), 33.3333);
+    }
+
+    #[test]
+    fn should_return_0_when_total_is_0() {
+        assert_eq!(umt_to_percentage_default(0.0, 0.0), 0.0);
+        assert_eq!(umt_to_percentage_default(5.0, 0.0), 0.0);
+        assert_eq!(umt_to_percentage_default(-5.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn should_handle_0_value() {
+        assert_eq!(umt_to_percentage_default(0.0, 100.0), 0.0);
+    }
+
+    #[test]
+    fn should_handle_values_greater_than_total() {
+        assert_eq!(umt_to_percentage_default(150.0, 100.0), 150.0);
+        assert_eq!(umt_to_percentage_default(200.0, 100.0), 200.0);
+    }
+
+    #[test]
+    fn should_handle_negative_values() {
+        assert_eq!(umt_to_percentage_default(-25.0, 100.0), -25.0);
+    }
+}


### PR DESCRIPTION
🔗 Source: `package/main/src/Number/toPercentage.ts`
🎯 Target: `package/umt_rust/src/number/to_percentage.rs`
🛠 Implementation: Emulated JS `Math.round` rounding rule using `(x + 0.5).floor()`. Handled the default parameter pattern by providing `umt_to_percentage_default`.
✅ Verification: Parity tests match the JS suite identically. `cargo test` and `cargo clippy` execute perfectly.

---
*PR created automatically by Jules for task [11564700973207850855](https://jules.google.com/task/11564700973207850855) started by @riya-amemiya*