### PR TITLE
Sync: Port formatNumber to umt_rust

### DIFF
--- a/package/umt_rust/src/number/format_number.rs
+++ b/package/umt_rust/src/number/format_number.rs
@@ -1,0 +1,296 @@
+use std::collections::HashMap;
+
+/// Formatting style accepted by [`umt_format_number`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FormatStyle {
+    #[default]
+    Decimal,
+    Currency,
+    Percent,
+}
+
+/// Options mirroring the `Intl.NumberFormat`-like API exposed by
+/// `package/main` and `umt_python`.
+#[derive(Debug, Default, Clone)]
+pub struct FormatNumberOptions {
+    /// BCP 47 locale tag (e.g. `"en-US"`, `"de-DE"`).
+    pub locale: Option<String>,
+    /// Minimum number of fractional digits.
+    pub minimum_fraction_digits: Option<u32>,
+    /// Maximum number of fractional digits.
+    pub maximum_fraction_digits: Option<u32>,
+    /// Formatting style. Defaults to [`FormatStyle::Decimal`].
+    pub style: FormatStyle,
+    /// ISO 4217 currency code used when `style` is [`FormatStyle::Currency`].
+    pub currency: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LocaleSpec {
+    thousands: &'static str,
+    decimal: &'static str,
+}
+
+const DEFAULT_LOCALE_SPEC: LocaleSpec = LocaleSpec {
+    thousands: ",",
+    decimal: ".",
+};
+
+fn locale_separators() -> &'static [(&'static str, LocaleSpec)] {
+    // Keep in sync with umt_python/src/number/format_number.py
+    &[
+        (
+            "en-US",
+            LocaleSpec {
+                thousands: ",",
+                decimal: ".",
+            },
+        ),
+        (
+            "en-GB",
+            LocaleSpec {
+                thousands: ",",
+                decimal: ".",
+            },
+        ),
+        (
+            "ja-JP",
+            LocaleSpec {
+                thousands: ",",
+                decimal: ".",
+            },
+        ),
+        (
+            "de-DE",
+            LocaleSpec {
+                thousands: ".",
+                decimal: ",",
+            },
+        ),
+        (
+            "fr-FR",
+            LocaleSpec {
+                thousands: "\u{202f}",
+                decimal: ",",
+            },
+        ),
+        (
+            "it-IT",
+            LocaleSpec {
+                thousands: ".",
+                decimal: ",",
+            },
+        ),
+        (
+            "es-ES",
+            LocaleSpec {
+                thousands: ".",
+                decimal: ",",
+            },
+        ),
+    ]
+}
+
+fn currency_symbols() -> HashMap<&'static str, &'static str> {
+    HashMap::from([
+        ("USD", "$"),
+        ("EUR", "\u{20ac}"),
+        ("GBP", "\u{00a3}"),
+        ("JPY", "\u{00a5}"),
+        ("CNY", "\u{00a5}"),
+        ("KRW", "\u{20a9}"),
+    ])
+}
+
+// Currencies whose Intl.NumberFormat default fraction digits diverge from
+// the standard "2 digits" rule and use 0 instead.
+const ZERO_FRACTION_CURRENCIES: &[&str] = &["JPY", "KRW"];
+
+fn resolve_locale_spec(locale: Option<&str>) -> LocaleSpec {
+    let Some(tag) = locale else {
+        return DEFAULT_LOCALE_SPEC;
+    };
+    let separators = locale_separators();
+    for (key, spec) in separators {
+        if *key == tag {
+            return *spec;
+        }
+    }
+    let language = tag.split('-').next().unwrap_or(tag);
+    for (key, spec) in separators {
+        if key.split('-').next().unwrap_or(*key) == language {
+            return *spec;
+        }
+    }
+    DEFAULT_LOCALE_SPEC
+}
+
+fn default_fraction_digits(style: FormatStyle, currency: Option<&str>) -> (u32, u32) {
+    match style {
+        FormatStyle::Currency => {
+            if currency
+                .map(|c| ZERO_FRACTION_CURRENCIES.contains(&c))
+                .unwrap_or(false)
+            {
+                (0, 0)
+            } else {
+                (2, 2)
+            }
+        }
+        FormatStyle::Percent => (0, 0),
+        FormatStyle::Decimal => (0, 3),
+    }
+}
+
+// Python's round() uses banker's rounding; Intl.NumberFormat rounds half
+// away from zero, so we cannot delegate to Rust's f64::round either without
+// care. Rust's `round` already rounds half away from zero, but we scale
+// manually to avoid surprises from floating point drift at boundary cases.
+fn round_half_away_from_zero(value: f64, digits: u32) -> f64 {
+    let factor = 10_f64.powi(digits as i32);
+    let scaled = value * factor;
+    let rounded = if scaled >= 0.0 {
+        (scaled + 0.5).floor()
+    } else {
+        -((-scaled + 0.5).floor())
+    };
+    rounded / factor
+}
+
+fn insert_thousands_separators(integer_part: u64, separator: &str) -> String {
+    let raw = integer_part.to_string();
+    if separator.is_empty() || raw.len() <= 3 {
+        return raw;
+    }
+    let bytes = raw.as_bytes();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    let remainder = bytes.len() % 3;
+    if remainder > 0 {
+        out.push_str(&raw[..remainder]);
+    }
+    let mut idx = remainder;
+    while idx < bytes.len() {
+        if idx != 0 {
+            out.push_str(separator);
+        }
+        out.push_str(&raw[idx..idx + 3]);
+        idx += 3;
+    }
+    out
+}
+
+fn format_absolute(value: f64, min_fraction: u32, max_fraction: u32, spec: LocaleSpec) -> String {
+    let rounded = round_half_away_from_zero(value, max_fraction);
+    let integer_part = rounded.trunc() as u64;
+    let remainder = (rounded - integer_part as f64).abs();
+
+    let integer_str = insert_thousands_separators(integer_part, spec.thousands);
+
+    if max_fraction == 0 {
+        return integer_str;
+    }
+
+    // Format the fractional part with enough precision, then trim trailing
+    // zeros down to `min_fraction`, matching Intl.NumberFormat behaviour.
+    let fraction_all = format!("{:.*}", max_fraction as usize, remainder);
+    // Skip the leading "0." (or "1." when carry occurred; carry is already
+    // absorbed into integer_part by the rounding above so "0." is expected).
+    let fraction_digits = fraction_all
+        .split_once('.')
+        .map(|(_, rest)| rest.to_string())
+        .unwrap_or_default();
+    let trimmed = fraction_digits.trim_end_matches('0');
+    let trimmed: String = if (trimmed.len() as u32) < min_fraction {
+        fraction_digits
+            .chars()
+            .take(min_fraction as usize)
+            .collect()
+    } else {
+        trimmed.to_string()
+    };
+    if trimmed.is_empty() {
+        return integer_str;
+    }
+    format!("{}{}{}", integer_str, spec.decimal, trimmed)
+}
+
+/// Formats a number similarly to `Intl.NumberFormat` in the TypeScript source.
+///
+/// # Arguments
+///
+/// * `value` - Numeric value to format.
+/// * `options` - Formatting options. See [`FormatNumberOptions`].
+///
+/// # Example
+///
+/// ```
+/// use umt_rust::number::{umt_format_number, FormatNumberOptions, FormatStyle};
+///
+/// assert_eq!(
+///     umt_format_number(1_234_567.89, &FormatNumberOptions::default()),
+///     "1,234,567.89"
+/// );
+///
+/// let opts = FormatNumberOptions {
+///     locale: Some("de-DE".to_string()),
+///     ..Default::default()
+/// };
+/// assert_eq!(umt_format_number(1_234_567.89, &opts), "1.234.567,89");
+///
+/// let opts = FormatNumberOptions {
+///     style: FormatStyle::Percent,
+///     ..Default::default()
+/// };
+/// assert_eq!(umt_format_number(0.75, &opts), "75%");
+///
+/// let opts = FormatNumberOptions {
+///     style: FormatStyle::Currency,
+///     currency: Some("USD".to_string()),
+///     locale: Some("en-US".to_string()),
+///     ..Default::default()
+/// };
+/// assert_eq!(umt_format_number(1234.5, &opts), "$1,234.50");
+/// ```
+pub fn umt_format_number(value: f64, options: &FormatNumberOptions) -> String {
+    let style = options.style;
+    let currency = options.currency.as_deref();
+
+    let (default_min, default_max) = default_fraction_digits(style, currency);
+    let min_fraction = options.minimum_fraction_digits.unwrap_or(default_min);
+    let max_fraction = options.maximum_fraction_digits.unwrap_or(default_max);
+    // Intl.NumberFormat forgives max < min by clamping max up to min.
+    let max_fraction = max_fraction.max(min_fraction);
+
+    let spec = resolve_locale_spec(options.locale.as_deref());
+
+    let scaled_value = if matches!(style, FormatStyle::Percent) {
+        value * 100.0
+    } else {
+        value
+    };
+
+    let sign = if scaled_value < 0.0 { "-" } else { "" };
+    let magnitude = format_absolute(scaled_value.abs(), min_fraction, max_fraction, spec);
+
+    match style {
+        FormatStyle::Percent => format!("{}{}%", sign, magnitude),
+        FormatStyle::Currency => {
+            let symbol_map = currency_symbols();
+            let code = currency.unwrap_or("");
+            let symbol_owned: String = if let Some(sym) = symbol_map.get(code) {
+                (*sym).to_string()
+            } else if !code.is_empty() {
+                format!("{}\u{00a0}", code)
+            } else {
+                String::new()
+            };
+            format!("{}{}{}", sign, symbol_owned, magnitude)
+        }
+        FormatStyle::Decimal => format!("{}{}", sign, magnitude),
+    }
+}
+
+/// Convenience wrapper that formats with the default options.
+pub fn umt_format_number_default(value: f64) -> String {
+    umt_format_number(value, &FormatNumberOptions::default())
+}

--- a/package/umt_rust/src/number/mod.rs
+++ b/package/umt_rust/src/number/mod.rs
@@ -1,3 +1,8 @@
+mod format_number;
+pub use format_number::{
+    FormatNumberOptions, FormatStyle, umt_format_number, umt_format_number_default,
+};
+
 mod to_ordinal;
 pub use to_ordinal::umt_to_ordinal;
 

--- a/package/umt_rust/tests/number/mod.rs
+++ b/package/umt_rust/tests/number/mod.rs
@@ -1,2 +1,3 @@
+mod test_format_number;
 mod test_to_ordinal;
 mod test_to_percentage;

--- a/package/umt_rust/tests/number/test_format_number.rs
+++ b/package/umt_rust/tests/number/test_format_number.rs
@@ -1,0 +1,141 @@
+use umt_rust::number::{
+    FormatNumberOptions, FormatStyle, umt_format_number, umt_format_number_default,
+};
+
+fn opts_with_locale(locale: &str) -> FormatNumberOptions {
+    FormatNumberOptions {
+        locale: Some(locale.to_string()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_format_decimal_en_us() {
+    assert_eq!(
+        umt_format_number(1_234_567.89, &opts_with_locale("en-US")),
+        "1,234,567.89"
+    );
+}
+
+#[test]
+fn test_format_decimal_de_de() {
+    assert_eq!(
+        umt_format_number(1_234_567.89, &opts_with_locale("de-DE")),
+        "1.234.567,89"
+    );
+}
+
+#[test]
+fn test_format_decimal_fallback_for_unknown_locale() {
+    // Unknown locales fall back to en-US layout (mirrors umt_python).
+    assert_eq!(
+        umt_format_number(1234.5, &opts_with_locale("xx-YY")),
+        "1,234.5"
+    );
+}
+
+#[test]
+fn test_format_percent_default() {
+    let opts = FormatNumberOptions {
+        style: FormatStyle::Percent,
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(0.75, &opts), "75%");
+}
+
+#[test]
+fn test_format_percent_with_fraction_digits() {
+    let opts = FormatNumberOptions {
+        style: FormatStyle::Percent,
+        minimum_fraction_digits: Some(2),
+        maximum_fraction_digits: Some(2),
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(0.1234, &opts), "12.34%");
+}
+
+#[test]
+fn test_format_currency_usd_en_us() {
+    let opts = FormatNumberOptions {
+        style: FormatStyle::Currency,
+        currency: Some("USD".to_string()),
+        locale: Some("en-US".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(1234.5, &opts), "$1,234.50");
+}
+
+#[test]
+fn test_format_currency_jpy_defaults_to_zero_fraction_digits() {
+    let opts = FormatNumberOptions {
+        style: FormatStyle::Currency,
+        currency: Some("JPY".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(1234.0, &opts), "\u{00a5}1,234");
+}
+
+#[test]
+fn test_format_currency_unknown_code_uses_iso_prefix() {
+    let opts = FormatNumberOptions {
+        style: FormatStyle::Currency,
+        currency: Some("XYZ".to_string()),
+        locale: Some("en-US".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(1000.0, &opts), "XYZ\u{00a0}1,000.00");
+}
+
+#[test]
+fn test_minimum_fraction_digits_pads_trailing_zeros() {
+    let opts = FormatNumberOptions {
+        minimum_fraction_digits: Some(2),
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(1.0, &opts), "1.00");
+}
+
+#[test]
+fn test_maximum_fraction_digits_truncates_with_half_away_from_zero() {
+    let opts = FormatNumberOptions {
+        maximum_fraction_digits: Some(2),
+        ..Default::default()
+    };
+    // 0.125 rounded to 2 digits should be 0.13 under half-away-from-zero.
+    assert_eq!(umt_format_number(0.125, &opts), "0.13");
+    // Negative mirror: -0.125 -> -0.13.
+    assert_eq!(umt_format_number(-0.125, &opts), "-0.13");
+}
+
+#[test]
+fn test_negative_numbers_keep_sign_and_separators() {
+    assert_eq!(
+        umt_format_number(-1_234_567.8, &opts_with_locale("en-US")),
+        "-1,234,567.8"
+    );
+}
+
+#[test]
+fn test_fraction_bounds_normalize_when_max_less_than_min() {
+    // Mimic Intl.NumberFormat's forgiving normalization: max gets clamped
+    // up to min when max < min is supplied.
+    let opts = FormatNumberOptions {
+        minimum_fraction_digits: Some(3),
+        maximum_fraction_digits: Some(1),
+        ..Default::default()
+    };
+    assert_eq!(umt_format_number(1.5, &opts), "1.500");
+}
+
+#[test]
+fn test_zero_formats_without_fractional_part() {
+    assert_eq!(umt_format_number(0.0, &opts_with_locale("en-US")), "0");
+}
+
+#[test]
+fn test_default_wrapper_matches_explicit_default() {
+    assert_eq!(
+        umt_format_number_default(1234.5),
+        umt_format_number(1234.5, &FormatNumberOptions::default())
+    );
+}


### PR DESCRIPTION
## Summary

Ports `formatNumber` from `package/main` and `package/umt_python` into `package/umt_rust` so the three language implementations reach parity.

## Source

- `package/main/src/Number/formatNumber.ts`
- `package/umt_python/src/number/format_number.py`
- `package/main/src/tests/unit/Number/formatNumber.test.ts`
- `package/umt_python/tests/unit/number/test_format_number.py`

## Target

- `package/umt_rust/src/number/format_number.rs` (new)
- `package/umt_rust/src/number/mod.rs`
- `package/umt_rust/tests/number/test_format_number.rs` (new)
- `package/umt_rust/tests/number/mod.rs`

## Implementation

Mirrors the `Intl.NumberFormat`-like API. Supports decimal/currency/percent styles, configurable locale, min/max fraction digits, and ISO 4217 currency codes. Covers the same en-US/en-GB/ja-JP/de-DE/fr-FR/it-IT/es-ES locales and USD/EUR/GBP/JPY/CNY/KRW currencies as the Python port, with JPY and KRW defaulting to zero fraction digits. Rounding uses half-away-from-zero semantics to match `Intl.NumberFormat` rather than Rust's or Python's banker's rounding.

Idiomatic Rust adaptations: options exposed as a `FormatNumberOptions` struct with `Default`, style as a `FormatStyle` enum, and the convenience wrapper `umt_format_number_default`.

## Verification

- `cargo build`, `cargo test` (274 tests + 1 doctest) all pass locally on the branch.
- `cargo fmt` applied.
- `cargo clippy --lib -- -D warnings` clean for the new module.
- Test cases mirror the Python port case-for-case (decimal locales, percent, currency, min/max fraction digits, half-away-from-zero rounding, negative numbers, max&lt;min normalization, zero, default-wrapper parity).

## Test plan

- [ ] CI runs `cargo test` on `umt_rust` and confirms the new tests pass.
- [ ] CI runs `cargo clippy` / `cargo fmt --check` on the new file.