### PR TITLE
🔄 Sync: Port parseQueryString to Python

### DIFF
--- a/package/umt_python/src/__init__.py
+++ b/package/umt_python/src/__init__.py
@@ -234,6 +234,7 @@ from .unit import (
 from .url import (
     is_absolute_url,
     join_path,
+    parse_query_string,
 )
 from .validate import (
     EmailParts,
@@ -407,6 +408,7 @@ __all__ = [
     "pad_start",
     "parse_email",
     "parse_json",
+    "parse_query_string",
     "parse_user_agent",
     "percentile",
     "pipe",

--- a/package/umt_python/src/url/__init__.py
+++ b/package/umt_python/src/url/__init__.py
@@ -1,4 +1,5 @@
 from .is_absolute_url import is_absolute_url
 from .join_path import join_path
+from .parse_query_string import parse_query_string
 
-__all__ = ["is_absolute_url", "join_path"]
+__all__ = ["is_absolute_url", "join_path", "parse_query_string"]

--- a/package/umt_python/src/url/parse_query_string.py
+++ b/package/umt_python/src/url/parse_query_string.py
@@ -1,0 +1,30 @@
+from urllib.parse import parse_qs, urlparse
+
+
+def parse_query_string(query: str) -> dict[str, str]:
+    """Parses a query string into a key-value dictionary.
+
+    Accepts either a full URL or a raw query string
+    (with or without leading "?").
+
+    Dangerous keys (__proto__, constructor, prototype) are
+    rejected to prevent prototype pollution attacks.
+
+    :param query: The query string or URL to parse
+    :return: A dictionary of key-value pairs from the query string
+    """
+    search_string = query
+    if "://" in query:
+        search_string = urlparse(query).query
+    elif search_string.startswith("?"):
+        search_string = search_string[1:]
+
+    # parse_qs returns dict[str, list[str]], take the last value for each key
+    parsed = parse_qs(search_string, keep_blank_values=True)
+    result: dict[str, str] = {}
+    for key, values in parsed.items():
+        # Prevent prototype pollution by rejecting dangerous keys
+        if key in ("__proto__", "constructor", "prototype"):
+            continue
+        result[key] = values[-1]
+    return result

--- a/package/umt_python/tests/unit/url/test_parse_query_string.py
+++ b/package/umt_python/tests/unit/url/test_parse_query_string.py
@@ -1,0 +1,50 @@
+import unittest
+
+from src.url import parse_query_string
+
+
+class TestParseQueryString(unittest.TestCase):
+    def test_parse_query_string_with_leading_question_mark(self):
+        result = parse_query_string("?page=1&q=search")
+        self.assertEqual(result, {"page": "1", "q": "search"})
+
+    def test_parse_query_string_without_leading_question_mark(self):
+        result = parse_query_string("foo=bar&baz=qux")
+        self.assertEqual(result, {"foo": "bar", "baz": "qux"})
+
+    def test_parse_full_url(self):
+        result = parse_query_string("https://example.com?a=1&b=2")
+        self.assertEqual(result, {"a": "1", "b": "2"})
+
+    def test_empty_string(self):
+        result = parse_query_string("")
+        self.assertEqual(result, {})
+
+    def test_question_mark_only(self):
+        result = parse_query_string("?")
+        self.assertEqual(result, {})
+
+    def test_encoded_values(self):
+        result = parse_query_string("?q=hello%20world")
+        self.assertEqual(result, {"q": "hello world"})
+
+    def test_single_parameter(self):
+        result = parse_query_string("?key=value")
+        self.assertEqual(result, {"key": "value"})
+
+    def test_url_with_no_query_string(self):
+        result = parse_query_string("https://example.com/path")
+        self.assertEqual(result, {})
+
+    def test_reject_proto_key(self):
+        result = parse_query_string("?__proto__=polluted&safe=value")
+        self.assertEqual(result, {"safe": "value"})
+        self.assertNotIn("__proto__", result)
+
+    def test_reject_constructor_and_prototype_keys(self):
+        result = parse_query_string("?constructor=bad&prototype=bad&ok=good")
+        self.assertEqual(result, {"ok": "good"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `parseQueryString` 関数を `package/main` から `umt_python` にポート
- プロトタイプ汚染防止（`__proto__`, `constructor`, `prototype` キーの拒否）も含めて完全移植
- 10件のテストケースを TypeScript のテストに対応する形で実装

## 🔗 Source

`package/main/src/URL/parseQueryString.ts`

## 🎯 Target

- `package/umt_python/src/url/parse_query_string.py` (新規)
- `package/umt_python/tests/unit/url/test_parse_query_string.py` (新規)
- `package/umt_python/src/url/__init__.py` (エクスポート追加)
- `package/umt_python/src/__init__.py` (エクスポート追加)

## 🛠 Implementation

Python 標準ライブラリの `urllib.parse.parse_qs` と `urlparse` を使用しています。TypeScript 版が `URLSearchParams` を使うのに対し、Python では同等の標準ライブラリ関数を使うことでイディオマティックな実装にしています。`parse_qs` は値をリストで返すため、各キーの最後の値を採用して TypeScript 版と同じ `dict[str, str]` の戻り値型を実現しています。

## ✅ Verification

全1333テスト合格、ruff check / ruff format / pyright 全てパス。

https://claude.ai/code/session_01PS4jBShQj8MaEMwtaWxnM9