### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Prototype Pollution in deepClone

### DIFF
--- a/package/main/src/Object/deepClone.ts
+++ b/package/main/src/Object/deepClone.ts
@@ -41,6 +41,9 @@ const cloneValue = (value: unknown): unknown => {
   // Plain object
   const result: Record<string, unknown> = {};
   for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      continue;
+    }
     result[key] = cloneValue((value as Record<string, unknown>)[key]);
   }
   return result;

--- a/package/main/src/tests/unit/Object/deepClone.test.ts
+++ b/package/main/src/tests/unit/Object/deepClone.test.ts
@@ -71,4 +71,22 @@ describe("deepClone", () => {
     expect(cloned.pattern.flags).toBe("gi");
     expect(cloned.pattern).not.toBe(original.pattern);
   });
+
+  it("should prevent prototype pollution via __proto__", () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": true}}');
+    const cloned = deepClone(payload);
+
+    // Should not have __proto__ property set directly
+    expect(Object.hasOwn(cloned, "__proto__")).toBe(false);
+  });
+
+  it("should prevent prototype pollution via constructor", () => {
+    const payload = JSON.parse(
+      '{"constructor": {"prototype": {"polluted": true}}}',
+    );
+    const cloned = deepClone(payload);
+
+    // Should not overwrite constructor
+    expect(cloned.constructor).toBe(Object);
+  });
 });


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Prototype Pollution via `deepClone`
🎯 Impact: Cloning a maliciously crafted object could allow attackers to alter properties across the prototype chain, potentially leading to unauthorized data manipulation or execution paths.
🔧 Fix: Explicitly filtered out unsafe keys (`__proto__`, `constructor`, `prototype`) within the `deepClone` plain object loop to ensure these properties cannot be copied directly.
✅ Verification: New test cases added to `src/tests/unit/Object/deepClone.test.ts` verify that the pollution is mitigated. Full test suite passes.

---
*PR created automatically by Jules for task [4772278696744247273](https://jules.google.com/task/4772278696744247273) started by @riya-amemiya*