### PR TITLE
perf(main): drop unused copy in Object/has, doc pick, port formatNumber to python

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-16 - [Iterators and Manual While loops]
 **Learning:** [When optimizing functions that consume iterables/generators, using a manual while loop and `iterator.next()` instead of a `for...of` loop is a critical regression. The `for...of` loop natively handles early termination by automatically calling `.return()` on the underlying iterable if aborted early. A manual while loop bypasses this, leading to resource/memory leaks in generators holding cleanup logic.]
 **Action:** [Avoid replacing `for...of` loops with manual while loops when consuming iterables unless explicitly implementing complex generator handling with try/finally and `.return()` propagation. Trust `for...of` for safe iterable consumption.]
+
+## 2026-04-16 - Read-only Traversals Don't Need Defensive Copies
+**Learning:** Path-walk utilities like `Object/has` were taking a `{ ...object }` shallow copy before iterating, but only ever called `Object.hasOwn` and read nested values — never wrote to the copy. The copy produced identical results for every test case while allocating one object per call proportional to the input's own-property count.
+**Action:** When adding "defensive" copies during code review, confirm the copy is actually written to before shipping it. For pure-read traversals (lookups, `has`, nested getters), traverse the input reference directly and let the allocator breathe.

--- a/.jules/sync.md
+++ b/.jules/sync.md
@@ -17,3 +17,7 @@
 ## 2026-04-05 - Port `throttle` from Function module to umt_python
 **Ported:** `throttle` function from `package/main/src/Function/throttle.ts` to `package/umt_python/src/function/throttle.py`.
 **Adaptation:** TypeScript uses `setTimeout`/`clearTimeout` for scheduling; Python uses `threading.Timer` with a lock for thread safety. The wait parameter is in seconds (Python convention) rather than milliseconds (JS convention). The `ThrottledFunction` class wraps the callable and exposes a `cancel()` method matching the TS `ThrottledFunction` interface. Uses `time.monotonic()` instead of `Date.now()` for robust elapsed-time tracking.
+
+## 2026-04-16 - Intl.NumberFormat Port to Python
+**Mismatch:** `formatNumber` in `package/main` delegates to `Intl.NumberFormat`, which has full ICU locale data and supports hundreds of locales, currencies, and rounding modes. Python's zero-dependency policy rules out Babel/ICU, and the stdlib `locale` module mutates global process state so it can't be used safely in a library.
+**Resolution:** Ported a curated implementation that covers the common cases documented in the TS JSDoc examples (decimal/percent/currency styles, minimum/maximum fraction digits, en-US/de-DE/ja-JP/fr-FR/etc. locales) and falls back to en-US for unknown locales. Emulated JS `Math.round` half-away-from-zero semantics explicitly because Python's built-in `round` uses banker's rounding and would diverge on half values.

--- a/package/main/src/Object/has.ts
+++ b/package/main/src/Object/has.ts
@@ -22,10 +22,6 @@ export const has = <T extends { [key: string]: unknown }>(
   path: string | string[],
 ): boolean => {
   const localPath = typeof path === "string" ? path.split(".") : path;
-  // Performance: traverse the object directly instead of taking a shallow
-  // copy. The copy was never written to (we only call Object.hasOwn and
-  // read nested values), so allocating a new object on every call was
-  // pure overhead proportional to the input's own-property count.
   let current: unknown = object;
   for (const key of localPath) {
     if (

--- a/package/main/src/Object/has.ts
+++ b/package/main/src/Object/has.ts
@@ -22,12 +22,19 @@ export const has = <T extends { [key: string]: unknown }>(
   path: string | string[],
 ): boolean => {
   const localPath = typeof path === "string" ? path.split(".") : path;
-  let current = { ...object };
+  // Performance: traverse the object directly instead of taking a shallow
+  // copy. The copy was never written to (we only call Object.hasOwn and
+  // read nested values), so allocating a new object on every call was
+  // pure overhead proportional to the input's own-property count.
+  let current: unknown = object;
   for (const key of localPath) {
-    if (current == null || !Object.hasOwn(current, key)) {
+    if (
+      current == null ||
+      !Object.hasOwn(current as Record<string, unknown>, key)
+    ) {
       return false;
     }
-    current = current[key] as T;
+    current = (current as Record<string, unknown>)[key];
   }
   return true;
 };

--- a/package/main/src/Object/pick.ts
+++ b/package/main/src/Object/pick.ts
@@ -19,12 +19,6 @@ export const pick = <T extends object, K extends keyof T>(
 ): Pick<T, K> => {
   const result = {} as Pick<T, K>;
   for (const key of keys) {
-    // Security: reject prototype-polluting keys. If an attacker bypasses
-    // TypeScript's compile-time key constraint (via cast or untrusted
-    // input), assigning to result["__proto__"] would invoke the
-    // Object.prototype __proto__ setter and replace result's prototype
-    // with the attacker-supplied value, tainting every subsequent
-    // property access on the returned object.
     if (key === "__proto__" || key === "constructor" || key === "prototype") {
       continue;
     }

--- a/package/main/src/Object/pick.ts
+++ b/package/main/src/Object/pick.ts
@@ -19,6 +19,15 @@ export const pick = <T extends object, K extends keyof T>(
 ): Pick<T, K> => {
   const result = {} as Pick<T, K>;
   for (const key of keys) {
+    // Security: reject prototype-polluting keys. If an attacker bypasses
+    // TypeScript's compile-time key constraint (via cast or untrusted
+    // input), assigning to result["__proto__"] would invoke the
+    // Object.prototype __proto__ setter and replace result's prototype
+    // with the attacker-supplied value, tainting every subsequent
+    // property access on the returned object.
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      continue;
+    }
     result[key] = object[key];
   }
   return result;

--- a/package/main/src/Object/pick.ts
+++ b/package/main/src/Object/pick.ts
@@ -19,9 +19,6 @@ export const pick = <T extends object, K extends keyof T>(
 ): Pick<T, K> => {
   const result = {} as Pick<T, K>;
   for (const key of keys) {
-    if (key === "__proto__" || key === "constructor" || key === "prototype") {
-      continue;
-    }
     result[key] = object[key];
   }
   return result;

--- a/package/main/src/Object/pick.ts
+++ b/package/main/src/Object/pick.ts
@@ -7,6 +7,16 @@
  * @param {...K[]} keys - The property keys to extract.
  * @returns {Pick<T, K>} A new object containing only the specified properties.
  *
+ * @remarks
+ * **Prototype pollution warning:** This function does not filter out
+ * prototype-polluting keys (`__proto__`, `constructor`, `prototype`).
+ * If processing user-controlled input, sanitize with the appropriate
+ * `removePrototype*` helper before calling this function:
+ * - `removePrototype` — shallow sanitization of a single object
+ * - `removePrototypeDeep` — recursive sanitization of a single object (for deeply nested data)
+ * - `removePrototypeMap` — shallow sanitization of an array of objects
+ * - `removePrototypeMapDeep` — recursive sanitization of an array of objects (for deeply nested data)
+ *
  * @example
  * ```typescript
  * const user = { id: 1, name: 'Alice', age: 30 };

--- a/package/main/src/tests/unit/Object/pick.test.ts
+++ b/package/main/src/tests/unit/Object/pick.test.ts
@@ -1,4 +1,5 @@
 import { pick } from "@/Object/pick";
+import { removePrototype } from "@/Object/removePrototype";
 
 describe("pick function", () => {
   test("should select a single key", () => {
@@ -61,5 +62,16 @@ describe("pick function", () => {
     const obj = { a: [1, 2, 3], b: 4 };
     const result = pick(obj, "a");
     expect(result).toEqual({ a: [1, 2, 3] });
+  });
+
+  it("should prevent prototype pollution via __proto__ when sanitized", () => {
+    const malicious = JSON.parse(
+      '{"__proto__": {"polluted": true}, "safe": 42}',
+    );
+    const result = pick(removePrototype(malicious), "safe");
+
+    expect(result).toEqual({ safe: 42 });
+    const clean = {} as Record<string, unknown>;
+    expect("polluted" in clean).toBe(false);
   });
 });

--- a/package/main/src/tests/unit/Object/pick.test.ts
+++ b/package/main/src/tests/unit/Object/pick.test.ts
@@ -62,4 +62,21 @@ describe("pick function", () => {
     const result = pick(obj, "a");
     expect(result).toEqual({ a: [1, 2, 3] });
   });
+
+  test("should skip dangerous keys to prevent prototype pollution", () => {
+    const malicious = JSON.parse(
+      '{"__proto__":{"polluted":true},"constructor":{"bad":1},"safe":42}',
+    ) as Record<string, unknown>;
+    const result = pick(
+      malicious,
+      "__proto__" as never,
+      "constructor" as never,
+      "safe" as never,
+    );
+    expect(result).toEqual({ safe: 42 });
+    // Returned object must still inherit from the unmodified Object.prototype.
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    // The global prototype must not have been tainted by the call above.
+    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/Object/pick.test.ts
+++ b/package/main/src/tests/unit/Object/pick.test.ts
@@ -62,21 +62,4 @@ describe("pick function", () => {
     const result = pick(obj, "a");
     expect(result).toEqual({ a: [1, 2, 3] });
   });
-
-  test("should skip dangerous keys to prevent prototype pollution", () => {
-    const malicious = JSON.parse(
-      '{"__proto__":{"polluted":true},"constructor":{"bad":1},"safe":42}',
-    ) as Record<string, unknown>;
-    const result = pick(
-      malicious,
-      "__proto__" as never,
-      "constructor" as never,
-      "safe" as never,
-    );
-    expect(result).toEqual({ safe: 42 });
-    // Returned object must still inherit from the unmodified Object.prototype.
-    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
-    // The global prototype must not have been tainted by the call above.
-    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
-  });
 });

--- a/package/umt_python/README.md
+++ b/package/umt_python/README.md
@@ -78,6 +78,14 @@ print(encoded)  # "SGVsbG8gV29ybGQ="
 |----------|------|-------------|---------|
 | `has_no_letters` | `(text: str) -> bool` | Check if string contains no letters (only numbers, emojis, special chars) | `has_no_letters("123!@#")  # True` / `has_no_letters("abc123")  # False` |
 
+### Number Functions
+
+| Function | Type | Description | Example |
+|----------|------|-------------|---------|
+| `format_number` | `(value: float \| int, *, locale: str \| None = None, minimum_fraction_digits: int \| None = None, maximum_fraction_digits: int \| None = None, style: Literal["decimal", "currency", "percent"] = "decimal", currency: str \| None = None) -> str` | Format a number with locale-aware separators, fraction-digit controls, and decimal/percent/currency styles. Mirrors `Intl.NumberFormat` from the TypeScript source. | `format_number(1234567.89)  # "1,234,567.89"` / `format_number(1234567.89, locale="de-DE")  # "1.234.567,89"` / `format_number(0.75, style="percent")  # "75%"` / `format_number(1234.5, style="currency", currency="USD")  # "$1,234.50"` |
+| `to_ordinal` | `(value: int \| float) -> str` | Convert a number to its English ordinal string (handles 11th/12th/13th specially) | `to_ordinal(1)  # "1st"` / `to_ordinal(11)  # "11th"` / `to_ordinal(21)  # "21st"` |
+| `to_percentage` | `(value: float \| int, total: float \| int, decimals: int = 2) -> float` | Calculate the percentage of a value relative to a total (returns 0 when total is 0) | `to_percentage(1, 3)  # 33.33` / `to_percentage(25, 100)  # 25.0` |
+
 ## Constants
 
 - `DEFAULT_RANDOM_STRING_CHARS`: Default character pool for random string generation (ASCII letters + digits)

--- a/package/umt_python/src/__init__.py
+++ b/package/umt_python/src/__init__.py
@@ -167,6 +167,7 @@ from .math import (
     xoshiro256,
 )
 from .number import (
+    format_number,
     to_ordinal,
 )
 from .object import (
@@ -359,6 +360,7 @@ __all__ = [
     "first",
     "flat_map_result",
     "flexible_number_conversion",
+    "format_number",
     "format_string",
     "from_base64",
     "fuzzy_search",

--- a/package/umt_python/src/number/__init__.py
+++ b/package/umt_python/src/number/__init__.py
@@ -1,4 +1,5 @@
+from .format_number import format_number
 from .to_ordinal import to_ordinal
 from .to_percentage import to_percentage
 
-__all__ = ["to_ordinal", "to_percentage"]
+__all__ = ["format_number", "to_ordinal", "to_percentage"]

--- a/package/umt_python/src/number/format_number.py
+++ b/package/umt_python/src/number/format_number.py
@@ -1,0 +1,184 @@
+"""Locale-aware number formatting ported from package/main Number/formatNumber.ts."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+FormatStyle = Literal["decimal", "currency", "percent"]
+
+
+@dataclass(frozen=True)
+class _LocaleSpec:
+    """Separator characters used when formatting numbers for a locale."""
+
+    thousands: str
+    decimal: str
+
+
+# Separator tables for the handful of locales we explicitly support. Any
+# unknown locale falls back to the en-US layout below, which mirrors the
+# default behavior of `Intl.NumberFormat` when the ICU data is missing.
+_LOCALE_SEPARATORS: dict[str, _LocaleSpec] = {
+    "en-US": _LocaleSpec(thousands=",", decimal="."),
+    "en-GB": _LocaleSpec(thousands=",", decimal="."),
+    "ja-JP": _LocaleSpec(thousands=",", decimal="."),
+    "de-DE": _LocaleSpec(thousands=".", decimal=","),
+    "fr-FR": _LocaleSpec(thousands="\u202f", decimal=","),
+    "it-IT": _LocaleSpec(thousands=".", decimal=","),
+    "es-ES": _LocaleSpec(thousands=".", decimal=","),
+}
+
+_DEFAULT_LOCALE_SPEC = _LOCALE_SEPARATORS["en-US"]
+
+# Minimal symbol table so the "currency" style produces a useful prefix
+# without pulling in a full ICU / Babel dependency (the Python package is
+# zero-dependency by policy, matching package/main). Unknown currencies
+# fall back to the ISO 4217 code plus a non-breaking space.
+_CURRENCY_SYMBOLS: dict[str, str] = {
+    "USD": "$",
+    "EUR": "\u20ac",
+    "GBP": "\u00a3",
+    "JPY": "\u00a5",
+    "CNY": "\u00a5",
+    "KRW": "\u20a9",
+}
+
+
+def _resolve_locale_spec(locale: str | None) -> _LocaleSpec:
+    if locale is None:
+        return _DEFAULT_LOCALE_SPEC
+    # Exact match first, then language-only fallback (e.g. "fr" -> "fr-FR").
+    if locale in _LOCALE_SEPARATORS:
+        return _LOCALE_SEPARATORS[locale]
+    language = locale.split("-", 1)[0]
+    for key, spec in _LOCALE_SEPARATORS.items():
+        if key.split("-", 1)[0] == language:
+            return spec
+    return _DEFAULT_LOCALE_SPEC
+
+
+def _default_fraction_digits(
+    style: FormatStyle,
+    currency: str | None,
+) -> tuple[int, int]:
+    """Mirror Intl.NumberFormat defaults for minimum/maximum fraction digits."""
+
+    if style == "currency":
+        # JPY and KRW historically have no fractional unit; everything else
+        # defaults to 2 digits per ECMA-402.
+        if currency in {"JPY", "KRW"}:
+            return (0, 0)
+        return (2, 2)
+    if style == "percent":
+        return (0, 0)
+    # decimal (default)
+    return (0, 3)
+
+
+def _round_half_away_from_zero(value: float, digits: int) -> float:
+    """Round matching Intl.NumberFormat (half away from zero)."""
+
+    if digits < 0:
+        msg = "digits must be non-negative"
+        raise ValueError(msg)
+    factor = 10**digits
+    scaled = value * factor
+    # Python's round() uses banker's rounding, which diverges from the
+    # half-away-from-zero behavior used by Intl.NumberFormat. Emulate the
+    # JS semantics so the port matches package/main.
+    rounded = int(scaled + 0.5) if scaled >= 0 else -int(-scaled + 0.5)
+    return rounded / factor
+
+
+def _format_absolute(
+    value: float,
+    min_fraction: int,
+    max_fraction: int,
+    spec: _LocaleSpec,
+) -> str:
+    rounded = _round_half_away_from_zero(value, max_fraction)
+    # Split into integer and fractional parts via string manipulation so we
+    # can apply locale-specific separators independently.
+    integer_part = int(rounded)
+    remainder = abs(rounded - integer_part)
+
+    integer_str = f"{integer_part:,}".replace(",", spec.thousands)
+
+    if max_fraction == 0:
+        return integer_str
+
+    # Produce exactly max_fraction digits then trim trailing zeros down to
+    # min_fraction, matching Intl.NumberFormat's default behavior.
+    fraction_digits = f"{remainder:.{max_fraction}f}"[2:]
+    trimmed = fraction_digits.rstrip("0")
+    if len(trimmed) < min_fraction:
+        trimmed = fraction_digits[:min_fraction]
+    if not trimmed:
+        return integer_str
+    return f"{integer_str}{spec.decimal}{trimmed}"
+
+
+def format_number(
+    value: float | int,
+    *,
+    locale: str | None = None,
+    minimum_fraction_digits: int | None = None,
+    maximum_fraction_digits: int | None = None,
+    style: FormatStyle = "decimal",
+    currency: str | None = None,
+) -> str:
+    """Format a number similarly to ``Intl.NumberFormat`` in the TypeScript source.
+
+    Supports decimal, percent, and currency styles, with configurable
+    minimum/maximum fraction digits and locale-aware separators for a
+    curated list of locales. Unknown locales fall back to ``en-US``.
+
+    Args:
+        value: Numeric value to format.
+        locale: BCP 47 locale tag (e.g. ``"en-US"``, ``"de-DE"``). Defaults
+            to ``"en-US"`` semantics when ``None``.
+        minimum_fraction_digits: Minimum number of fractional digits.
+        maximum_fraction_digits: Maximum number of fractional digits.
+        style: One of ``"decimal"``, ``"currency"``, or ``"percent"``.
+        currency: ISO 4217 code used when ``style`` is ``"currency"``.
+
+    Returns:
+        The formatted number as a string.
+
+    Example:
+        >>> format_number(1234567.89)
+        '1,234,567.89'
+        >>> format_number(1234567.89, locale="de-DE")
+        '1.234.567,89'
+        >>> format_number(0.75, style="percent")
+        '75%'
+        >>> format_number(1234.5, style="currency", currency="USD", locale="en-US")
+        '$1,234.50'
+    """
+
+    default_min, default_max = _default_fraction_digits(style, currency)
+    min_fraction = (
+        default_min if minimum_fraction_digits is None else minimum_fraction_digits
+    )
+    max_fraction = (
+        default_max if maximum_fraction_digits is None else maximum_fraction_digits
+    )
+    # Intl.NumberFormat normalizes this by treating max as the larger of
+    # the two \u2014 replicate the same forgiving behavior instead of raising.
+    max_fraction = max(max_fraction, min_fraction)
+
+    spec = _resolve_locale_spec(locale)
+
+    scaled_value = value * 100 if style == "percent" else value
+    sign = "-" if scaled_value < 0 else ""
+    magnitude = _format_absolute(abs(scaled_value), min_fraction, max_fraction, spec)
+
+    if style == "percent":
+        return f"{sign}{magnitude}%"
+
+    if style == "currency":
+        symbol = _CURRENCY_SYMBOLS.get(
+            currency or "", f"{currency}\u00a0" if currency else ""
+        )
+        return f"{sign}{symbol}{magnitude}"
+
+    return f"{sign}{magnitude}"

--- a/package/umt_python/src/number/format_number.py
+++ b/package/umt_python/src/number/format_number.py
@@ -8,15 +8,10 @@ FormatStyle = Literal["decimal", "currency", "percent"]
 
 @dataclass(frozen=True)
 class _LocaleSpec:
-    """Separator characters used when formatting numbers for a locale."""
-
     thousands: str
     decimal: str
 
 
-# Separator tables for the handful of locales we explicitly support. Any
-# unknown locale falls back to the en-US layout below, which mirrors the
-# default behavior of `Intl.NumberFormat` when the ICU data is missing.
 _LOCALE_SEPARATORS: dict[str, _LocaleSpec] = {
     "en-US": _LocaleSpec(thousands=",", decimal="."),
     "en-GB": _LocaleSpec(thousands=",", decimal="."),
@@ -29,10 +24,6 @@ _LOCALE_SEPARATORS: dict[str, _LocaleSpec] = {
 
 _DEFAULT_LOCALE_SPEC = _LOCALE_SEPARATORS["en-US"]
 
-# Minimal symbol table so the "currency" style produces a useful prefix
-# without pulling in a full ICU / Babel dependency (the Python package is
-# zero-dependency by policy, matching package/main). Unknown currencies
-# fall back to the ISO 4217 code plus a non-breaking space.
 _CURRENCY_SYMBOLS: dict[str, str] = {
     "USD": "$",
     "EUR": "\u20ac",
@@ -42,11 +33,14 @@ _CURRENCY_SYMBOLS: dict[str, str] = {
     "KRW": "\u20a9",
 }
 
+# Currencies whose Intl.NumberFormat default minimum/maximum fraction digits
+# diverge from the standard "2 digits" rule and use 0 instead.
+_ZERO_FRACTION_CURRENCIES = frozenset({"JPY", "KRW"})
+
 
 def _resolve_locale_spec(locale: str | None) -> _LocaleSpec:
     if locale is None:
         return _DEFAULT_LOCALE_SPEC
-    # Exact match first, then language-only fallback (e.g. "fr" -> "fr-FR").
     if locale in _LOCALE_SEPARATORS:
         return _LOCALE_SEPARATORS[locale]
     language = locale.split("-", 1)[0]
@@ -60,31 +54,23 @@ def _default_fraction_digits(
     style: FormatStyle,
     currency: str | None,
 ) -> tuple[int, int]:
-    """Mirror Intl.NumberFormat defaults for minimum/maximum fraction digits."""
-
     if style == "currency":
-        # JPY and KRW historically have no fractional unit; everything else
-        # defaults to 2 digits per ECMA-402.
-        if currency in {"JPY", "KRW"}:
+        if currency in _ZERO_FRACTION_CURRENCIES:
             return (0, 0)
         return (2, 2)
     if style == "percent":
         return (0, 0)
-    # decimal (default)
     return (0, 3)
 
 
 def _round_half_away_from_zero(value: float, digits: int) -> float:
-    """Round matching Intl.NumberFormat (half away from zero)."""
-
     if digits < 0:
         msg = "digits must be non-negative"
         raise ValueError(msg)
     factor = 10**digits
     scaled = value * factor
-    # Python's round() uses banker's rounding, which diverges from the
-    # half-away-from-zero behavior used by Intl.NumberFormat. Emulate the
-    # JS semantics so the port matches package/main.
+    # Python's round() uses banker's rounding; Intl.NumberFormat rounds
+    # half away from zero, so we cannot delegate to round() here.
     rounded = int(scaled + 0.5) if scaled >= 0 else -int(-scaled + 0.5)
     return rounded / factor
 
@@ -96,8 +82,6 @@ def _format_absolute(
     spec: _LocaleSpec,
 ) -> str:
     rounded = _round_half_away_from_zero(value, max_fraction)
-    # Split into integer and fractional parts via string manipulation so we
-    # can apply locale-specific separators independently.
     integer_part = int(rounded)
     remainder = abs(rounded - integer_part)
 
@@ -106,8 +90,6 @@ def _format_absolute(
     if max_fraction == 0:
         return integer_str
 
-    # Produce exactly max_fraction digits then trim trailing zeros down to
-    # min_fraction, matching Intl.NumberFormat's default behavior.
     fraction_digits = f"{remainder:.{max_fraction}f}"[2:]
     trimmed = fraction_digits.rstrip("0")
     if len(trimmed) < min_fraction:
@@ -127,10 +109,6 @@ def format_number(
     currency: str | None = None,
 ) -> str:
     """Format a number similarly to ``Intl.NumberFormat`` in the TypeScript source.
-
-    Supports decimal, percent, and currency styles, with configurable
-    minimum/maximum fraction digits and locale-aware separators for a
-    curated list of locales. Unknown locales fall back to ``en-US``.
 
     Args:
         value: Numeric value to format.
@@ -162,8 +140,6 @@ def format_number(
     max_fraction = (
         default_max if maximum_fraction_digits is None else maximum_fraction_digits
     )
-    # Intl.NumberFormat normalizes this by treating max as the larger of
-    # the two \u2014 replicate the same forgiving behavior instead of raising.
     max_fraction = max(max_fraction, min_fraction)
 
     spec = _resolve_locale_spec(locale)

--- a/package/umt_python/tests/unit/number/test_format_number.py
+++ b/package/umt_python/tests/unit/number/test_format_number.py
@@ -1,0 +1,71 @@
+from src.number.format_number import format_number
+
+
+def test_format_decimal_en_us():
+    assert format_number(1234567.89) == "1,234,567.89"
+
+
+def test_format_decimal_de_de():
+    assert format_number(1234567.89, locale="de-DE") == "1.234.567,89"
+
+
+def test_format_decimal_fallback_for_unknown_locale():
+    # Unknown locales fall back to en-US layout.
+    assert format_number(1234.5, locale="xx-YY") == "1,234.5"
+
+
+def test_format_percent_default():
+    assert format_number(0.75, style="percent") == "75%"
+
+
+def test_format_percent_with_fraction_digits():
+    assert (
+        format_number(
+            0.1234,
+            style="percent",
+            minimum_fraction_digits=2,
+            maximum_fraction_digits=2,
+        )
+        == "12.34%"
+    )
+
+
+def test_format_currency_usd_en_us():
+    assert (
+        format_number(1234.5, style="currency", currency="USD", locale="en-US")
+        == "$1,234.50"
+    )
+
+
+def test_format_currency_jpy_defaults_to_zero_fraction_digits():
+    assert format_number(1234, style="currency", currency="JPY") == "\u00a51,234"
+
+
+def test_format_currency_unknown_code_uses_iso_prefix():
+    assert (
+        format_number(1000, style="currency", currency="XYZ", locale="en-US")
+        == "XYZ\u00a01,000.00"
+    )
+
+
+def test_minimum_fraction_digits_pads_trailing_zeros():
+    assert format_number(1, minimum_fraction_digits=2) == "1.00"
+
+
+def test_maximum_fraction_digits_truncates_with_half_away_from_zero():
+    # 0.125 rounded to 2 digits should be 0.13 under half-away-from-zero.
+    assert format_number(0.125, maximum_fraction_digits=2) == "0.13"
+    # Negative mirror: -0.125 -> -0.13.
+    assert format_number(-0.125, maximum_fraction_digits=2) == "-0.13"
+
+
+def test_negative_numbers_keep_sign_and_separators():
+    assert format_number(-1234567.8, locale="en-US") == "-1,234,567.8"
+
+
+def test_fraction_bounds_normalize_when_max_less_than_min():
+    # Mimic Intl.NumberFormat's forgiving normalization.
+    assert (
+        format_number(1.5, minimum_fraction_digits=3, maximum_fraction_digits=1)
+        == "1.500"
+    )


### PR DESCRIPTION
#789 は PR タイトルに tool call の XML 残骸が混入した状態で作ってしまい、ユーザーにクローズされたため作り直し。今回は XML 残骸なしで、ボットが指摘していた `package/umt_python/README.md` の Number Functions セクション追加も含める。

## 変更内容

### 1. `Object/has` の不要なシャローコピー削除 (perf)
`has(obj, path)` は `Object.hasOwn` とネスト参照しか行わず、入り口の `let current = { ...object };` のコピー先に一切書き込まない。参照を直接たどる形に変更してアロケーションを削った。挙動不変、全テスト通過。

対象: `package/main/src/Object/has.ts` / `.jules/bolt.md`

### 2. `Object/pick` のプロトタイプ汚染 warning ドキュメント追加
`merge` / `mergeDeep` / `mapKeys` と同じ `@remarks` ブロックを JSDoc に追加。実装側にガードは入れず、既存の「呼び出し側が `removePrototype*` でサニタイズする」方針に揃える。`merge.test.ts` の `merge({}, removePrototype(malicious))` パターンに倣ったテストを追加。

対象: `package/main/src/Object/pick.ts` / `package/main/src/tests/unit/Object/pick.test.ts`

### 3. `formatNumber` を `umt_python` にポート (sync)
`Intl.NumberFormat` は Python で素直に再現できないため (`locale` はプロセスグローバル、Babel/ICU はゼロ依存方針に反する)、TS JSDoc `@example` が文書化している範囲を純 Python で実装。

- decimal / percent / currency の 3 スタイル
- `minimum_fraction_digits` / `maximum_fraction_digits`
- `en-US` / `en-GB` / `ja-JP` / `de-DE` / `fr-FR` / `it-IT` / `es-ES` ロケール (未知ロケールは en-US fallback)
- 通貨記号テーブル `USD` / `EUR` / `GBP` / `JPY` / `CNY` / `KRW`、未知通貨は ISO 4217 + 非破壊空白
- ECMA-402 の `JPY` / `KRW` 0 小数桁デフォルト
- JS `Math.round` 互換 half-away-from-zero

対象: `package/umt_python/src/number/format_number.py` (新規) / `package/umt_python/tests/unit/number/test_format_number.py` (新規 12 ケース) / `package/umt_python/src/number/__init__.py` / `package/umt_python/src/__init__.py` / `.jules/sync.md`

### 4. `package/umt_python/README.md` に Number Functions セクション追加
`package/umt_python/CLAUDE.md` の「Adding New Functions」step 6 (README 更新) が抜けていたのを修正。`format_number` と既存の `to_ordinal` / `to_percentage` を Number Functions テーブルで文書化。

対象: `package/umt_python/README.md`

## Test plan

- [x] `bun run lint` (eslint + biome + tsc) クリーン
- [x] `bun run test src/tests/unit/Object/` 172/172 通過
- [x] `uv run ruff format` 差分なし
- [x] `uv run ruff check` クリーン
- [x] `uv run pyright src/` 既存の `sum_precise` 警告以外なし
- [x] `uv run pytest tests/unit/number/` 27/27 通過

https://claude.ai/code/session_011K6dhky9K8TQMZUrgk3mrX