### PR TITLE
Replace substring() with slice() in string operations

### DIFF
--- a/package/main/src/tests/benchmark/array.groupBy-first-char.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-first-char.benchmark.ts
@@ -22,7 +22,7 @@ for (const size of arraySizes) {
       { length: size },
       (_, i) =>
         chars.charAt(Math.floor(Math.random() * chars.length)) +
-        `item${i}-${Math.random().toString(36).substring(2)}`,
+        `item${i}-${Math.random().toString(36).slice(2)}`,
     ),
   );
 }

--- a/package/main/src/tests/benchmark/array.groupBy-length.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-length.benchmark.ts
@@ -19,7 +19,7 @@ for (const size of arraySizes) {
     size,
     Array.from(
       { length: size },
-      (_, i) => `item${i}-${Math.random().toString(36).substring(2)}`,
+      (_, i) => `item${i}-${Math.random().toString(36).slice(2)}`,
     ),
   );
 }

--- a/package/main/src/tests/benchmark/array.sort-object-complex.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-object-complex.benchmark.ts
@@ -35,7 +35,7 @@ const compareProductComplex = (a: Product, b: Product): number => {
 const arraySizes = [10, 100, 1000, 10_000, 50_000];
 
 const generateProduct = (): Product => ({
-  id: Math.random().toString(36).substring(2, 9),
+  id: Math.random().toString(36).slice(2, 9),
   name: `Product${Math.floor(Math.random() * 1000)}`,
   price: Math.floor(Math.random() * 1000) + 1,
   category: ["Electronics", "Clothing", "Food", "Books", "Toys"][

--- a/package/main/src/tests/unit/Validate/object/optional.test.ts
+++ b/package/main/src/tests/unit/Validate/object/optional.test.ts
@@ -88,7 +88,6 @@ describe("optional function", () => {
   });
 
   it("should infer correct types for optional properties", () => {
-    // biome-ignore lint/correctness/noUnusedVariables: ignore
     const validateObject = object({
       name: string(),
       age: optional(number()),


### PR DESCRIPTION
## Summary
This PR updates string manipulation methods across benchmark and test files to use `slice()` instead of `substring()` for better consistency and modern JavaScript practices.

## Key Changes
- Replaced `substring(2)` with `slice(2)` in array groupBy benchmark files (2 occurrences)
- Replaced `substring(2, 9)` with `slice(2, 9)` in array sort benchmark file
- Removed unnecessary `biome-ignore` lint comment from optional validation test

## Implementation Details
The `slice()` method is preferred over `substring()` because:
- It's more intuitive with negative indices support
- It's the modern standard for string slicing in JavaScript
- It provides consistent behavior across edge cases

These changes maintain identical functionality while improving code consistency and removing outdated lint suppressions.

https://claude.ai/code/session_01RPayDTxpaLbYX8nn2Xb6i7