### PR TITLE
⚡ Bolt: optimize Base58/Base32 encode/decode algorithms

### DIFF
--- a/package/main/src/Crypto/decodeBase32.ts
+++ b/package/main/src/Crypto/decodeBase32.ts
@@ -1,5 +1,10 @@
 import { BASE32_ALPHABET } from "./constants";
 
+// O(1) lookup table for Base32 character-to-index mapping
+const base32CharToIndex = new Map(
+  [...BASE32_ALPHABET].map((c, index) => [c, index]),
+);
+
 /**
  * Decodes a Base32 string to Uint8Array
  * @param {string} input - Base32 encoded string
@@ -7,14 +12,13 @@ import { BASE32_ALPHABET } from "./constants";
  * @example decodeBase32("JBSWY3DP"); // Uint8Array for "Hello"
  */
 export const decodeBase32 = (input: string): Uint8Array => {
-  const alphabet = BASE32_ALPHABET;
   const cleanedInput = input.replaceAll("=", "");
   const result: number[] = [];
   let buffer = 0;
   let bufferLength = 0;
 
   for (const char of cleanedInput) {
-    const value = alphabet.indexOf(char);
+    const value = base32CharToIndex.get(char) ?? 0;
 
     buffer = (buffer << 5) | value;
     bufferLength += 5;

--- a/package/main/src/Crypto/decodeBase58.ts
+++ b/package/main/src/Crypto/decodeBase58.ts
@@ -1,5 +1,10 @@
 import { BASE58_ALPHABET } from "./constants";
 
+// O(1) lookup table for Base58 character-to-index mapping
+const base58CharToIndex = new Map(
+  [...BASE58_ALPHABET].map((c, index) => [c, index]),
+);
+
 /**
  * Decodes a Base58 string to Uint8Array
  * @param {string} input - Base58 encoded string
@@ -7,19 +12,20 @@ import { BASE58_ALPHABET } from "./constants";
  * @example decodeBase58("9Ajdvzr"); // Uint8Array for "Hello"
  */
 export const decodeBase58 = (input: string): Uint8Array => {
-  const alphabet = BASE58_ALPHABET;
   let bigNumber = 0n;
 
   for (const char of input) {
-    const value = alphabet.indexOf(char);
+    const value = base58CharToIndex.get(char) ?? 0;
     bigNumber = bigNumber * 58n + BigInt(value);
   }
 
+  // Use push + reverse instead of unshift to avoid O(n²) array shifting
   const bytes: number[] = [];
   while (bigNumber > 0) {
-    bytes.unshift(Number(bigNumber % 256n));
+    bytes.push(Number(bigNumber % 256n));
     bigNumber /= 256n;
   }
+  bytes.reverse();
 
   let leadingOnes = 0;
   for (const char of input) {

--- a/package/main/src/Crypto/encodeBase58.ts
+++ b/package/main/src/Crypto/encodeBase58.ts
@@ -11,7 +11,8 @@ export const encodeBase58 = (input: string | Uint8Array): string => {
   const bytes =
     typeof input === "string" ? new TextEncoder().encode(input) : input;
 
-  let encoded = "";
+  // Use array + reverse + join instead of string prepend to avoid O(n²) string concatenation
+  const chars: string[] = [];
   let bigNumber = 0n;
 
   for (const byte of bytes) {
@@ -20,9 +21,11 @@ export const encodeBase58 = (input: string | Uint8Array): string => {
 
   while (bigNumber > 0) {
     const remainder = Number(bigNumber % 58n);
-    encoded = alphabet[remainder] + encoded;
+    chars.push(alphabet[remainder]);
     bigNumber /= 58n;
   }
+  chars.reverse();
+  const encoded = chars.join("");
 
   let leadingZeros = 0;
   for (const byte of bytes) {


### PR DESCRIPTION
## 💡 What

Base58/Base32のエンコード・デコード処理で3つのアルゴリズム的非効率を修正しました。

**decodeBase58.ts / decodeBase32.ts**
`alphabet.indexOf(char)` をループ内で毎回呼び出していたため、文字→インデックスの変換がO(m)（mはアルファベット長）でした。事前計算したMapルックアップテーブルに置き換えることでO(1)に改善しました。

**decodeBase58.ts**
`bytes.unshift()` をwhileループ内で使用していたため、配列の先頭への挿入が毎回O(n)で全体がO(n²)でした。`push()` + `reverse()` パターンに置き換えることで全体をO(n)に改善しました。

**encodeBase58.ts**
`encoded = alphabet[remainder] + encoded` で文字列の先頭に結合していたため、不変な文字列の再構築が毎回O(n)で全体がO(n²)でした。配列に `push()` して最後に `reverse().join("")` するパターンに置き換えることでO(n)に改善しました。

## 🎯 Why

入力サイズが大きくなるにつれて、これらのO(n²)操作がボトルネックになります。特にBase58デコードでは `indexOf` O(n*m) と `unshift` O(n²) の二重の非効率が存在していました。

## 📊 Impact

入力サイズnに対して以下の改善が期待されます。

| 変更箇所 | Before | After |
|----------|--------|-------|
| Base58 decode (indexOf) | O(n × 58) | O(n) |
| Base32 decode (indexOf) | O(n × 32) | O(n) |
| Base58 decode (unshift) | O(n²) | O(n) |
| Base58 encode (string prepend) | O(n²) | O(n) |

大きな入力（数千バイト以上）では10倍以上の速度向上が見込まれます。

## 🔬 Measurement

```
bun run test src/tests/unit/Crypto/
```

全35テスト、lint、型チェックをパスしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)