### PR TITLE
🔄 Sync: Port URL module to Rust

### DIFF
--- a/package/umt_rust/src/lib.rs
+++ b/package/umt_rust/src/lib.rs
@@ -18,4 +18,5 @@ pub mod time;
 pub mod tool;
 pub mod ua;
 pub mod unit;
+pub mod url;
 pub mod validate;

--- a/package/umt_rust/src/url/is_absolute_url.rs
+++ b/package/umt_rust/src/url/is_absolute_url.rs
@@ -1,0 +1,31 @@
+use regex::Regex;
+
+/// Checks whether a URL string is absolute (RFC 3986).
+///
+/// An absolute URL starts with a scheme followed by a colon,
+/// where the scheme begins with a letter and may contain
+/// letters, digits, plus, hyphen, or period.
+///
+/// # Arguments
+///
+/// * `url` - The URL string to check
+///
+/// # Returns
+///
+/// `true` if the URL is absolute, `false` otherwise.
+///
+/// # Example
+///
+/// ```
+/// use umt_rust::url::umt_is_absolute_url;
+///
+/// assert!(umt_is_absolute_url("https://example.com"));
+/// assert!(umt_is_absolute_url("ftp://files.example"));
+/// assert!(!umt_is_absolute_url("/path/to/page"));
+/// assert!(!umt_is_absolute_url("relative/path"));
+/// assert!(umt_is_absolute_url("mailto:user@host"));
+/// ```
+pub fn umt_is_absolute_url(url: &str) -> bool {
+    let re = Regex::new(r"(?i)^[a-z][\da-z+.\-]*:").unwrap();
+    re.is_match(url)
+}

--- a/package/umt_rust/src/url/join_path.rs
+++ b/package/umt_rust/src/url/join_path.rs
@@ -1,0 +1,49 @@
+/// Joins multiple path segments into a single path,
+/// normalizing slashes between segments.
+///
+/// Leading slash of the first segment is preserved.
+/// Trailing slash of the last segment is preserved.
+/// All intermediate slashes are normalized to a single slash.
+///
+/// # Arguments
+///
+/// * `segments` - The path segments to join
+///
+/// # Returns
+///
+/// The joined and normalized path.
+///
+/// # Example
+///
+/// ```
+/// use umt_rust::url::umt_join_path;
+///
+/// assert_eq!(umt_join_path(&["https://example.com/", "/api/", "/users"]), "https://example.com/api/users");
+/// assert_eq!(umt_join_path(&["/a/", "/b/", "/c"]), "/a/b/c");
+/// assert_eq!(umt_join_path(&["a", "b", "c"]), "a/b/c");
+/// ```
+pub fn umt_join_path(segments: &[&str]) -> String {
+    if segments.is_empty() {
+        return String::new();
+    }
+
+    let mut normalized: Vec<&str> = Vec::new();
+
+    for (index, segment) in segments.iter().enumerate() {
+        let mut s = *segment;
+
+        if index > 0 {
+            s = s.trim_start_matches('/');
+        }
+
+        if index < segments.len() - 1 {
+            s = s.trim_end_matches('/');
+        }
+
+        if !s.is_empty() {
+            normalized.push(s);
+        }
+    }
+
+    normalized.join("/")
+}

--- a/package/umt_rust/src/url/mod.rs
+++ b/package/umt_rust/src/url/mod.rs
@@ -1,0 +1,11 @@
+//! URL utility module for UMT Rust.
+//!
+//! This module provides URL-related utility functions:
+//! - `is_absolute_url` - Check if a URL string is absolute (RFC 3986)
+//! - `join_path` - Join multiple path segments into a normalized path
+
+pub mod is_absolute_url;
+pub use is_absolute_url::*;
+
+pub mod join_path;
+pub use join_path::*;

--- a/package/umt_rust/tests/tests.rs
+++ b/package/umt_rust/tests/tests.rs
@@ -180,6 +180,11 @@ mod unit_module {
     mod test_unit_converter;
 }
 
+mod url {
+    mod test_is_absolute_url;
+    mod test_join_path;
+}
+
 mod object {
     mod test_has;
     mod test_is_empty;

--- a/package/umt_rust/tests/url/mod.rs
+++ b/package/umt_rust/tests/url/mod.rs
@@ -1,0 +1,2 @@
+mod test_is_absolute_url;
+mod test_join_path;

--- a/package/umt_rust/tests/url/test_is_absolute_url.rs
+++ b/package/umt_rust/tests/url/test_is_absolute_url.rs
@@ -1,0 +1,46 @@
+use umt_rust::url::umt_is_absolute_url;
+
+#[test]
+fn test_returns_true_for_http_urls() {
+    assert!(umt_is_absolute_url("http://example.com"));
+    assert!(umt_is_absolute_url("https://example.com"));
+}
+
+#[test]
+fn test_returns_true_for_other_schemes() {
+    assert!(umt_is_absolute_url("ftp://files.example"));
+    assert!(umt_is_absolute_url("mailto:user@host"));
+    assert!(umt_is_absolute_url("tel:+1234567890"));
+    assert!(umt_is_absolute_url("ssh://host"));
+}
+
+#[test]
+fn test_returns_true_for_custom_schemes() {
+    assert!(umt_is_absolute_url("custom+scheme://path"));
+    assert!(umt_is_absolute_url("my-app://deep-link"));
+    assert!(umt_is_absolute_url("x.y://test"));
+}
+
+#[test]
+fn test_returns_false_for_relative_paths() {
+    assert!(!umt_is_absolute_url("/path/to/page"));
+    assert!(!umt_is_absolute_url("relative/path"));
+    assert!(!umt_is_absolute_url("./relative"));
+    assert!(!umt_is_absolute_url("../parent"));
+}
+
+#[test]
+fn test_returns_false_for_protocol_relative_urls() {
+    assert!(!umt_is_absolute_url("//example.com"));
+}
+
+#[test]
+fn test_returns_false_for_empty_string() {
+    assert!(!umt_is_absolute_url(""));
+}
+
+#[test]
+fn test_returns_false_for_invalid_scheme_starts() {
+    assert!(!umt_is_absolute_url("123://invalid"));
+    assert!(!umt_is_absolute_url("+bad://invalid"));
+}

--- a/package/umt_rust/tests/url/test_join_path.rs
+++ b/package/umt_rust/tests/url/test_join_path.rs
@@ -1,0 +1,49 @@
+use umt_rust::url::umt_join_path;
+
+#[test]
+fn test_joins_simple_segments() {
+    assert_eq!(umt_join_path(&["a", "b", "c"]), "a/b/c");
+}
+
+#[test]
+fn test_normalizes_slashes_between_segments() {
+    assert_eq!(umt_join_path(&["a/", "/b/", "/c"]), "a/b/c");
+}
+
+#[test]
+fn test_preserves_leading_slash_of_first_segment() {
+    assert_eq!(umt_join_path(&["/a", "b", "c"]), "/a/b/c");
+}
+
+#[test]
+fn test_preserves_trailing_slash_of_last_segment() {
+    assert_eq!(umt_join_path(&["a", "b", "c/"]), "a/b/c/");
+}
+
+#[test]
+fn test_handles_url_like_base_segments() {
+    assert_eq!(
+        umt_join_path(&["https://example.com/", "/api/", "/users"]),
+        "https://example.com/api/users"
+    );
+}
+
+#[test]
+fn test_handles_single_segment() {
+    assert_eq!(umt_join_path(&["path"]), "path");
+}
+
+#[test]
+fn test_returns_empty_string_for_no_segments() {
+    assert_eq!(umt_join_path(&[]), "");
+}
+
+#[test]
+fn test_handles_multiple_slashes() {
+    assert_eq!(umt_join_path(&["a///", "///b"]), "a/b");
+}
+
+#[test]
+fn test_handles_empty_segments() {
+    assert_eq!(umt_join_path(&["a", "", "b"]), "a/b");
+}


### PR DESCRIPTION
## Summary

- Port the `URL` module from `package/main` to `umt_rust`, adding `umt_is_absolute_url` and `umt_join_path`
- The URL module was completely missing from the Rust implementation
- Full test coverage mirroring the TypeScript test suite (18 tests)

## Details

### 🔗 Source
- `package/main/src/URL/isAbsoluteUrl.ts`
- `package/main/src/URL/joinPath.ts`

### 🎯 Target
- `package/umt_rust/src/url/is_absolute_url.rs` — RFC 3986 absolute URL detection
- `package/umt_rust/src/url/join_path.rs` — Path segment joining with slash normalization
- `package/umt_rust/src/url/mod.rs` — Module definition
- `package/umt_rust/tests/url/` — Test files

### 🛠 Implementation Notes
- `is_absolute_url`: Uses the `regex` crate (already a dependency) with case-insensitive matching, equivalent to the JS `/^[a-z][\d+.a-z-]*:/i` pattern
- `join_path`: Uses `trim_start_matches('/')` / `trim_end_matches('/')` instead of regex for idiomatic Rust — simpler and more performant than regex-based replacement
- Functions follow the `umt_` prefix convention used throughout the crate
- `buildUrl` and `parseQueryString` were not ported as they rely heavily on JS-specific `URL`/`URLSearchParams` APIs and would require adding a new dependency — can be addressed in a follow-up

### ✅ Verification
- `cargo fmt` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test url` — 18/18 tests passed
- `cargo test` — full suite 253 passed, 0 failed

https://claude.ai/code/session_01HcW3kP1Poy41Swe1FRdptT