### PR TITLE
🔄 Sync: Port matches predicate to python

### DIFF
--- a/.jules/sync.md
+++ b/.jules/sync.md
@@ -7,3 +7,5 @@
 ## 2025-02-23 - Logic Mismatch in `is_double` for Lists
 **Mismatch:** `isDouble` in `package/main` (JS) implicitly coerces single-element arrays to numbers (e.g., `[1.5]` -> `1.5`), returning `true`.
 **Resolution:** In `package/umt_python`, `is_double` explicitly returns `False` for `list` and `dict` types to maintain idiomatic Python behavior and type safety, aligning with the precedent set by `is_number`.
+
+## 2026-03-16 - [Strict Equality in Python] **Mismatch:** [Python's `==` treats `False == 0` and `True == 1` as equal] **Resolution:** [Explicitly check types `if type(obj_val) is bool and type(value) is not bool` when porting strict equality (`===`) from TS to Python to ensure parity in `matches` predicate]

--- a/package/umt_python/src/predicate/__init__.py
+++ b/package/umt_python/src/predicate/__init__.py
@@ -1,5 +1,6 @@
 from .every import every
+from .matches import matches
 from .not_ import not_
 from .some import some
 
-__all__ = ["every", "not_", "some"]
+__all__ = ["every", "matches", "not_", "some"]

--- a/package/umt_python/src/predicate/matches.py
+++ b/package/umt_python/src/predicate/matches.py
@@ -1,0 +1,37 @@
+from collections.abc import Callable
+from typing import Any
+
+
+def matches(pattern: dict[str, Any]) -> Callable[[dict[str, Any]], bool]:
+    """
+    Creates a predicate that checks whether an object matches
+    all properties of the given pattern using strict equality
+
+    Args:
+        pattern: The pattern to match against
+
+    Returns:
+        A predicate that tests objects
+
+    Example:
+        >>> is_admin = matches({"role": "admin"})
+        >>> is_admin({"name": "Alice", "role": "admin"})
+        True
+        >>> is_admin({"name": "Bob", "role": "user"})
+        False
+    """
+
+    def matcher(obj: dict[str, Any]) -> bool:
+        for key, value in pattern.items():
+            if key not in obj:
+                return False
+            obj_val = obj[key]
+            if type(obj_val) is bool and type(value) is not bool:
+                return False
+            if type(obj_val) is not bool and type(value) is bool:
+                return False
+            if obj_val != value:
+                return False
+        return True
+
+    return matcher

--- a/package/umt_python/tests/unit/predicate/test_matches.py
+++ b/package/umt_python/tests/unit/predicate/test_matches.py
@@ -1,0 +1,45 @@
+from src.predicate.matches import matches
+
+
+def test_matches_returns_true_when_object_matches_the_pattern() -> None:
+    is_admin = matches({"role": "admin"})
+    assert is_admin({"name": "Alice", "role": "admin"}) is True
+
+
+def test_matches_returns_false_when_object_does_not_match() -> None:
+    is_admin = matches({"role": "admin"})
+    assert is_admin({"name": "Bob", "role": "user"}) is False
+
+
+def test_matches_multiple_properties() -> None:
+    matcher = matches({"a": 1, "b": 2})
+    assert matcher({"a": 1, "b": 2, "c": 3}) is True
+    assert matcher({"a": 1, "b": 3}) is False
+    assert matcher({"a": 2, "b": 2}) is False
+
+
+def test_matches_uses_strict_equality() -> None:
+    matcher = matches({"value": 0})
+    assert matcher({"value": 0}) is True
+    assert matcher({"value": False}) is False
+    assert matcher({"value": ""}) is False
+    assert matcher({"value": None}) is False
+
+
+def test_matches_returns_true_for_empty_pattern() -> None:
+    always_match = matches({})
+    assert always_match({"anything": "goes"}) is True
+    assert always_match({}) is True
+
+
+def test_matches_handles_missing_keys_in_target_object() -> None:
+    matcher = matches({"x": 1})
+    assert matcher({}) is False
+    assert matcher({"y": 1}) is False
+
+
+def test_matches_handles_none_values() -> None:
+    match_none = matches({"a": None})
+    assert match_none({"a": None}) is True
+    assert match_none({"a": False}) is False
+    assert match_none({}) is False


### PR DESCRIPTION
🔗 Source: `package/main/src/Predicate/matches.ts`
🎯 Target: `package/umt_python/src/predicate/matches.py`, `package/umt_python/src/predicate/__init__.py`, `package/umt_python/tests/unit/predicate/test_matches.py`
🛠 Implementation:
- Implemented `matches` predicate in `package/umt_python/src/predicate/matches.py` to match the exact behavior of `package/main/src/Predicate/matches.ts`.
- Included explicit type checking between `bool` and non-`bool` types (`int`, `float`) to enforce strict equality parity (preventing `False == 0` and `True == 1`).
- Exported `matches` in `package/umt_python/src/predicate/__init__.py`.
- Ported the full suite of unit tests over into `package/umt_python/tests/unit/predicate/test_matches.py`.
✅ Verification: 
- `uv run pytest` test suite passed locally.
- `uv run ruff check` and `uv run ruff format` passed locally.
- Noted strict equality `bool`/`int` discrepancy in `.jules/sync.md`.

---
*PR created automatically by Jules for task [12560750882651501782](https://jules.google.com/task/12560750882651501782) started by @riya-amemiya*