### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix prototype pollution in pickDeep

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Replacing `Math.random` with `crypto.getRandomValues` caused a crash for large requested sizes because the API has a 65536 byte limit (QuotaExceededError).
 **Learning:** `crypto.getRandomValues` is not a drop-in replacement for loop-based `Math.random` generation when arbitrary sizes are supported.
 **Prevention:** Always implement chunking (e.g. 64KB batches) when using `crypto.getRandomValues` to fill buffers of potentially unlimited size.
+## 2025-03-02 - [CRITICAL] Fix Prototype Pollution in pickDeep
+**Vulnerability:** The `pickDeep` function did not filter out sensitive object keys (`__proto__`, `constructor`, `prototype`), allowing an attacker to traverse the prototype chain and overwrite global properties (Prototype Pollution) by passing malicious paths like `__proto__.polluted`.
+**Learning:** Utilities that deeply traverse and construct objects based on dynamic, user-controlled paths must explicitly block access to prototype-related keys to prevent Prototype Pollution attacks.
+**Prevention:** Always validate and sanitize keys during deep object traversal or assignment, explicitly ignoring or rejecting keys like `__proto__`, `constructor`, and `prototype`.

--- a/package/main/src/Object/pickDeep.ts
+++ b/package/main/src/Object/pickDeep.ts
@@ -35,6 +35,14 @@ export const pickDeep = <
     let target: any = result;
 
     for (const [index, part] of parts.entries()) {
+      if (
+        part === "__proto__" ||
+        part === "constructor" ||
+        part === "prototype"
+      ) {
+        continue;
+      }
+
       if (current && typeof current === "object" && part in current) {
         if (index === parts.length - 1) {
           target[part] = current[part];

--- a/package/main/src/tests/unit/Object/pickDeep.test.ts
+++ b/package/main/src/tests/unit/Object/pickDeep.test.ts
@@ -119,4 +119,41 @@ describe("pickDeep function", () => {
     const result = pickDeep(obj, "a", "a", "c");
     expect(result).toEqual({ a: 1, c: 3 });
   });
+
+  test("should prevent prototype pollution via __proto__", () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": true}}');
+    // @ts-expect-error - testing invalid keys
+    const result = pickDeep(payload, "__proto__.polluted");
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (result as any).polluted,
+    ).toBeUndefined();
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      ({} as any).polluted,
+    ).toBeUndefined();
+  });
+
+  test("should prevent prototype pollution via constructor", () => {
+    const payload = JSON.parse(
+      '{"constructor": {"prototype": {"polluted": true}}}',
+    );
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    const result = pickDeep(payload, "constructor.prototype.polluted" as any);
+    expect(result.constructor).toBe(Object);
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).polluted,
+    ).toBeUndefined();
+  });
+
+  test("should prevent prototype pollution via prototype", () => {
+    const payload = JSON.parse('{"prototype": {"polluted": true}}');
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    const result = pickDeep(payload, "prototype.polluted" as any);
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (result as any).prototype,
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix prototype pollution in pickDeep

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `pickDeep` utility permitted deep property extraction without filtering dangerous property names (`__proto__`, `constructor`, `prototype`), leading to a prototype pollution vulnerability.
🎯 **Impact:** Attackers who can control the selected properties parameter could potentially execute a prototype pollution attack to overwrite base Object prototypes, resulting in arbitrary variable manipulation or potential Remote Code Execution in dependent Node.js services.
🔧 **Fix:** Added guard checks inside the traversal loops in `pickDeep.ts` to `continue` and ignore sensitive prototype-related property names.
✅ **Verification:** Verified fix with comprehensive new tests in `pickDeep.test.ts` executing successfully against prototype pollution payloads, ensuring the global prototypes remain clean.

---
*PR created automatically by Jules for task [8599181753946541521](https://jules.google.com/task/8599181753946541521) started by @riya-amemiya*