### PR TITLE
⚡ Bolt: optimize longToIp with bitwise operations

### DIFF
--- a/package/main/src/IP/longToIp.ts
+++ b/package/main/src/IP/longToIp.ts
@@ -15,14 +15,7 @@ export const longToIp = (long: number): string => {
     );
   }
 
-  // Convert to binary string and ensure 32-bit length
-  const binary = long.toString(2).padStart(32, "0");
-
-  // Split into octets and convert to decimal
-  const octets = Array.from({ length: 4 }, (_, index) =>
-    Number.parseInt(binary.slice(index * 8, (index + 1) * 8), 2),
-  );
-
-  // Join octets with dots
-  return octets.join(".");
+  // Extract each octet using bitwise operations instead of string conversion.
+  // This avoids creating a 32-char binary string, slicing, and parsing it back.
+  return `${(long >>> 24) & 0xff}.${(long >>> 16) & 0xff}.${(long >>> 8) & 0xff}.${long & 0xff}`;
 };


### PR DESCRIPTION
## Summary

💡 What: Replaced string-based conversion in `longToIp` with direct bitwise operations.

🎯 Why: The previous implementation converted the number to a 32-char binary string, sliced it into 4 chunks, parsed each chunk back to a number, and joined with dots. This created unnecessary intermediate strings and allocations.

📊 Impact: Eliminates binary string creation, 4x `slice()`, 4x `parseInt()`, `Array.from()`, and `join()` calls per invocation. Reduces to 4 bitwise shifts and masks.

🔬 Measurement: Template literal with `>>>` and `&` operates directly on the number without any intermediate string allocation.

## Test plan

- [ ] `bun run test src/tests/unit/IP/longToIp.test.ts` passes
- [ ] `bun run lint` passes
- [ ] `bun run format` passes

https://claude.ai/code/session_012WdshyWcmnBTA25BFjaST6