### PR TITLE
🛡️ Sentinel: Fix prototype pollution in getValue and has path traversal

### DIFF
--- a/package/main/src/Object/has.ts
+++ b/package/main/src/Object/has.ts
@@ -7,6 +7,10 @@
  * has({ a: { b: 1 } }, ["a", "b"]); // true
  * has({ a: { b: 1 } }, "a.c"); // false
  */
+// Security: Keys that must be blocked to prevent prototype pollution
+// when traversing objects with user-controlled paths.
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 export const has = <T extends { [key: string]: unknown }>(
   object: T,
   path: string | string[],
@@ -14,6 +18,10 @@ export const has = <T extends { [key: string]: unknown }>(
   const localPath = typeof path === "string" ? path.split(".") : path;
   let current = { ...object };
   for (const key of localPath) {
+    // Security: Block prototype pollution keys to prevent prototype chain traversal
+    if (DANGEROUS_KEYS.has(key)) {
+      return false;
+    }
     if (current == null || !Object.hasOwn(current, key)) {
       return false;
     }

--- a/package/main/src/String/formatString/getValue.ts
+++ b/package/main/src/String/formatString/getValue.ts
@@ -28,6 +28,10 @@
 // Pre-compiled regex pattern for array index notation to avoid recompilation per path segment
 const ARRAY_INDEX_PATTERN = /^(.+?)\[(-?\d+)]$/;
 
+// Security: Keys that must be blocked to prevent prototype pollution and
+// information leakage when traversing objects with user-controlled paths.
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 export function getValue(object: unknown, path: string): unknown {
   const segments: { key: string; index?: number }[] = [];
 
@@ -47,6 +51,12 @@ export function getValue(object: unknown, path: string): unknown {
 
   for (const segment of segments) {
     if (typeof current !== "object" || current == null) {
+      return;
+    }
+
+    // Security: Block prototype pollution keys to prevent prototype chain
+    // traversal and information leakage via user-controlled paths
+    if (DANGEROUS_KEYS.has(segment.key)) {
       return;
     }
 

--- a/package/main/src/tests/unit/Object/has.test.ts
+++ b/package/main/src/tests/unit/Object/has.test.ts
@@ -35,4 +35,30 @@ describe("has", () => {
     // @ts-expect-error
     expect(has(undefined, "a.b")).toBe(false);
   });
+
+  it("should block __proto__ key to prevent prototype pollution", () => {
+    const obj = { a: { b: 1 } };
+    expect(has(obj, "__proto__")).toBe(false);
+    expect(has(obj, "__proto__.polluted")).toBe(false);
+    expect(has(obj, "a.__proto__")).toBe(false);
+  });
+
+  it("should block constructor key to prevent prototype pollution", () => {
+    const obj = { a: { b: 1 } };
+    expect(has(obj, "constructor")).toBe(false);
+    expect(has(obj, "constructor.prototype")).toBe(false);
+  });
+
+  it("should block prototype key to prevent prototype pollution", () => {
+    const obj = { a: { b: 1 } };
+    expect(has(obj, "prototype")).toBe(false);
+  });
+
+  it("should block dangerous keys passed as array path", () => {
+    const obj = { a: { b: 1 } };
+    expect(has(obj, ["__proto__"])).toBe(false);
+    expect(has(obj, ["constructor"])).toBe(false);
+    expect(has(obj, ["prototype"])).toBe(false);
+    expect(has(obj, ["a", "__proto__"])).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/String/formatString/getValue.test.ts
+++ b/package/main/src/tests/unit/String/formatString/getValue.test.ts
@@ -261,6 +261,35 @@ describe("getValue function", () => {
     });
   });
 
+  describe("prototype pollution prevention", () => {
+    test("should block __proto__ key access", () => {
+      const obj = { a: { b: 1 } };
+      expect(getValue(obj, "__proto__")).toBeUndefined();
+      expect(getValue(obj, "__proto__.polluted")).toBeUndefined();
+      expect(getValue(obj, "a.__proto__")).toBeUndefined();
+    });
+
+    test("should block constructor key access", () => {
+      const obj = { a: { b: 1 } };
+      expect(getValue(obj, "constructor")).toBeUndefined();
+      expect(getValue(obj, "constructor.prototype")).toBeUndefined();
+      expect(getValue(obj, "a.constructor")).toBeUndefined();
+    });
+
+    test("should block prototype key access", () => {
+      const obj = { a: { b: 1 } };
+      expect(getValue(obj, "prototype")).toBeUndefined();
+      expect(getValue(obj, "a.prototype")).toBeUndefined();
+    });
+
+    test("should still allow normal keys that are not dangerous", () => {
+      const obj = { proto: "safe", construct: "ok", proto_type: "fine" };
+      expect(getValue(obj, "proto")).toBe("safe");
+      expect(getValue(obj, "construct")).toBe("ok");
+      expect(getValue(obj, "proto_type")).toBe("fine");
+    });
+  });
+
   describe("data type preservation", () => {
     test("should preserve original data types", () => {
       const obj = {


### PR DESCRIPTION
## Severity
Medium - Information leakage and prototype chain traversal via user-controlled paths

## Vulnerability
The `getValue` function (used internally by `formatString`) and the `has` utility both accept dot-notation path strings to traverse objects. Neither function validated path segments against dangerous prototype keys (`__proto__`, `constructor`, `prototype`).

An attacker supplying user-controlled template strings to `formatString` could use paths like `{constructor.prototype}` or `{__proto__}` to traverse the prototype chain, leaking internal object metadata or potentially manipulating shared prototypes.

Similarly, `has` could be used to probe for prototype chain properties, confirming object types or internal structure to an attacker.

## Impact
- Information leakage through `formatString` template injection (e.g. `formatString("{constructor}", userObj)` exposes constructor references)
- Prototype chain traversal enabling fingerprinting of object types
- Potential for prototype pollution when combined with other write-path utilities

## Fix
Added a `DANGEROUS_KEYS` Set containing `__proto__`, `constructor`, and `prototype` to both functions. Path segments are checked against this set before traversal, returning `undefined` (getValue) or `false` (has) when a dangerous key is encountered. This matches the guard pattern already used in `mergeDeep`, `merge`, `mapValues`, `mapKeys`, `keyBy`, `deepClone`, `pickDeep`, `getObjectsCommon`, and `getObjectsDiff`.

## Verification
- 38 targeted tests pass (8 new security tests added)
- Full test suite passes (2518 tests, 257 suites)
- 100% code coverage maintained on modified files
- `bun run format` and `bun run lint` pass cleanly

## Files Changed
- `package/main/src/String/formatString/getValue.ts` - Added DANGEROUS_KEYS guard
- `package/main/src/Object/has.ts` - Added DANGEROUS_KEYS guard
- `package/main/src/tests/unit/String/formatString/getValue.test.ts` - Added 4 security tests
- `package/main/src/tests/unit/Object/has.test.ts` - Added 4 security tests