### PR TITLE
🔄 Sync: Port parseQueryString to Rust

### DIFF
--- a/package/umt_rust/src/url/mod.rs
+++ b/package/umt_rust/src/url/mod.rs
@@ -3,9 +3,13 @@
 //! This module provides URL-related utility functions:
 //! - `is_absolute_url` - Check if a URL string is absolute (RFC 3986)
 //! - `join_path` - Join multiple path segments into a normalized path
+//! - `parse_query_string` - Parse a query string into a key-value map
 
 pub mod is_absolute_url;
 pub use is_absolute_url::*;
 
 pub mod join_path;
 pub use join_path::*;
+
+pub mod parse_query_string;
+pub use parse_query_string::*;

--- a/package/umt_rust/src/url/parse_query_string.rs
+++ b/package/umt_rust/src/url/parse_query_string.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+/// Parses a query string into a key-value map.
+///
+/// Accepts either a full URL or a raw query string
+/// (with or without leading "?").
+///
+/// Keys that could cause prototype pollution (`__proto__`, `constructor`,
+/// `prototype`) are silently dropped for parity with the TypeScript
+/// implementation.
+///
+/// # Arguments
+///
+/// * `query` - The query string or URL to parse
+///
+/// # Returns
+///
+/// A `HashMap<String, String>` of decoded key-value pairs.
+///
+/// # Example
+///
+/// ```
+/// use umt_rust::url::umt_parse_query_string;
+///
+/// let result = umt_parse_query_string("?page=1&q=search");
+/// assert_eq!(result.get("page").unwrap(), "1");
+/// assert_eq!(result.get("q").unwrap(), "search");
+/// ```
+pub fn umt_parse_query_string(query: &str) -> HashMap<String, String> {
+    let search_string = if query.contains("://") {
+        // Extract the query portion after '?'
+        match query.find('?') {
+            Some(idx) => &query[idx..],
+            None => return HashMap::new(),
+        }
+    } else {
+        query
+    };
+
+    let raw = search_string.strip_prefix('?').unwrap_or(search_string);
+
+    if raw.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut result = HashMap::new();
+
+    for pair in raw.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+
+        let (key_raw, value_raw) = match pair.find('=') {
+            Some(idx) => (&pair[..idx], &pair[idx + 1..]),
+            None => (pair, ""),
+        };
+
+        let key = decode_percent(key_raw);
+        let value = decode_percent(value_raw);
+
+        // Prevent prototype pollution by rejecting dangerous keys
+        if key == "__proto__" || key == "constructor" || key == "prototype" {
+            continue;
+        }
+
+        result.insert(key, value);
+    }
+
+    result
+}
+
+/// Decodes percent-encoded strings, also converting '+' to spaces
+/// (application/x-www-form-urlencoded).
+fn decode_percent(input: &str) -> String {
+    let plus_decoded = input.replace('+', " ");
+    let bytes = plus_decoded.as_bytes();
+    let mut result = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Ok(byte) = u8::from_str_radix(&plus_decoded[i + 1..i + 3], 16)
+        {
+            result.push(byte);
+            i += 3;
+            continue;
+        }
+        result.push(bytes[i]);
+        i += 1;
+    }
+
+    String::from_utf8_lossy(&result).into_owned()
+}

--- a/package/umt_rust/tests/tests.rs
+++ b/package/umt_rust/tests/tests.rs
@@ -186,6 +186,7 @@ mod unit_module {
 mod url {
     mod test_is_absolute_url;
     mod test_join_path;
+    mod test_parse_query_string;
 }
 
 mod predicate {

--- a/package/umt_rust/tests/url/mod.rs
+++ b/package/umt_rust/tests/url/mod.rs
@@ -1,2 +1,3 @@
 mod test_is_absolute_url;
 mod test_join_path;
+mod test_parse_query_string;

--- a/package/umt_rust/tests/url/test_parse_query_string.rs
+++ b/package/umt_rust/tests/url/test_parse_query_string.rs
@@ -1,0 +1,73 @@
+use umt_rust::url::umt_parse_query_string;
+
+#[test]
+fn test_parse_query_string_with_leading_question_mark() {
+    let result = umt_parse_query_string("?page=1&q=search");
+    assert_eq!(result.get("page").unwrap(), "1");
+    assert_eq!(result.get("q").unwrap(), "search");
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn test_parse_query_string_without_leading_question_mark() {
+    let result = umt_parse_query_string("foo=bar&baz=qux");
+    assert_eq!(result.get("foo").unwrap(), "bar");
+    assert_eq!(result.get("baz").unwrap(), "qux");
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn test_parse_full_url() {
+    let result = umt_parse_query_string("https://example.com?a=1&b=2");
+    assert_eq!(result.get("a").unwrap(), "1");
+    assert_eq!(result.get("b").unwrap(), "2");
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn test_parse_empty_string() {
+    let result = umt_parse_query_string("");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_parse_question_mark_only() {
+    let result = umt_parse_query_string("?");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_parse_encoded_values() {
+    let result = umt_parse_query_string("?q=hello%20world");
+    assert_eq!(result.get("q").unwrap(), "hello world");
+}
+
+#[test]
+fn test_parse_single_parameter() {
+    let result = umt_parse_query_string("?key=value");
+    assert_eq!(result.get("key").unwrap(), "value");
+    assert_eq!(result.len(), 1);
+}
+
+#[test]
+fn test_parse_url_with_no_query_string() {
+    let result = umt_parse_query_string("https://example.com/path");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_reject_proto_key() {
+    let result = umt_parse_query_string("?__proto__=polluted&safe=value");
+    assert_eq!(result.get("safe").unwrap(), "value");
+    assert!(!result.contains_key("__proto__"));
+    assert_eq!(result.len(), 1);
+}
+
+#[test]
+fn test_reject_constructor_and_prototype_keys() {
+    let result = umt_parse_query_string("?constructor=bad&prototype=bad&ok=good");
+    assert_eq!(result.get("ok").unwrap(), "good");
+    assert!(!result.contains_key("constructor"));
+    assert!(!result.contains_key("prototype"));
+    assert_eq!(result.len(), 1);
+}


### PR DESCRIPTION
## 🔗 Source
`package/main/src/URL/parseQueryString.ts`

## 🎯 Target
`package/umt_rust/src/url/parse_query_string.rs`

## 🛠 Implementation
Ported the `parseQueryString` utility function from TypeScript to Rust as `umt_parse_query_string`. The function parses URL query strings into a `HashMap<String, String>`, supporting three input formats: raw query strings (`foo=bar&baz=qux`), query strings with leading `?` (`?page=1&q=search`), and full URLs (`https://example.com?a=1&b=2`). Includes a custom percent-decoding implementation that handles `%XX` sequences and `+` as space (application/x-www-form-urlencoded). Prototype pollution prevention is preserved by rejecting `__proto__`, `constructor`, and `prototype` keys, matching the TypeScript behavior exactly.

## ✅ Verification
All 10 test cases pass via `cargo test`, covering: leading `?` parsing, raw query strings, full URL extraction, empty string, `?` only, percent-encoded values, single parameter, URL without query string, `__proto__` rejection, and `constructor`/`prototype` rejection. `cargo fmt` and `cargo clippy -- -D warnings` pass cleanly.

https://claude.ai/code/session_01WJi8JU3u5GPGHv8VmFmwG3