### PR TITLE
🛡️ Sentinel: Add input validation to ipToBinaryString

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** `getObjectsCommon` and `getObjectsDiff` were vulnerable to Prototype Pollution because they iterated over and copied all keys, including `__proto__`, `constructor`, and `prototype`.
 **Learning:** Even simple object diffing or commonality utilities need explicit prototype pollution guards because they dynamically assign keys to a new object based on unsanitized input objects.
 **Prevention:** Always explicitly check and ignore `__proto__`, `constructor`, and `prototype` keys during object iteration in any utility that dynamically constructs or merges objects.
+## 2026-03-30 - Missing Input Validation in ipToBinaryString
+**Vulnerability:** The `ipToBinaryString` function accepted arbitrary strings without validating octet count, numeric format, or value range (0-255). Since it is the foundational function used by `ipToLong`, `isInRange`, `isPrivateIp`, `getNetworkAddress`, and `subnetMaskToCidr`, malformed inputs could cause silent incorrect results in security-critical IP-based access control decisions.
+**Learning:** Core parsing functions used by security-sensitive utilities must enforce strict input validation. Silent failures (returning garbage data instead of throwing) can lead to access control bypasses when downstream functions rely on the parsed result for allow/deny decisions.
+**Prevention:** Always validate format and value ranges in IP address parsing functions. Throw descriptive errors for malformed inputs rather than silently producing incorrect results.

--- a/package/main/src/IP/ipToBinaryString.ts
+++ b/package/main/src/IP/ipToBinaryString.ts
@@ -2,10 +2,28 @@
  * Converts an IPv4 address to its binary string representation
  * @param {string} ip - IPv4 address (e.g., "192.168.1.1")
  * @returns {string} Binary string representation (32 bits)
+ * @throws {Error} If the IP address format is invalid
  */
 export const ipToBinaryString = (ip: string): string => {
-  return ip
-    .split(".")
-    .map((octet) => Number.parseInt(octet, 10).toString(2).padStart(8, "0"))
+  if (typeof ip !== "string" || ip.length === 0) {
+    throw new Error("ipToBinaryString: input must be a non-empty string");
+  }
+
+  const parts = ip.split(".");
+  if (parts.length !== 4) {
+    throw new Error("ipToBinaryString: expected 4 octets separated by dots");
+  }
+
+  return parts
+    .map((part) => {
+      if (!/^\d{1,3}$/.test(part)) {
+        throw new Error(`ipToBinaryString: invalid octet "${part}"`);
+      }
+      const value = Number.parseInt(part, 10);
+      if (value < 0 || value > 255) {
+        throw new Error(`ipToBinaryString: octet ${value} out of range 0-255`);
+      }
+      return value.toString(2).padStart(8, "0");
+    })
     .join("");
 };

--- a/package/main/src/tests/unit/IP/ipToBinaryString.test.ts
+++ b/package/main/src/tests/unit/IP/ipToBinaryString.test.ts
@@ -29,4 +29,21 @@ describe("ipToBinaryString", () => {
       expect(ipToBinaryString(ip)).toBe(expected);
     });
   });
+
+  describe("invalid inputs should throw", () => {
+    test.each([
+      ["", "non-empty string"],
+      ["1.2.3", "4 octets"],
+      ["1.2.3.4.5", "4 octets"],
+      ["256.0.0.1", "out of range"],
+      ["-1.0.0.0", 'invalid octet "-1"'],
+      ["abc.0.0.1", 'invalid octet "abc"'],
+      ["1.2.3.999", "out of range"],
+      ["1.2.3.", 'invalid octet ""'],
+      ["1.2.3.0x1", 'invalid octet "0x1"'],
+      ["01onal.0.0.1", 'invalid octet "01onal"'],
+    ])("should throw for invalid input: %s", (ip, expectedMsg) => {
+      expect(() => ipToBinaryString(ip)).toThrow(expectedMsg);
+    });
+  });
 });


### PR DESCRIPTION
## 🚨 Severity

Medium — affects security-critical IP access control utilities

## 💡 Vulnerability

`ipToBinaryString` accepted arbitrary strings without validating octet count, numeric format, or 0-255 value range. As the foundational parser used by `ipToLong`, `isInRange`, `isPrivateIp`, `getNetworkAddress`, and `subnetMaskToCidr`, malformed IP inputs could silently produce incorrect binary representations. This enables potential bypass of IP-based access control decisions (e.g., `isPrivateIp` returning incorrect results for crafted strings like `"999.0.0.1"` or `"abc.0.0.1"`).

## 🎯 Impact

Any application using `isPrivateIp` or `isInRange` for security decisions (allowlists, blocklists, network segmentation) could be bypassed with malformed IP strings that silently produce garbage output instead of throwing an error.

## 🔧 Fix

Added strict input validation to `ipToBinaryString`:

- Verify input is a non-empty string
- Require exactly 4 dot-separated octets
- Validate each octet is digits-only (1-3 chars) via `/^\d{1,3}$/`
- Enforce 0-255 range for each parsed octet value
- Throw descriptive `Error` messages for all invalid inputs

## ✅ Verification

- All 125 existing IP module tests pass (no regressions)
- 10 new test cases for invalid inputs added
- 100% code coverage maintained across all IP utilities
- Format and lint checks pass