### PR TITLE
fix: claude-code-action の認証・権限設定を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     steps:
@@ -15,7 +15,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-          persist-credentials: false
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@ff9acae5886d41a99ed4ec14b7dc147d55834722 # v1.0.77

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,9 +17,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read
     steps:
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-          persist-credentials: false
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@ff9acae5886d41a99ed4ec14b7dc147d55834722 # v1.0.77


### PR DESCRIPTION
## Summary
- `persist-credentials: false` を削除し、git認証情報を保持するよう変更
- `claude.yml` の permissions を `contents: write`, `pull-requests: write`, `issues: write` に変更
- `claude-code-review.yml` の `pull-requests` を `write` に変更

## 原因
`persist-credentials: false` により `actions/checkout` 後にgit認証情報が破棄され、claude-code-actionが内部で `git fetch` を実行する際に `could not read Username` エラーが発生していた。また、tag モードではブランチ作成・コミット・PR作成を行うため write 権限が必要。

## Test plan
- [ ] issueで `@claude` をメンションしてclaude-code-actionが正常動作することを確認
- [ ] PRでclaude-code-reviewが正常動作することを確認