### PR TITLE
⚡ Bolt: Hoist regex constant outside loop in getValue

### DIFF
--- a/package/main/src/String/formatString/getValue.ts
+++ b/package/main/src/String/formatString/getValue.ts
@@ -24,13 +24,17 @@
  * // Complex nested access
  * getValue({ users: [{ name: "Alice" }] }, "users[0].name") // → "Alice"
  */
+
+// Pre-compiled regex pattern for array index notation to avoid recompilation per path segment
+const ARRAY_INDEX_PATTERN = /^(.+?)\[(-?\d+)]$/;
+
 export function getValue(object: unknown, path: string): unknown {
   const segments: { key: string; index?: number }[] = [];
 
   const parts = path.split(".");
 
   for (const part of parts) {
-    const arrayMatch = /^(.+?)\[(-?\d+)]$/.exec(part);
+    const arrayMatch = ARRAY_INDEX_PATTERN.exec(part);
     if (arrayMatch) {
       const [, key, indexString] = arrayMatch;
       segments.push({ key, index: Number(indexString) });


### PR DESCRIPTION
## Summary

Hoist the regex pattern `/^(.+?)\[(-?\d+)]$/` out of the `for` loop in `getValue.ts` into a module-level constant `ARRAY_INDEX_PATTERN`, avoiding unnecessary recompilation on every loop iteration.

## What

- Moved the inline regex literal from inside the `for (const part of parts)` loop to a module-level `const ARRAY_INDEX_PATTERN` declared before the function definition.
- Replaced the inline regex usage with `ARRAY_INDEX_PATTERN.exec(part)` inside the loop.

## Why

JavaScript engines may re-create regex objects declared as literals inside loops on each iteration. By hoisting the pattern to a module-level constant, the regex is compiled exactly once when the module is loaded, then reused for every call to `getValue` and every path segment within each call.

## Impact

- **Performance**: Eliminates per-iteration regex object allocation for paths with multiple segments. The improvement scales with the depth of the dot-notation path being resolved.
- **Readability**: The named constant `ARRAY_INDEX_PATTERN` is self-documenting and makes the intent of the regex clearer.
- **Correctness**: No behavioral change -- the regex pattern itself is identical, only its allocation site moved.

## Measurement

For a path like `"data[0].items[-1].nested[2].value"` (4 segments), this eliminates 4 regex compilations per `getValue` call, replacing them with a single module-load-time compilation.

https://claude.ai/code/session_01AR419kHnr1i2C2tEtEDAPB