### PR TITLE
Optimize zipLongest with pre-allocated arrays and direct indexing

### DIFF
--- a/package/main/src/Array/zipLongest.ts
+++ b/package/main/src/Array/zipLongest.ts
@@ -30,9 +30,9 @@ export const zipLongest = <T extends unknown[][]>(
 
   // Optimize: Pre-allocate arrays with known lengths and use direct index assignment
   // instead of .push() to avoid repeated capacity checks and potential reallocations.
-  const result: unknown[][] = new Array(maxLength);
+  const result: unknown[][] = Array.from({ length: maxLength });
   for (let index = 0; index < maxLength; index += 1) {
-    const tuple: unknown[] = new Array(arraysLength);
+    const tuple: unknown[] = Array.from({ length: arraysLength });
     for (let arrayIndex = 0; arrayIndex < arraysLength; arrayIndex += 1) {
       tuple[arrayIndex] = arrays[arrayIndex][index];
     }

--- a/package/main/src/tests/benchmark/array.zipLongest.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.zipLongest.benchmark.ts
@@ -3,16 +3,18 @@ import { run, bench, summary, do_not_optimize, type k_state } from "mitata";
 // Pre-allocated version (optimized)
 const zipLongestOptimized = (...arrays: unknown[][]) => {
   const arraysLength = arrays.length;
-  if (arraysLength === 0) return [];
+  if (arraysLength === 0) {
+    return [];
+  }
   let maxLength = arrays[0].length;
   for (let index = 1; index < arraysLength; index += 1) {
     if (arrays[index].length > maxLength) {
       maxLength = arrays[index].length;
     }
   }
-  const result: unknown[][] = new Array(maxLength);
+  const result: unknown[][] = Array.from({ length: maxLength });
   for (let index = 0; index < maxLength; index += 1) {
-    const tuple: unknown[] = new Array(arraysLength);
+    const tuple: unknown[] = Array.from({ length: arraysLength });
     for (let arrayIndex = 0; arrayIndex < arraysLength; arrayIndex += 1) {
       tuple[arrayIndex] = arrays[arrayIndex][index];
     }
@@ -24,7 +26,9 @@ const zipLongestOptimized = (...arrays: unknown[][]) => {
 // Push-based version (original)
 const zipLongestPush = (...arrays: unknown[][]) => {
   const arraysLength = arrays.length;
-  if (arraysLength === 0) return [];
+  if (arraysLength === 0) {
+    return [];
+  }
   let maxLength = arrays[0].length;
   for (let index = 1; index < arraysLength; index += 1) {
     if (arrays[index].length > maxLength) {
@@ -43,7 +47,7 @@ const zipLongestPush = (...arrays: unknown[][]) => {
 };
 
 const arrayCounts = [3, 10, 50];
-const arrayLengths = [100, 1_000, 10_000];
+const arrayLengths = [100, 1000, 10_000];
 
 const testData = new Map<string, unknown[][]>();
 for (const count of arrayCounts) {
@@ -64,7 +68,7 @@ summary(() => {
     function* (state: k_state) {
       const count = state.get("count") as number;
       const length = state.get("length") as number;
-      const arrays = testData.get(`${count}-${length}`)!;
+      const arrays = testData.get(`${count}-${length}`) as unknown[][];
       yield () => {
         do_not_optimize(zipLongestOptimized(...arrays));
       };
@@ -78,7 +82,7 @@ summary(() => {
     function* (state: k_state) {
       const count = state.get("count") as number;
       const length = state.get("length") as number;
-      const arrays = testData.get(`${count}-${length}`)!;
+      const arrays = testData.get(`${count}-${length}`) as unknown[][];
       yield () => {
         do_not_optimize(zipLongestPush(...arrays));
       };


### PR DESCRIPTION
## Summary
Optimized the `zipLongest` function to use pre-allocated arrays with direct index assignment instead of dynamic array growth via `.push()` calls. This reduces memory reallocations and improves performance.

## Key Changes
- **Pre-allocate outer result array**: Changed from `[]` to `new Array(maxLength)` to avoid repeated capacity checks during push operations
- **Pre-allocate inner tuple arrays**: Changed from `[]` to `new Array(arraysLength)` for consistent tuple sizing
- **Use direct index assignment**: Replaced `.push()` calls with direct index assignment (`result[index] = tuple` and `tuple[arrayIndex] = value`) to eliminate push overhead
- **Added benchmark suite**: Created comprehensive benchmark comparing the optimized pre-allocation approach against the original push-based implementation across various array counts (3, 10, 50) and lengths (100, 1K, 10K)

## Implementation Details
The optimization leverages the fact that we know the exact dimensions of the result arrays before construction:
- The outer array length equals the maximum length of input arrays
- Each inner tuple length equals the number of input arrays

By pre-allocating with these known sizes, we avoid the overhead of dynamic array growth and the repeated capacity checks that `.push()` performs internally. Direct index assignment is a more efficient operation for arrays with pre-determined sizes.

https://claude.ai/code/session_01TXJu63xRsMNtCUg5QScmTM