### PR TITLE
🛡️ Sentinel: [HIGH] Fix Prototype Pollution in Object utilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** The `pickDeep` function did not filter out sensitive object keys (`__proto__`, `constructor`, `prototype`), allowing an attacker to traverse the prototype chain and overwrite global properties (Prototype Pollution) by passing malicious paths like `__proto__.polluted`.
 **Learning:** Utilities that deeply traverse and construct objects based on dynamic, user-controlled paths must explicitly block access to prototype-related keys to prevent Prototype Pollution attacks.
 **Prevention:** Always validate and sanitize keys during deep object traversal or assignment, explicitly ignoring or rejecting keys like `__proto__`, `constructor`, and `prototype`.
+## 2025-03-16 - Prototype Pollution in Object Utilities
+**Vulnerability:** `getObjectsCommon` and `getObjectsDiff` were vulnerable to Prototype Pollution because they iterated over and copied all keys, including `__proto__`, `constructor`, and `prototype`.
+**Learning:** Even simple object diffing or commonality utilities need explicit prototype pollution guards because they dynamically assign keys to a new object based on unsanitized input objects.
+**Prevention:** Always explicitly check and ignore `__proto__`, `constructor`, and `prototype` keys during object iteration in any utility that dynamically constructs or merges objects.

--- a/package/main/src/Object/getObjectsCommon.ts
+++ b/package/main/src/Object/getObjectsCommon.ts
@@ -33,6 +33,10 @@ export const getObjectsCommon = <T extends Record<string, unknown>>(
   const result = {} as Partial<T>;
 
   for (const [key, value] of Object.entries(object)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      continue;
+    }
+
     let isCommon = true;
     let allPlainObjects = isPlainObject(value);
 

--- a/package/main/src/Object/getObjectsDiff.ts
+++ b/package/main/src/Object/getObjectsDiff.ts
@@ -37,6 +37,9 @@ export const getObjectsDiff = <T extends Record<string, unknown>>(
   const allKeys = new Set<string>();
   for (const object_ of allObjects) {
     for (const key of Object.keys(object_)) {
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        continue;
+      }
       allKeys.add(key);
     }
   }

--- a/package/main/src/tests/unit/Object/getObjectsCommon.test.ts
+++ b/package/main/src/tests/unit/Object/getObjectsCommon.test.ts
@@ -122,4 +122,15 @@ describe("getObjectsCommon", () => {
     expect(obj1).toEqual(obj1Copy);
     expect(obj2).toEqual(obj2Copy);
   });
+
+  test("should prevent prototype pollution via __proto__", () => {
+    const obj1 = JSON.parse('{"__proto__": {"polluted": true}}');
+    const obj2 = JSON.parse('{"__proto__": {"polluted": true}}');
+
+    const result = getObjectsCommon(obj1, obj2);
+
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect((result as any).polluted).toBeUndefined();
+  });
 });

--- a/package/main/src/tests/unit/Object/getObjectsDiff.test.ts
+++ b/package/main/src/tests/unit/Object/getObjectsDiff.test.ts
@@ -121,4 +121,15 @@ describe("getObjectsDiff", () => {
     expect(obj1).toEqual(obj1Copy);
     expect(obj2).toEqual(obj2Copy);
   });
+
+  it("should prevent prototype pollution via __proto__", () => {
+    const obj1 = JSON.parse('{"__proto__": {"polluted": true}}');
+    const obj2 = { a: 1 };
+
+    const result = getObjectsDiff(obj1, obj2);
+
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect((result as any).polluted).toBeUndefined();
+  });
 });


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Prototype Pollution in Object utilities

🚨 Severity: HIGH
💡 Vulnerability: `getObjectsCommon` and `getObjectsDiff` were vulnerable to Prototype Pollution because they iterated over and copied all keys, including `__proto__`, `constructor`, and `prototype`.
🎯 Impact: Malicious actors could inject properties into the global Object prototype, potentially leading to widespread unexpected behavior or security issues if the outputs are used in unsafe ways.
🔧 Fix: Added explicit checks to ignore `__proto__`, `constructor`, and `prototype` keys during object iteration.
✅ Verification: Ran `bun test` in `package/main` and verified the new unit tests (testing via `JSON.parse('{"__proto__": ...}')`) pass without mutating the object prototype.

---
*PR created automatically by Jules for task [15612500736074852417](https://jules.google.com/task/15612500736074852417) started by @riya-amemiya*