### PR TITLE
🔄 Sync: Port unwrap to Python

### DIFF
--- a/package/umt_python/src/tool/__init__.py
+++ b/package/umt_python/src/tool/__init__.py
@@ -2,6 +2,7 @@ from .create_pipeline import Pipeline, create_pipeline
 from .escape_regexp import escape_regexp
 from .parse_json import parse_json
 from .pipe import Pipe, pipe
+from .unwrap import unwrap
 
 __all__ = [
     "Pipe",
@@ -10,4 +11,5 @@ __all__ = [
     "escape_regexp",
     "parse_json",
     "pipe",
+    "unwrap",
 ]

--- a/package/umt_python/src/tool/unwrap.py
+++ b/package/umt_python/src/tool/unwrap.py
@@ -1,0 +1,22 @@
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def unwrap(value: T | None, message: str) -> T:
+    """
+    Unwraps a value that may be None, raising a ValueError if the value is absent.
+
+    Args:
+        value: The value to unwrap (may be None)
+        message: The error message to raise if the value is absent
+
+    Returns:
+        The unwrapped value of type T
+
+    Raises:
+        ValueError: If the value is None
+    """
+    if value is not None:
+        return value
+    raise ValueError(message)

--- a/package/umt_python/tests/unit/tool/test_unwrap.py
+++ b/package/umt_python/tests/unit/tool/test_unwrap.py
@@ -1,0 +1,49 @@
+import unittest
+
+from src.tool.unwrap import unwrap
+
+
+class TestUnwrap(unittest.TestCase):
+    def test_should_return_the_value_when_it_is_not_undefined_or_null(self):
+        value = "test"
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, "test")
+
+    def test_should_return_the_value_when_it_is_a_number(self):
+        value = 42
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, 42)
+
+    def test_should_return_the_value_when_it_is_zero(self):
+        value = 0
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, 0)
+
+    def test_should_return_the_value_when_it_is_an_empty_string(self):
+        value = ""
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, "")
+
+    def test_should_return_the_value_when_it_is_false(self):
+        value = False
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, False)
+
+    def test_should_return_the_value_when_it_is_an_object(self):
+        value = {"key": "value"}
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, {"key": "value"})
+
+    def test_should_return_the_value_when_it_is_an_array(self):
+        value = [1, 2, 3]
+        result = unwrap(value, "Value is absent")
+        self.assertEqual(result, [1, 2, 3])
+
+    def test_should_throw_an_error_when_the_value_is_null(self):
+        value = None
+        with self.assertRaisesRegex(ValueError, "Value is null"):
+            unwrap(value, "Value is null")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ported the `unwrap` utility function from `package/main/src/Tool/unwrap.ts` to `package/umt_python/src/tool/unwrap.py`. Added corresponding unit tests in `package/umt_python/tests/unit/tool/test_unwrap.py` and exported it via `package/umt_python/src/tool/__init__.py`. Tested with `pytest`, `ruff`, and `pyright`.

---
*PR created automatically by Jules for task [18410471578343507069](https://jules.google.com/task/18410471578343507069) started by @riya-amemiya*