### PR TITLE
Add tests for invalid character handling in Base32/Base58 decoders

### DIFF
--- a/package/main/src/tests/unit/Crypto/decodeBase32.test.ts
+++ b/package/main/src/tests/unit/Crypto/decodeBase32.test.ts
@@ -33,4 +33,12 @@ describe("decodeBase32", () => {
     expect(new TextDecoder().decode(decodeBase32("JBSWY3DP"))).toBe("Hello");
     expect(new TextDecoder().decode(decodeBase32("MZXW6YTB"))).toBe("fooba");
   });
+
+  test("treats invalid characters as 0", () => {
+    // '1' is not in the Base32 alphabet, so it should fall back to 0 via ?? 0
+    const resultWithInvalid = decodeBase32("1A");
+    const resultWithZero = decodeBase32("AA");
+    // Invalid char maps to 0 (same as 'A'), so results should be equal
+    expect(Array.from(resultWithInvalid)).toEqual(Array.from(resultWithZero));
+  });
 });

--- a/package/main/src/tests/unit/Crypto/decodeBase58.test.ts
+++ b/package/main/src/tests/unit/Crypto/decodeBase58.test.ts
@@ -35,4 +35,12 @@ describe("decodeBase58", () => {
     const result = decodeBase58("Vt9aq46");
     expect(Array.from(result)).toEqual([255, 254, 253, 252, 251]);
   });
+
+  test("treats invalid characters as 0", () => {
+    // '0' is not in the Base58 alphabet, so it should fall back to 0 via ?? 0
+    const resultWithInvalid = decodeBase58("0");
+    // Invalid char maps to index 0, bigNumber stays 0, no bytes produced,
+    // and '0' is not '1' so no leading zeros are added
+    expect(Array.from(resultWithInvalid)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
Added unit tests to verify that invalid characters in Base32 and Base58 encoded strings are properly handled by treating them as 0 via the nullish coalescing operator (`?? 0`).

## Changes
- **decodeBase32.test.ts**: Added test case verifying that invalid Base32 alphabet characters (e.g., '1') are treated as 0, resulting in the same output as if a valid character mapping to 0 (e.g., 'A') was used
- **decodeBase58.test.ts**: Added test case verifying that invalid Base58 alphabet characters (e.g., '0') are treated as 0, resulting in an empty byte array when no valid leading characters are present

## Details
These tests ensure the decoders gracefully handle malformed input by falling back to a default value of 0 for unrecognized characters, rather than throwing errors or producing undefined behavior. This defensive programming approach makes the decoders more robust when processing untrusted or corrupted input.

https://claude.ai/code/session_01GJ6DYJdmJeCG7Hq6MmwGSq