### PR TITLE
Add locale-aware number formatting to Rust package

### DIFF
--- a/package/umt_rust/src/number/format_number.rs
+++ b/package/umt_rust/src/number/format_number.rs
@@ -157,6 +157,18 @@ fn format_absolute(value: f64, min_fraction: u32, max_fraction: u32, spec: &Loca
 
 /// Formats `value` according to `options`, mirroring `Intl.NumberFormat`.
 ///
+/// Returns the literal string `"NaN"` for NaN input, matching the TypeScript
+/// reference and the Python port.
+///
+/// # Arguments
+///
+/// * `value` - The number to format.
+/// * `options` - Locale, style, currency, and fraction-digit configuration.
+///
+/// # Returns
+///
+/// The formatted number as a `String`.
+///
 /// # Examples
 ///
 /// ```
@@ -188,6 +200,10 @@ fn format_absolute(value: f64, min_fraction: u32, max_fraction: u32, spec: &Loca
 /// assert_eq!(umt_format_number(1234.5, &usd), "$1,234.50");
 /// ```
 pub fn umt_format_number(value: f64, options: &FormatNumberOptions) -> String {
+    if value.is_nan() {
+        return "NaN".to_string();
+    }
+
     let style = options.style.unwrap_or_default();
     let (default_min, default_max) = default_fraction_digits(style, options.currency);
     let min_fraction = options.minimum_fraction_digits.unwrap_or(default_min);
@@ -230,6 +246,14 @@ pub fn umt_format_number(value: f64, options: &FormatNumberOptions) -> String {
 }
 
 /// Convenience wrapper that formats with all defaults (decimal, en-US layout).
+///
+/// # Arguments
+///
+/// * `value` - The number to format.
+///
+/// # Returns
+///
+/// The formatted number as a `String`.
 pub fn umt_format_number_default(value: f64) -> String {
     umt_format_number(value, &FormatNumberOptions::default())
 }

--- a/package/umt_rust/src/number/format_number.rs
+++ b/package/umt_rust/src/number/format_number.rs
@@ -1,0 +1,235 @@
+// Locale-aware number formatting ported from package/main Number/formatNumber.ts.
+//
+// The TypeScript reference delegates to `Intl.NumberFormat`, which Rust lacks.
+// We reproduce the same observable output for the locales and currencies that
+// the Python port (`package/umt_python/src/number/format_number.py`) already
+// covers, keeping the three packages in sync.
+
+/// Formatting style accepted by [`umt_format_number`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FormatStyle {
+    #[default]
+    Decimal,
+    Currency,
+    Percent,
+}
+
+/// Options mirroring the TypeScript `FormatNumberOptions` interface.
+///
+/// Using `Option` for each field allows callers to rely on
+/// `Intl.NumberFormat`-style defaults while still overriding individual knobs.
+#[derive(Debug, Clone, Default)]
+pub struct FormatNumberOptions<'a> {
+    /// BCP 47 locale tag (e.g. "en-US", "de-DE"). Defaults to "en-US" semantics.
+    pub locale: Option<&'a str>,
+    /// Minimum number of fractional digits.
+    pub minimum_fraction_digits: Option<u32>,
+    /// Maximum number of fractional digits.
+    pub maximum_fraction_digits: Option<u32>,
+    /// Formatting style (decimal / currency / percent).
+    pub style: Option<FormatStyle>,
+    /// ISO 4217 code used when `style` is `Currency`.
+    pub currency: Option<&'a str>,
+}
+
+struct LocaleSpec {
+    thousands: &'static str,
+    decimal: &'static str,
+}
+
+const EN_SPEC: LocaleSpec = LocaleSpec {
+    thousands: ",",
+    decimal: ".",
+};
+const DE_SPEC: LocaleSpec = LocaleSpec {
+    thousands: ".",
+    decimal: ",",
+};
+const FR_SPEC: LocaleSpec = LocaleSpec {
+    thousands: "\u{202f}",
+    decimal: ",",
+};
+
+fn resolve_locale_spec(locale: Option<&str>) -> LocaleSpec {
+    match locale {
+        None => EN_SPEC,
+        Some(tag) => {
+            // Explicit match first, then language-only fallback, then en-US.
+            match tag {
+                "en-US" | "en-GB" | "ja-JP" => EN_SPEC,
+                "de-DE" | "it-IT" | "es-ES" => DE_SPEC,
+                "fr-FR" => FR_SPEC,
+                _ => match tag.split('-').next().unwrap_or("") {
+                    "en" | "ja" => EN_SPEC,
+                    "de" | "it" | "es" => DE_SPEC,
+                    "fr" => FR_SPEC,
+                    _ => EN_SPEC,
+                },
+            }
+        }
+    }
+}
+
+fn currency_symbol(code: &str) -> Option<&'static str> {
+    // Matches the symbol table used by the Python port.
+    match code {
+        "USD" => Some("$"),
+        "EUR" => Some("\u{20ac}"),
+        "GBP" => Some("\u{00a3}"),
+        "JPY" | "CNY" => Some("\u{00a5}"),
+        "KRW" => Some("\u{20a9}"),
+        _ => None,
+    }
+}
+
+// Currencies whose Intl defaults are 0 fraction digits rather than 2.
+fn is_zero_fraction_currency(code: &str) -> bool {
+    matches!(code, "JPY" | "KRW")
+}
+
+fn default_fraction_digits(style: FormatStyle, currency: Option<&str>) -> (u32, u32) {
+    match style {
+        FormatStyle::Currency => {
+            if currency.is_some_and(is_zero_fraction_currency) {
+                (0, 0)
+            } else {
+                (2, 2)
+            }
+        }
+        FormatStyle::Percent => (0, 0),
+        FormatStyle::Decimal => (0, 3),
+    }
+}
+
+// Intl.NumberFormat rounds half away from zero; f64::round matches that
+// semantic, unlike the usual banker's rounding that format! applies.
+fn round_half_away_from_zero(value: f64, digits: u32) -> f64 {
+    let factor = 10_f64.powi(digits as i32);
+    (value * factor).round() / factor
+}
+
+fn insert_thousands(integer: u128, sep: &str) -> String {
+    let digits = integer.to_string();
+    let bytes = digits.as_bytes();
+    let n = bytes.len();
+    let mut out = String::with_capacity(n + n / 3 * sep.len());
+    for (i, byte) in bytes.iter().enumerate() {
+        if i > 0 && (n - i).is_multiple_of(3) {
+            out.push_str(sep);
+        }
+        out.push(*byte as char);
+    }
+    out
+}
+
+fn format_absolute(value: f64, min_fraction: u32, max_fraction: u32, spec: &LocaleSpec) -> String {
+    let rounded = round_half_away_from_zero(value, max_fraction);
+    let integer_part = rounded.trunc() as u128;
+    let integer_str = insert_thousands(integer_part, spec.thousands);
+
+    if max_fraction == 0 {
+        return integer_str;
+    }
+
+    let remainder = (rounded - rounded.trunc()).abs();
+    // `format!("{:.N}", x)` already rounds to N digits; because `rounded` was
+    // snapped to max_fraction digits above, this formatting simply extracts
+    // those digits without re-rounding in a lossy direction.
+    let formatted_remainder = format!("{:.*}", max_fraction as usize, remainder);
+    let fraction_digits = formatted_remainder
+        .strip_prefix("0.")
+        .unwrap_or(&formatted_remainder);
+
+    let trimmed = fraction_digits.trim_end_matches('0');
+    let min = min_fraction as usize;
+    let final_fraction: String = if trimmed.len() < min {
+        fraction_digits.chars().take(min).collect()
+    } else {
+        trimmed.to_string()
+    };
+
+    if final_fraction.is_empty() {
+        integer_str
+    } else {
+        format!("{}{}{}", integer_str, spec.decimal, final_fraction)
+    }
+}
+
+/// Formats `value` according to `options`, mirroring `Intl.NumberFormat`.
+///
+/// # Examples
+///
+/// ```
+/// use umt_rust::number::{umt_format_number, FormatNumberOptions, FormatStyle};
+///
+/// assert_eq!(
+///     umt_format_number(1234567.89, &FormatNumberOptions::default()),
+///     "1,234,567.89",
+/// );
+///
+/// let de = FormatNumberOptions {
+///     locale: Some("de-DE"),
+///     ..FormatNumberOptions::default()
+/// };
+/// assert_eq!(umt_format_number(1234567.89, &de), "1.234.567,89");
+///
+/// let percent = FormatNumberOptions {
+///     style: Some(FormatStyle::Percent),
+///     ..FormatNumberOptions::default()
+/// };
+/// assert_eq!(umt_format_number(0.75, &percent), "75%");
+///
+/// let usd = FormatNumberOptions {
+///     style: Some(FormatStyle::Currency),
+///     currency: Some("USD"),
+///     locale: Some("en-US"),
+///     ..FormatNumberOptions::default()
+/// };
+/// assert_eq!(umt_format_number(1234.5, &usd), "$1,234.50");
+/// ```
+pub fn umt_format_number(value: f64, options: &FormatNumberOptions) -> String {
+    let style = options.style.unwrap_or_default();
+    let (default_min, default_max) = default_fraction_digits(style, options.currency);
+    let min_fraction = options.minimum_fraction_digits.unwrap_or(default_min);
+    // Intl.NumberFormat forgives max < min by lifting max up to min.
+    let max_fraction = options
+        .maximum_fraction_digits
+        .unwrap_or(default_max)
+        .max(min_fraction);
+
+    let spec = resolve_locale_spec(options.locale);
+
+    let scaled_value = if style == FormatStyle::Percent {
+        value * 100.0
+    } else {
+        value
+    };
+
+    let sign = if scaled_value.is_sign_negative() && scaled_value != 0.0 {
+        "-"
+    } else {
+        ""
+    };
+    let magnitude = format_absolute(scaled_value.abs(), min_fraction, max_fraction, &spec);
+
+    match style {
+        FormatStyle::Percent => format!("{}{}%", sign, magnitude),
+        FormatStyle::Currency => {
+            let symbol = match options.currency {
+                Some(code) => match currency_symbol(code) {
+                    Some(sym) => sym.to_string(),
+                    // ISO fallback uses a non-breaking space, as Intl does.
+                    None => format!("{}\u{00a0}", code),
+                },
+                None => String::new(),
+            };
+            format!("{}{}{}", sign, symbol, magnitude)
+        }
+        FormatStyle::Decimal => format!("{}{}", sign, magnitude),
+    }
+}
+
+/// Convenience wrapper that formats with all defaults (decimal, en-US layout).
+pub fn umt_format_number_default(value: f64) -> String {
+    umt_format_number(value, &FormatNumberOptions::default())
+}

--- a/package/umt_rust/src/number/mod.rs
+++ b/package/umt_rust/src/number/mod.rs
@@ -1,3 +1,8 @@
+mod format_number;
+pub use format_number::{
+    FormatNumberOptions, FormatStyle, umt_format_number, umt_format_number_default,
+};
+
 mod to_ordinal;
 pub use to_ordinal::umt_to_ordinal;
 

--- a/package/umt_rust/src/string/format_string/get_value.rs
+++ b/package/umt_rust/src/string/format_string/get_value.rs
@@ -48,17 +48,14 @@ pub fn get_value<'a>(object: &'a Value, path: &str) -> Option<&'a Value> {
             current = current.get(key)?;
 
             // Then get the array element
-            if let Some(arr) = current.as_array() {
-                let actual_index = if index < 0 {
-                    (arr.len() as i64 + index) as usize
-                } else {
-                    index as usize
-                };
-
-                current = arr.get(actual_index)?;
+            let arr = current.as_array()?;
+            let actual_index = if index < 0 {
+                (arr.len() as i64 + index) as usize
             } else {
-                return None;
-            }
+                index as usize
+            };
+
+            current = arr.get(actual_index)?;
         } else {
             // Simple property access
             current = current.get(part)?;

--- a/package/umt_rust/tests/number/mod.rs
+++ b/package/umt_rust/tests/number/mod.rs
@@ -1,2 +1,3 @@
+mod test_format_number;
 mod test_to_ordinal;
 mod test_to_percentage;

--- a/package/umt_rust/tests/number/test_format_number.rs
+++ b/package/umt_rust/tests/number/test_format_number.rs
@@ -114,3 +114,21 @@ fn should_lift_max_fraction_digits_to_minimum() {
     };
     assert_eq!(umt_format_number(1.5, &options), "1.500");
 }
+
+#[test]
+fn should_return_nan_string_for_nan_input() {
+    assert_eq!(umt_format_number_default(f64::NAN), "NaN");
+
+    let percent = FormatNumberOptions {
+        style: Some(FormatStyle::Percent),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(f64::NAN, &percent), "NaN");
+
+    let currency = FormatNumberOptions {
+        style: Some(FormatStyle::Currency),
+        currency: Some("USD"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(f64::NAN, &currency), "NaN");
+}

--- a/package/umt_rust/tests/number/test_format_number.rs
+++ b/package/umt_rust/tests/number/test_format_number.rs
@@ -1,0 +1,117 @@
+use umt_rust::number::{
+    FormatNumberOptions, FormatStyle, umt_format_number, umt_format_number_default,
+};
+
+#[test]
+fn should_format_decimal_en_us_by_default() {
+    assert_eq!(umt_format_number_default(1234567.89), "1,234,567.89");
+}
+
+#[test]
+fn should_format_decimal_with_de_de_locale() {
+    let options = FormatNumberOptions {
+        locale: Some("de-DE"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1234567.89, &options), "1.234.567,89");
+}
+
+#[test]
+fn should_fall_back_to_en_us_layout_for_unknown_locale() {
+    let options = FormatNumberOptions {
+        locale: Some("xx-YY"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1234.5, &options), "1,234.5");
+}
+
+#[test]
+fn should_format_percent_with_default_digits() {
+    let options = FormatNumberOptions {
+        style: Some(FormatStyle::Percent),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(0.75, &options), "75%");
+}
+
+#[test]
+fn should_format_percent_with_explicit_fraction_digits() {
+    let options = FormatNumberOptions {
+        style: Some(FormatStyle::Percent),
+        minimum_fraction_digits: Some(2),
+        maximum_fraction_digits: Some(2),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(0.1234, &options), "12.34%");
+}
+
+#[test]
+fn should_format_currency_usd_with_en_us() {
+    let options = FormatNumberOptions {
+        style: Some(FormatStyle::Currency),
+        currency: Some("USD"),
+        locale: Some("en-US"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1234.5, &options), "$1,234.50");
+}
+
+#[test]
+fn should_default_jpy_currency_to_zero_fraction_digits() {
+    let options = FormatNumberOptions {
+        style: Some(FormatStyle::Currency),
+        currency: Some("JPY"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1234.0, &options), "\u{00a5}1,234");
+}
+
+#[test]
+fn should_prefix_unknown_currency_with_iso_code_and_nbsp() {
+    let options = FormatNumberOptions {
+        style: Some(FormatStyle::Currency),
+        currency: Some("XYZ"),
+        locale: Some("en-US"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1000.0, &options), "XYZ\u{00a0}1,000.00");
+}
+
+#[test]
+fn should_pad_with_minimum_fraction_digits() {
+    let options = FormatNumberOptions {
+        minimum_fraction_digits: Some(2),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1.0, &options), "1.00");
+}
+
+#[test]
+fn should_truncate_with_half_away_from_zero_rounding() {
+    let options = FormatNumberOptions {
+        maximum_fraction_digits: Some(2),
+        ..FormatNumberOptions::default()
+    };
+    // 0.125 under half-away-from-zero rounds up to 0.13 (not banker's 0.12).
+    assert_eq!(umt_format_number(0.125, &options), "0.13");
+    assert_eq!(umt_format_number(-0.125, &options), "-0.13");
+}
+
+#[test]
+fn should_preserve_sign_and_separators_for_negative_numbers() {
+    let options = FormatNumberOptions {
+        locale: Some("en-US"),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(-1234567.8, &options), "-1,234,567.8");
+}
+
+#[test]
+fn should_lift_max_fraction_digits_to_minimum() {
+    let options = FormatNumberOptions {
+        minimum_fraction_digits: Some(3),
+        maximum_fraction_digits: Some(1),
+        ..FormatNumberOptions::default()
+    };
+    assert_eq!(umt_format_number(1.5, &options), "1.500");
+}

--- a/package/umt_rust/tests/number/test_format_number.rs
+++ b/package/umt_rust/tests/number/test_format_number.rs
@@ -92,7 +92,6 @@ fn should_truncate_with_half_away_from_zero_rounding() {
         maximum_fraction_digits: Some(2),
         ..FormatNumberOptions::default()
     };
-    // 0.125 under half-away-from-zero rounds up to 0.13 (not banker's 0.12).
     assert_eq!(umt_format_number(0.125, &options), "0.13");
     assert_eq!(umt_format_number(-0.125, &options), "-0.13");
 }


### PR DESCRIPTION
## Summary
Implements locale-aware number formatting in the Rust package, porting the functionality from the TypeScript reference implementation and keeping it in sync with the Python port.

## Key Changes
- **New module**: `package/umt_rust/src/number/format_number.rs` with complete number formatting implementation
  - `FormatStyle` enum supporting Decimal, Currency, and Percent styles
  - `FormatNumberOptions` struct mirroring the TypeScript `FormatNumberOptions` interface
  - `umt_format_number()` function that formats numbers according to locale and style options
  - `umt_format_number_default()` convenience wrapper for default formatting

- **Locale support**: Handles en-US, de-DE, fr-FR and their language-only variants with appropriate thousands separators and decimal points
  - en-US/en-GB/ja-JP: comma thousands separator, period decimal
  - de-DE/it-IT/es-ES: period thousands separator, comma decimal
  - fr-FR: non-breaking space thousands separator, comma decimal
  - Unknown locales fall back to en-US semantics

- **Currency support**: Recognizes USD, EUR, GBP, JPY, CNY, and KRW with proper symbols; unknown currencies use ISO code with non-breaking space

- **Formatting features**:
  - Half-away-from-zero rounding (matching `Intl.NumberFormat` behavior)
  - Configurable minimum and maximum fraction digits
  - Special handling for zero-fraction currencies (JPY, KRW)
  - Proper sign handling for negative numbers
  - Automatic lifting of max fraction digits to meet minimum requirements

- **Comprehensive test suite**: `package/umt_rust/tests/number/test_format_number.rs` with 11 tests covering all major formatting scenarios

## Implementation Details
- Uses `f64::round()` for half-away-from-zero rounding semantics
- Implements thousands separator insertion via digit-by-digit string building
- Fraction digit handling via string formatting and trimming to avoid floating-point precision issues
- All locale and currency data matches the Python port for cross-package consistency

https://claude.ai/code/session_01PJjDWxvUC4mp9Ewzg46z2r