### PR TITLE
🔄 Sync: Port parseQueryString to Rust and Python

### DIFF
--- a/package/umt_python/src/__init__.py
+++ b/package/umt_python/src/__init__.py
@@ -234,6 +234,7 @@ from .unit import (
 from .url import (
     is_absolute_url,
     join_path,
+    parse_query_string,
 )
 from .validate import (
     EmailParts,
@@ -407,6 +408,7 @@ __all__ = [
     "pad_start",
     "parse_email",
     "parse_json",
+    "parse_query_string",
     "parse_user_agent",
     "percentile",
     "pipe",

--- a/package/umt_python/src/url/__init__.py
+++ b/package/umt_python/src/url/__init__.py
@@ -1,4 +1,5 @@
 from .is_absolute_url import is_absolute_url
 from .join_path import join_path
+from .parse_query_string import parse_query_string
 
-__all__ = ["is_absolute_url", "join_path"]
+__all__ = ["is_absolute_url", "join_path", "parse_query_string"]

--- a/package/umt_python/src/url/parse_query_string.py
+++ b/package/umt_python/src/url/parse_query_string.py
@@ -1,0 +1,46 @@
+from urllib.parse import parse_qs, urlparse
+
+# Keys rejected to prevent prototype pollution in downstream consumers
+_DANGEROUS_KEYS = frozenset({"__proto__", "constructor", "prototype"})
+
+
+def parse_query_string(query: str) -> dict[str, str]:
+    """Parses a query string into a key-value dictionary.
+
+    Accepts either a full URL or a raw query string
+    (with or without leading ``?``).
+
+    Keys that could cause prototype pollution in downstream
+    JavaScript consumers (``__proto__``, ``constructor``,
+    ``prototype``) are silently dropped for defence-in-depth.
+
+    Args:
+        query: The query string or URL to parse.
+
+    Returns:
+        A dictionary of key-value pairs from the query string.
+
+    Examples:
+        >>> parse_query_string("?page=1&q=search")
+        {'page': '1', 'q': 'search'}
+
+        >>> parse_query_string("foo=bar&baz=qux")
+        {'foo': 'bar', 'baz': 'qux'}
+
+        >>> parse_query_string("https://example.com?a=1&b=2")
+        {'a': '1', 'b': '2'}
+    """
+    if "://" in query:
+        search_string = urlparse(query).query
+    elif query.startswith("?"):
+        search_string = query[1:]
+    else:
+        search_string = query
+
+    if not search_string:
+        return {}
+
+    parsed = parse_qs(search_string, keep_blank_values=True)
+    return {
+        key: values[0] for key, values in parsed.items() if key not in _DANGEROUS_KEYS
+    }

--- a/package/umt_python/tests/unit/url/test_parse_query_string.py
+++ b/package/umt_python/tests/unit/url/test_parse_query_string.py
@@ -1,0 +1,52 @@
+import unittest
+
+from src.url import parse_query_string
+
+
+class TestParseQueryString(unittest.TestCase):
+    def test_parse_with_leading_question_mark(self):
+        result = parse_query_string("?page=1&q=search")
+        self.assertEqual(result, {"page": "1", "q": "search"})
+
+    def test_parse_without_leading_question_mark(self):
+        result = parse_query_string("foo=bar&baz=qux")
+        self.assertEqual(result, {"foo": "bar", "baz": "qux"})
+
+    def test_parse_full_url(self):
+        result = parse_query_string("https://example.com?a=1&b=2")
+        self.assertEqual(result, {"a": "1", "b": "2"})
+
+    def test_empty_string(self):
+        result = parse_query_string("")
+        self.assertEqual(result, {})
+
+    def test_question_mark_only(self):
+        result = parse_query_string("?")
+        self.assertEqual(result, {})
+
+    def test_encoded_values(self):
+        result = parse_query_string("?q=hello%20world")
+        self.assertEqual(result, {"q": "hello world"})
+
+    def test_single_parameter(self):
+        result = parse_query_string("?key=value")
+        self.assertEqual(result, {"key": "value"})
+
+    def test_url_with_no_query_string(self):
+        result = parse_query_string("https://example.com/path")
+        self.assertEqual(result, {})
+
+    def test_reject_proto_key(self):
+        result = parse_query_string("?__proto__=polluted&safe=value")
+        self.assertEqual(result, {"safe": "value"})
+        self.assertNotIn("__proto__", result)
+
+    def test_reject_constructor_and_prototype_keys(self):
+        result = parse_query_string("?constructor=bad&prototype=bad&ok=good")
+        self.assertEqual(result, {"ok": "good"})
+        self.assertNotIn("constructor", result)
+        self.assertNotIn("prototype", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package/umt_rust/src/url/mod.rs
+++ b/package/umt_rust/src/url/mod.rs
@@ -9,3 +9,6 @@ pub use is_absolute_url::*;
 
 pub mod join_path;
 pub use join_path::*;
+
+pub mod parse_query_string;
+pub use parse_query_string::*;

--- a/package/umt_rust/src/url/parse_query_string.rs
+++ b/package/umt_rust/src/url/parse_query_string.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+
+/// Parses a query string into a key-value map.
+///
+/// Accepts either a full URL or a raw query string
+/// (with or without leading "?").
+///
+/// Keys that could cause prototype pollution in downstream
+/// JavaScript consumers (`__proto__`, `constructor`, `prototype`)
+/// are silently dropped for defence-in-depth.
+///
+/// # Arguments
+///
+/// * `query` - The query string or URL to parse
+///
+/// # Returns
+///
+/// A `HashMap<String, String>` of key-value pairs.
+///
+/// # Example
+///
+/// ```
+/// use umt_rust::url::umt_parse_query_string;
+///
+/// let result = umt_parse_query_string("?page=1&q=search");
+/// assert_eq!(result.get("page").unwrap(), "1");
+/// assert_eq!(result.get("q").unwrap(), "search");
+///
+/// let result = umt_parse_query_string("foo=bar&baz=qux");
+/// assert_eq!(result.get("foo").unwrap(), "bar");
+/// assert_eq!(result.get("baz").unwrap(), "qux");
+///
+/// let result = umt_parse_query_string("https://example.com?a=1&b=2");
+/// assert_eq!(result.get("a").unwrap(), "1");
+/// assert_eq!(result.get("b").unwrap(), "2");
+/// ```
+pub fn umt_parse_query_string(query: &str) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+
+    // Extract the query portion from a full URL or raw query string
+    let search_string = if query.contains("://") {
+        match query.find('?') {
+            Some(pos) => &query[pos + 1..],
+            None => return result,
+        }
+    } else if let Some(stripped) = query.strip_prefix('?') {
+        stripped
+    } else {
+        query
+    };
+
+    if search_string.is_empty() {
+        return result;
+    }
+
+    for pair in search_string.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+
+        let (key_raw, value_raw) = match pair.find('=') {
+            Some(pos) => (&pair[..pos], &pair[pos + 1..]),
+            None => (pair, ""),
+        };
+
+        let key = url_decode(key_raw);
+        if key == "__proto__" || key == "constructor" || key == "prototype" {
+            continue;
+        }
+
+        let value = url_decode(value_raw);
+        result.insert(key, value);
+    }
+
+    result
+}
+
+/// Decodes a percent-encoded string and converts '+' to spaces,
+/// matching the behaviour of `URLSearchParams`.
+fn url_decode(input: &str) -> String {
+    let plus_replaced = input.replace('+', " ");
+    let bytes = plus_replaced.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Ok(byte) = u8::from_str_radix(&plus_replaced[i + 1..i + 3], 16)
+        {
+            decoded.push(byte);
+            i += 3;
+            continue;
+        }
+        decoded.push(bytes[i]);
+        i += 1;
+    }
+
+    String::from_utf8_lossy(&decoded).into_owned()
+}

--- a/package/umt_rust/tests/tests.rs
+++ b/package/umt_rust/tests/tests.rs
@@ -183,6 +183,7 @@ mod unit_module {
 mod url {
     mod test_is_absolute_url;
     mod test_join_path;
+    mod test_parse_query_string;
 }
 
 mod predicate {

--- a/package/umt_rust/tests/url/mod.rs
+++ b/package/umt_rust/tests/url/mod.rs
@@ -1,2 +1,3 @@
 mod test_is_absolute_url;
 mod test_join_path;
+mod test_parse_query_string;

--- a/package/umt_rust/tests/url/test_parse_query_string.rs
+++ b/package/umt_rust/tests/url/test_parse_query_string.rs
@@ -1,0 +1,73 @@
+use umt_rust::url::umt_parse_query_string;
+
+#[test]
+fn test_parse_query_string_with_leading_question_mark() {
+    let result = umt_parse_query_string("?page=1&q=search");
+    assert_eq!(result.get("page").unwrap(), "1");
+    assert_eq!(result.get("q").unwrap(), "search");
+}
+
+#[test]
+fn test_parse_query_string_without_leading_question_mark() {
+    let result = umt_parse_query_string("foo=bar&baz=qux");
+    assert_eq!(result.get("foo").unwrap(), "bar");
+    assert_eq!(result.get("baz").unwrap(), "qux");
+}
+
+#[test]
+fn test_parse_full_url() {
+    let result = umt_parse_query_string("https://example.com?a=1&b=2");
+    assert_eq!(result.get("a").unwrap(), "1");
+    assert_eq!(result.get("b").unwrap(), "2");
+}
+
+#[test]
+fn test_parse_empty_string() {
+    let result = umt_parse_query_string("");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_parse_question_mark_only() {
+    let result = umt_parse_query_string("?");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_parse_encoded_values() {
+    let result = umt_parse_query_string("?q=hello%20world");
+    assert_eq!(result.get("q").unwrap(), "hello world");
+}
+
+#[test]
+fn test_parse_single_parameter() {
+    let result = umt_parse_query_string("?key=value");
+    assert_eq!(result.get("key").unwrap(), "value");
+}
+
+#[test]
+fn test_parse_url_with_no_query_string() {
+    let result = umt_parse_query_string("https://example.com/path");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_reject_proto_key() {
+    let result = umt_parse_query_string("?__proto__=polluted&safe=value");
+    assert_eq!(result.get("safe").unwrap(), "value");
+    assert!(result.get("__proto__").is_none());
+}
+
+#[test]
+fn test_reject_constructor_and_prototype_keys() {
+    let result = umt_parse_query_string("?constructor=bad&prototype=bad&ok=good");
+    assert_eq!(result.get("ok").unwrap(), "good");
+    assert!(result.get("constructor").is_none());
+    assert!(result.get("prototype").is_none());
+}
+
+#[test]
+fn test_parse_plus_as_space() {
+    let result = umt_parse_query_string("?q=hello+world");
+    assert_eq!(result.get("q").unwrap(), "hello world");
+}


### PR DESCRIPTION
## Summary

- Port `parseQueryString` from `package/main/src/URL/` to both `umt_rust` and `umt_python`
- Both implementations handle URL-encoded values, full URL inputs, and raw query strings
- Dangerous keys (`__proto__`, `constructor`, `prototype`) are rejected for defence-in-depth parity with the TypeScript source

## Source

`package/main/src/URL/parseQueryString.ts`

## Target

- `package/umt_rust/src/url/parse_query_string.rs` (+ tests in `tests/url/test_parse_query_string.rs`)
- `package/umt_python/src/url/parse_query_string.py` (+ tests in `tests/unit/url/test_parse_query_string.py`)

## Implementation Notes

- Rust: Pure implementation using manual URL decoding (`%XX` and `+` to space) without external dependencies, matching the zero-dependency policy. Returns `HashMap<String, String>`.
- Python: Uses stdlib `urllib.parse.parse_qs` and `urlparse` for idiomatic URL parsing. Returns `dict[str, str]`.
- Both follow target language naming conventions (`umt_parse_query_string` / `parse_query_string`).

## Verification

- Rust: 11 tests passing (`cargo test parse_query`), clippy clean
- Python: 10 tests passing (`uv run pytest`), ruff + pyright clean

https://claude.ai/code/session_012qSQxLpL54RRBh4nuhd83o