### PR TITLE
Add comprehensive prototype pollution defense integration tests

### DIFF
--- a/package/main/src/tests/integration/Object/prototype-pollution.test.ts
+++ b/package/main/src/tests/integration/Object/prototype-pollution.test.ts
@@ -1,0 +1,277 @@
+import { deepClone } from "@/Object/deepClone";
+import { getObjectsCommon } from "@/Object/getObjectsCommon";
+import { getObjectsDiff } from "@/Object/getObjectsDiff";
+import { mapKeys } from "@/Object/mapKeys";
+import { mapValues } from "@/Object/mapValues";
+import { merge } from "@/Object/merge";
+import { mergeDeep } from "@/Object/mergeDeep";
+import { pick } from "@/Object/pick";
+import { pickDeep } from "@/Object/pickDeep";
+import { removePrototype } from "@/Object/removePrototype";
+import { removePrototypeDeep } from "@/Object/removePrototypeDeep";
+import { removePrototypeMap } from "@/Object/removePrototypeMap";
+import { removePrototypeMapDeep } from "@/Object/removePrototypeMapDeep";
+
+type PollutionProbe = {
+  leaked?: unknown;
+  injected?: unknown;
+  polluted?: unknown;
+};
+
+/**
+ * Integration tests for the prototype-pollution defense chain.
+ *
+ * These tests verify two things together:
+ *   1. That naive user code (equivalent to popular vulnerable patterns)
+ *      actually pollutes the global Object.prototype when fed JSON-parsed
+ *      attacker payloads. This proves the attack surface is real.
+ *   2. That combining the library's sanitizers with the Object helpers
+ *      neutralizes the attack end-to-end.
+ */
+describe("Integration test for prototype pollution defense", () => {
+  // All tests that pollute Object.prototype must clean up in afterEach —
+  // otherwise the contamination leaks to other test files.
+  afterEach(() => {
+    Reflect.deleteProperty(Object.prototype, "leaked");
+    Reflect.deleteProperty(Object.prototype, "injected");
+    Reflect.deleteProperty(Object.prototype, "polluted");
+  });
+
+  const naiveDeepMerge = (
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+  ): Record<string, unknown> => {
+    for (const key of Object.keys(source)) {
+      const sourceValue = source[key];
+      const targetValue = target[key];
+      const targetIsObjectLike =
+        targetValue !== null &&
+        (typeof targetValue === "object" || typeof targetValue === "function");
+      if (
+        sourceValue !== null &&
+        typeof sourceValue === "object" &&
+        !Array.isArray(sourceValue) &&
+        targetIsObjectLike
+      ) {
+        naiveDeepMerge(
+          targetValue as Record<string, unknown>,
+          sourceValue as Record<string, unknown>,
+        );
+      } else {
+        target[key] = sourceValue;
+      }
+    }
+    return target;
+  };
+
+  it("should globally pollute via __proto__ with a naive deep merge, and prevent it with removePrototypeDeep + mergeDeep", () => {
+    const payload = JSON.parse('{"__proto__":{"leaked":"yes"},"ok":1}');
+
+    const victim: Record<string, unknown> = {};
+    naiveDeepMerge(victim, payload);
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBe("yes");
+
+    Reflect.deleteProperty(Object.prototype, "leaked");
+
+    const safe = mergeDeep({}, removePrototypeDeep(payload)) as PollutionProbe;
+    const afterSafe: PollutionProbe = {};
+    expect(afterSafe.leaked).toBeUndefined();
+    expect(safe.leaked).toBeUndefined();
+    expect(safe).toEqual({ ok: 1 });
+  });
+
+  it("should globally pollute via constructor.prototype, and prevent it via removePrototypeDeep", () => {
+    const payload = JSON.parse(
+      '{"constructor":{"prototype":{"injected":"deep"}},"ok":1}',
+    );
+
+    const victim: Record<string, unknown> = {};
+    naiveDeepMerge(victim, payload);
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.injected).toBe("deep");
+
+    Reflect.deleteProperty(Object.prototype, "injected");
+
+    const sanitized = removePrototypeDeep(payload);
+    const afterVictim: Record<string, unknown> = {};
+    naiveDeepMerge(afterVictim, sanitized);
+    const afterSafe: PollutionProbe = {};
+    expect(afterSafe.injected).toBeUndefined();
+    expect(sanitized).toEqual({ ok: 1 });
+  });
+
+  it("should sanitize an entire request batch before merging configs", () => {
+    const batch = [
+      JSON.parse(
+        '{"__proto__":{"leaked":"req1"},"app":{"name":"MyApp","flags":{"a":true}}}',
+      ),
+      JSON.parse('{"app":{"flags":{"b":true},"__proto__":{"leaked":"req2"}}}'),
+      JSON.parse(
+        '{"constructor":{"prototype":{"injected":"req3"}},"app":{"version":"2.0"}}',
+      ),
+    ];
+
+    const sanitized = removePrototypeMapDeep(batch);
+    const merged = mergeDeep({}, ...sanitized);
+
+    expect(merged).toEqual({
+      app: {
+        name: "MyApp",
+        flags: { a: true, b: true },
+        version: "2.0",
+      },
+    });
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+    expect(innocent.injected).toBeUndefined();
+  });
+
+  it("should keep deepClone output free of polluted prototypes when the payload is sanitized first", () => {
+    const payload = JSON.parse(
+      '{"a":{"__proto__":{"leaked":"x"},"value":1},"b":[{"__proto__":{"leaked":"y"},"item":2}]}',
+    );
+
+    const cloned = deepClone(removePrototypeDeep(payload));
+
+    expect(cloned).toEqual({ a: { value: 1 }, b: [{ item: 2 }] });
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+  });
+
+  it("should chain pick -> mergeDeep -> deepClone safely on user-controlled input", () => {
+    const userInput = JSON.parse(
+      '{"__proto__":{"leaked":"pick"},"name":"Alice","age":30,"secret":"top"}',
+    );
+
+    const visible = pick(removePrototype(userInput), "name", "age");
+    const profile = mergeDeep({ role: "user" }, visible);
+    const snapshot = deepClone(profile);
+
+    expect(snapshot).toEqual({ role: "user", name: "Alice", age: 30 });
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+  });
+
+  it("should safely extract nested fields with pickDeep when input is sanitized", () => {
+    const payload = JSON.parse(
+      '{"user":{"__proto__":{"leaked":"nested"},"profile":{"name":"Bob","email":"bob@example.com"}}}',
+    );
+
+    const sanitized = removePrototypeDeep(payload) as {
+      user: { profile: { name: string; email: string } };
+    };
+    const result = pickDeep(sanitized, "user.profile.name");
+
+    expect(result).toEqual({ user: { profile: { name: "Bob" } } });
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+  });
+
+  it("should not leak across helper boundaries: shallow sanitization is not enough for deep payloads", () => {
+    const payload = JSON.parse(
+      '{"outer":{"__proto__":{"leaked":"deep"},"value":1}}',
+    );
+
+    // Shallow `removePrototype` only clears the top-level dangerous keys;
+    // the nested __proto__ survives. Demonstrates why removePrototypeDeep
+    // is required when the payload is deeper than one level.
+    const shallow = removePrototype(payload) as {
+      outer: Record<string, unknown>;
+    };
+    expect(Object.hasOwn(shallow.outer, "__proto__")).toBe(true);
+
+    // Deep sanitization removes all of them.
+    const deep = removePrototypeDeep(payload) as {
+      outer: Record<string, unknown>;
+    };
+    expect(Object.hasOwn(deep.outer, "__proto__")).toBe(false);
+  });
+
+  it("should combine removePrototypeMap with merge for arrays of shallow user inputs", () => {
+    const entries = [
+      JSON.parse('{"__proto__":{"leaked":"a"},"k":"value1"}'),
+      JSON.parse('{"constructor":{"polluted":true},"k":"value2"}'),
+      JSON.parse('{"prototype":{"hack":true},"k":"value3"}'),
+    ];
+
+    const sanitized = removePrototypeMap(entries);
+    const combined = merge({}, ...sanitized);
+
+    expect(combined).toEqual({ k: "value3" });
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+  });
+
+  it("should keep diff and common helpers safe when combined with removePrototypeDeep", () => {
+    const a = JSON.parse(
+      '{"__proto__":{"leaked":"a"},"kept":1,"changed":"x","nested":{"only":"a"}}',
+    );
+    const b = JSON.parse(
+      '{"__proto__":{"leaked":"b"},"kept":1,"changed":"y","nested":{"shared":2}}',
+    );
+
+    const safeA = removePrototypeDeep(a);
+    const safeB = removePrototypeDeep(b);
+
+    const common = getObjectsCommon(safeA, safeB);
+    const diff = getObjectsDiff(safeA, safeB);
+
+    expect(common).toEqual({ kept: 1 });
+    expect(diff).toEqual({
+      changed: "y",
+      nested: { only: "a", shared: 2 },
+    });
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+  });
+
+  it("should ensure mapKeys/mapValues output never exposes __proto__ as an own key with sanitized input", () => {
+    const payload = JSON.parse('{"__proto__":{"leaked":"x"},"a":1,"b":2}');
+
+    const sanitized = removePrototype(payload);
+    const renamed = mapKeys(sanitized, (_value, key) => key.toUpperCase());
+    const doubled = mapValues(renamed, (value) => (value as number) * 2);
+
+    expect(doubled).toEqual({ A: 2, B: 4 });
+    expect(Object.hasOwn(doubled, "__proto__")).toBe(false);
+
+    const innocent: PollutionProbe = {};
+    expect(innocent.leaked).toBeUndefined();
+  });
+
+  it("should catch a real-world lodash-style deep merge scenario end-to-end", () => {
+    // Simulates a config endpoint that merges user overrides into defaults.
+    const defaults = {
+      service: { port: 3000, features: { cache: true } },
+    };
+    const userOverrides = JSON.parse(
+      '{"service":{"port":8080,"__proto__":{"leaked":"port"}},"__proto__":{"leaked":"root"}}',
+    );
+
+    // Without sanitization, a naive deep merge would pollute Object.prototype.
+    const victim: Record<string, unknown> = {};
+    naiveDeepMerge(victim, userOverrides);
+    const innocentDuringAttack: PollutionProbe = {};
+    expect(innocentDuringAttack.leaked).toBeDefined();
+
+    Reflect.deleteProperty(Object.prototype, "leaked");
+
+    // With sanitization, no leak.
+    const safeConfig = mergeDeep(defaults, removePrototypeDeep(userOverrides));
+    expect(safeConfig).toEqual({
+      service: { port: 8080, features: { cache: true } },
+    });
+
+    const innocentAfterSafe: PollutionProbe = {};
+    expect(innocentAfterSafe.leaked).toBeUndefined();
+  });
+});

--- a/package/main/src/tests/unit/Object/deepClone.test.ts
+++ b/package/main/src/tests/unit/Object/deepClone.test.ts
@@ -90,4 +90,136 @@ describe("deepClone", () => {
     // Should not overwrite constructor
     expect(cloned.constructor).toBe(Object);
   });
+
+  it("should demonstrate that cloning an unsanitized payload locally pollutes the clone", () => {
+    const payload = JSON.parse('{"__proto__":{"injected":"local"},"safe":1}');
+
+    const polluted = deepClone(payload) as {
+      injected?: unknown;
+      safe?: unknown;
+    };
+
+    // JSON.parse keeps __proto__ as an own property; deepClone uses Object.keys
+    // and assigns via bracket notation, which triggers the __proto__ setter on
+    // the freshly-created result, replacing its prototype locally.
+    expect(Object.getPrototypeOf(polluted)).toEqual({ injected: "local" });
+    expect(polluted.injected).toBe("local");
+    expect(polluted.safe).toBe(1);
+
+    // Global Object.prototype remains clean.
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).injected,
+    ).toBeUndefined();
+
+    // After sanitization the clone is clean and has no injected prototype.
+    const safe = deepClone(removePrototype(payload)) as { injected?: unknown };
+    expect(Object.getPrototypeOf(safe)).toBe(Object.prototype);
+    expect(safe.injected).toBeUndefined();
+  });
+
+  it("should deep clone deeply nested arrays and objects together", () => {
+    const original = {
+      list: [{ tags: ["a", "b"] }, { tags: ["c", "d"] }],
+    };
+
+    const cloned = deepClone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned.list).not.toBe(original.list);
+    expect(cloned.list[0]).not.toBe(original.list[0]);
+    expect(cloned.list[0].tags).not.toBe(original.list[0].tags);
+    cloned.list[0].tags.push("z");
+    expect(original.list[0].tags).toEqual(["a", "b"]);
+  });
+
+  it("should clone Map entries recursively", () => {
+    const nested = { inner: 1 };
+    const original = new Map<string, unknown>([["a", nested]]);
+
+    const cloned = deepClone(original);
+
+    const clonedNested = cloned.get("a") as { inner: number };
+    expect(clonedNested).toEqual(nested);
+    expect(clonedNested).not.toBe(nested);
+  });
+
+  it("should clone Set members recursively", () => {
+    const nested = { inner: 1 };
+    const original = new Set<unknown>([nested]);
+
+    const cloned = deepClone(original);
+
+    const [clonedNested] = [...cloned] as { inner: number }[];
+    expect(clonedNested).toEqual(nested);
+    expect(clonedNested).not.toBe(nested);
+  });
+
+  it("should preserve the RegExp lastIndex-independent state (new instance)", () => {
+    const pattern = /x/g;
+    pattern.lastIndex = 5;
+    const cloned = deepClone({ pattern });
+
+    expect(cloned.pattern.source).toBe("x");
+    expect(cloned.pattern.flags).toBe("g");
+    expect(cloned.pattern.lastIndex).toBe(0);
+  });
+
+  it("should produce independent clones for multiple references to the same nested object", () => {
+    const shared = { x: 1 };
+    const original = { a: shared, b: shared };
+
+    const cloned = deepClone(original);
+
+    expect(cloned.a).toEqual({ x: 1 });
+    expect(cloned.b).toEqual({ x: 1 });
+    // deepClone does not deduplicate references — each occurrence becomes a
+    // distinct copy. Callers should be aware of this trade-off.
+    expect(cloned.a).not.toBe(cloned.b);
+    cloned.a.x = 99;
+    expect(cloned.b.x).toBe(1);
+  });
+
+  it("should not copy symbol-keyed properties", () => {
+    const symbol = Symbol("k");
+    const original = { a: 1, [symbol]: "value" } as Record<string, unknown>;
+
+    const cloned = deepClone(original);
+
+    expect(Object.getOwnPropertySymbols(cloned)).toHaveLength(0);
+    expect((cloned as Record<symbol, unknown>)[symbol]).toBeUndefined();
+  });
+
+  it("should not copy inherited enumerable properties", () => {
+    const parent = { inherited: "value" };
+    const child = Object.create(parent);
+    child.own = 1;
+
+    const cloned = deepClone(child) as Record<string, unknown>;
+
+    expect(Object.hasOwn(cloned, "own")).toBe(true);
+    expect(Object.hasOwn(cloned, "inherited")).toBe(false);
+  });
+
+  it("should handle undefined input", () => {
+    expect(deepClone(undefined)).toBeUndefined();
+  });
+
+  it("should clone an empty object and empty array", () => {
+    expect(deepClone({})).toEqual({});
+    expect(deepClone([])).toEqual([]);
+  });
+
+  it("should clone Date values that hold sub-properties by producing a Date (sub-props not copied)", () => {
+    const date = new Date("2024-01-01") as Date & { tag?: string };
+    date.tag = "extra";
+
+    const cloned = deepClone({ date }).date as Date & { tag?: string };
+
+    expect(cloned).toBeInstanceOf(Date);
+    expect(cloned.getTime()).toBe(date.getTime());
+    expect(cloned).not.toBe(date);
+    // Ad-hoc properties on Date are not preserved — documents the behavior.
+    expect(cloned.tag).toBeUndefined();
+  });
 });

--- a/package/main/src/tests/unit/Object/getObjectsCommon.test.ts
+++ b/package/main/src/tests/unit/Object/getObjectsCommon.test.ts
@@ -137,4 +137,87 @@ describe("getObjectsCommon", () => {
     // biome-ignore lint/suspicious/noExplicitAny: ignore
     expect((result as any).polluted).toBeUndefined();
   });
+
+  test("should return an empty result when either object lacks a key present in the other", () => {
+    expect(getObjectsCommon({ a: 1, b: 2 }, { a: 1 })).toEqual({ a: 1 });
+    expect(getObjectsCommon({ a: 1 }, { a: 1, b: 2 })).toEqual({ a: 1 });
+  });
+
+  test("should handle NaN reference equality (=== returns false for NaN)", () => {
+    expect(getObjectsCommon({ a: Number.NaN }, { a: Number.NaN })).toEqual({});
+  });
+
+  test("should compare using strict equality (no coercion)", () => {
+    expect(
+      getObjectsCommon(
+        { a: 1 } as Record<string, unknown>,
+        { a: "1" } as Record<string, unknown>,
+      ),
+    ).toEqual({});
+    expect(
+      getObjectsCommon(
+        { a: true } as Record<string, unknown>,
+        { a: 1 } as Record<string, unknown>,
+      ),
+    ).toEqual({});
+  });
+
+  test("should not copy inherited keys from the first object", () => {
+    const parent = { inherited: 1 };
+    const child: { own?: number } = Object.create(parent);
+    child.own = 2;
+
+    const result = getObjectsCommon(child as Record<string, unknown>, {
+      own: 2,
+      inherited: 1,
+    });
+
+    // getObjectsCommon iterates Object.entries, which only sees own enumerable
+    // keys on the first argument.
+    expect(Object.hasOwn(result, "own")).toBe(true);
+    expect(Object.hasOwn(result, "inherited")).toBe(false);
+  });
+
+  test("should return shared indices when comparing a plain object and an array (top-level own keys match)", () => {
+    // getObjectsCommon walks own keys and compares values strictly, so numeric
+    // string indices on a plain object that match the same positions on an
+    // array are treated as common pairs. This documents the actual behavior.
+    const object = { "0": "a", "1": "b" };
+    const array = ["a", "b"] as unknown as Record<string, unknown>;
+    expect(getObjectsCommon(object, array)).toEqual({ "0": "a", "1": "b" });
+  });
+
+  test("should skip __proto__ keys on plain objects passed unsanitized", () => {
+    // Object.entries does include JSON-parsed __proto__ own keys. The library
+    // does NOT filter dangerous keys itself — but since values are compared
+    // strictly and written via bracket notation on a result=`{}`, the result
+    // never exposes __proto__ as an own key (primitive rejected by setter;
+    // objects fall into the recursion path and assign to prototype only).
+    const obj1 = JSON.parse('{"__proto__":{"polluted":true},"a":1}');
+    const obj2 = JSON.parse('{"__proto__":{"polluted":true},"a":1}');
+
+    const result = getObjectsCommon(obj1, obj2) as { a?: number };
+
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(result.a).toBe(1);
+  });
+
+  test("should handle many objects efficiently", () => {
+    const objects = Array.from({ length: 20 }, () => ({
+      shared: 1,
+      unique: Math.random(),
+    }));
+
+    const result = getObjectsCommon(objects[0], ...objects.slice(1));
+
+    expect(result).toEqual({ shared: 1 });
+  });
+
+  test("should return a new object, not the original", () => {
+    const source = { a: 1, b: 2 };
+    const result = getObjectsCommon(source);
+
+    expect(result).toEqual(source);
+    expect(result).not.toBe(source);
+  });
 });

--- a/package/main/src/tests/unit/Object/getObjectsDiff.test.ts
+++ b/package/main/src/tests/unit/Object/getObjectsDiff.test.ts
@@ -133,4 +133,95 @@ describe("getObjectsDiff", () => {
     // biome-ignore lint/suspicious/noExplicitAny: ignore
     expect((result as any).polluted).toBeUndefined();
   });
+
+  test("should compare using strict equality (no type coercion)", () => {
+    expect(
+      getObjectsDiff(
+        { a: 1 } as Record<string, unknown>,
+        { a: "1" } as Record<string, unknown>,
+      ),
+    ).toEqual({ a: "1" });
+    expect(
+      getObjectsDiff(
+        { a: true } as Record<string, unknown>,
+        { a: 1 } as Record<string, unknown>,
+      ),
+    ).toEqual({ a: 1 });
+  });
+
+  test("should handle NaN with SameValueZero semantics (NaN equals NaN in the internal Map)", () => {
+    // Map keys use SameValueZero, which equates NaN with NaN. As a result,
+    // two identical NaN entries count as shared rather than unique.
+    expect(getObjectsDiff({ a: Number.NaN }, { a: Number.NaN })).toEqual({});
+  });
+
+  test("should include keys present in only some of the objects", () => {
+    expect(
+      getObjectsDiff(
+        { a: 1, only1: "x" },
+        { a: 1, only2: "y" },
+        { a: 1, only3: "z" },
+      ),
+    ).toEqual({ only1: "x", only2: "y", only3: "z" });
+  });
+
+  test("should keep the last unique value when 4+ objects have conflicting values", () => {
+    expect(getObjectsDiff({ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 })).toEqual({
+      x: 4,
+    });
+  });
+
+  test("should not include a key when all values are identical across many objects", () => {
+    expect(getObjectsDiff({ x: 1 }, { x: 1 }, { x: 1 }, { x: 1 })).toEqual({});
+  });
+
+  test("should not include a key when exactly one value is shared and one is unique (the unique wins)", () => {
+    expect(getObjectsDiff({ x: 1 }, { x: 1 }, { x: 2 })).toEqual({ x: 2 });
+  });
+
+  test("should pair shared values correctly across objects even when the shared value is not first", () => {
+    expect(getObjectsDiff({ x: 3 }, { x: 1 }, { x: 1 })).toEqual({ x: 3 });
+  });
+
+  test("should handle keys that exist in only a subset of the inputs", () => {
+    expect(getObjectsDiff({ a: 1 }, { b: 2 }, { a: 1, b: 2 })).toEqual({});
+    expect(getObjectsDiff({ a: 1 }, { b: 2 }, { a: 3, b: 4 })).toEqual({
+      a: 3,
+      b: 4,
+    });
+  });
+
+  test("should iterate own enumerable keys only (skip inherited)", () => {
+    const parent = { inherited: 1 };
+    const child: { own?: number } = Object.create(parent);
+    child.own = 2;
+
+    expect(
+      getObjectsDiff(child as Record<string, unknown>, { own: 2, extra: 9 }),
+    ).toEqual({
+      extra: 9,
+    });
+  });
+
+  test("should return a new object, not the original", () => {
+    const source = { a: 1 };
+    const result = getObjectsDiff(source);
+
+    expect(result).toEqual(source);
+    expect(result).not.toBe(source);
+  });
+
+  test("should pass through unsanitized __proto__ as own key (diff does not filter)", () => {
+    // Documents the library's scope: getObjectsDiff does not filter dangerous
+    // keys itself. Callers should sanitize with removePrototype* first.
+    const obj1 = JSON.parse('{"__proto__":{"polluted":true},"a":1}');
+    const obj2 = { a: 1 };
+
+    const result = getObjectsDiff(obj1, obj2) as Record<string, unknown>;
+
+    // __proto__ is present in obj1 only, so it becomes a unique value. The
+    // assignment goes through the setter though, so it does not appear as an
+    // own key of the result.
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/Object/has.test.ts
+++ b/package/main/src/tests/unit/Object/has.test.ts
@@ -61,4 +61,75 @@ describe("has", () => {
     expect(has(obj, ["prototype"])).toBe(false);
     expect(has(obj, ["a", "__proto__"])).toBe(false);
   });
+
+  it("should return true when the value at the path is falsy but the key exists", () => {
+    expect(has({ a: null }, "a")).toBe(true);
+    expect(has({ a: undefined }, "a")).toBe(true);
+    expect(has({ a: 0 }, "a")).toBe(true);
+    expect(has({ a: false }, "a")).toBe(true);
+    expect(has({ a: "" }, "a")).toBe(true);
+  });
+
+  it("should return false when traversing through null or undefined", () => {
+    expect(has({ a: null }, "a.b")).toBe(false);
+    expect(has({ a: undefined }, "a.b")).toBe(false);
+  });
+
+  it("should distinguish own properties from inherited ones", () => {
+    const parent = { inherited: 1 };
+    const child = Object.create(parent);
+    child.own = 2;
+
+    expect(has(child, "own")).toBe(true);
+    // Object.hasOwn — inherited keys must NOT be reported.
+    expect(has(child, "inherited")).toBe(false);
+  });
+
+  it("should handle deeply nested paths", () => {
+    const object = { a: { b: { c: { d: { e: 1 } } } } };
+    expect(has(object, "a.b.c.d.e")).toBe(true);
+    expect(has(object, "a.b.c.d.f")).toBe(false);
+    expect(has(object, "a.b.c.d.e.f")).toBe(false);
+  });
+
+  it("should demonstrate that plain `in` operator would incorrectly report inherited keys", () => {
+    const object = { a: 1 } as Record<string, unknown>;
+
+    // Using `in` walks the prototype chain — hasOwn-based `has` must not.
+    expect("toString" in object).toBe(true);
+    expect(has(object, "toString")).toBe(false);
+    expect(has(object, ["toString"])).toBe(false);
+  });
+
+  it("should report __proto__ as present only when it is an own property (JSON.parse)", () => {
+    // Documents the actual semantic: `has` uses Object.hasOwn, so a
+    // JSON.parse-created __proto__ own key is visible. Callers sanitizing
+    // untrusted input should use removePrototype* before calling has.
+    const malicious = JSON.parse('{"__proto__":{"polluted":true}}');
+    expect(has(malicious, "__proto__")).toBe(true);
+
+    // A plain object has __proto__ only via the prototype chain, not as own.
+    expect(has({ a: 1 }, "__proto__")).toBe(false);
+  });
+
+  it("should handle a path that steps off a primitive", () => {
+    const object = { a: 1 } as Record<string, unknown>;
+    expect(has(object, "a.b")).toBe(false);
+    expect(has(object, ["a", "b"])).toBe(false);
+  });
+
+  it("should accept an object as the last segment", () => {
+    const object = { a: { b: { c: 1 } } };
+    expect(has(object, "a.b")).toBe(true);
+    expect(has(object, ["a", "b"])).toBe(true);
+  });
+
+  it("should not match numeric indices as property names unless they are own keys", () => {
+    const array = [10, 20, 30];
+    const wrapper = { list: array } as Record<string, unknown>;
+    expect(has(wrapper, "list.0")).toBe(true);
+    expect(has(wrapper, "list.3")).toBe(false);
+    // Inherited Array prototype methods must not be reported.
+    expect(has(wrapper, "list.push")).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/Object/isEmpty.test.ts
+++ b/package/main/src/tests/unit/Object/isEmpty.test.ts
@@ -79,4 +79,58 @@ describe("isEmpty", () => {
 
     expect(result).toBe(false);
   });
+
+  it("should return true for Object.create(null) with no own keys", () => {
+    const object = Object.create(null);
+    expect(isEmpty(object)).toBe(true);
+  });
+
+  it("should return false for Object.create(null) with own keys", () => {
+    const object = Object.create(null);
+    object.a = 1;
+    expect(isEmpty(object)).toBe(false);
+  });
+
+  it("should return true when only non-enumerable own keys exist", () => {
+    const object = {};
+    Object.defineProperty(object, "hidden", {
+      value: 1,
+      enumerable: false,
+    });
+    expect(isEmpty(object)).toBe(true);
+  });
+
+  it("should return false when only a non-enumerable symbol property exists", () => {
+    const object = {};
+    const symbol = Symbol("hidden");
+    Object.defineProperty(object, symbol, {
+      value: 1,
+      enumerable: false,
+    });
+    // getOwnPropertySymbols returns both enumerable and non-enumerable symbols.
+    expect(isEmpty(object)).toBe(false);
+  });
+
+  it("should return false when a string key and a symbol key coexist", () => {
+    const object = { a: 1, [Symbol("b")]: 2 };
+    expect(isEmpty(object)).toBe(false);
+  });
+
+  it("should not be confused by a polluted Object.prototype", () => {
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: controlled pollution
+      (Object.prototype as any).injected = "bad";
+      expect(isEmpty({})).toBe(true);
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "injected");
+    }
+  });
+
+  it("should return false for an object with a single property after removing it and adding a new one", () => {
+    const object: { a?: number; b?: number } = { a: 1 };
+    Reflect.deleteProperty(object, "a");
+    expect(isEmpty(object as Record<string, unknown>)).toBe(true);
+    object.b = 2;
+    expect(isEmpty(object as Record<string, unknown>)).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/Object/isPlainObject.test.ts
+++ b/package/main/src/tests/unit/Object/isPlainObject.test.ts
@@ -62,4 +62,86 @@ describe("isPlainObject", () => {
     ).toBe(false);
     expect(isPlainObject(() => 1)).toBe(false);
   });
+
+  it("should return true for JSON.parse output (which has an own __proto__ key)", () => {
+    // JSON.parse produces plain objects with Object.prototype chain.
+    // Malicious payloads rely on this being recognized as a plain object.
+    expect(isPlainObject(JSON.parse("{}"))).toBe(true);
+    expect(isPlainObject(JSON.parse('{"a":1}'))).toBe(true);
+    expect(isPlainObject(JSON.parse('{"__proto__":{"polluted":true}}'))).toBe(
+      true,
+    );
+  });
+
+  it("should return true after Object.setPrototypeOf(obj, null)", () => {
+    const object = { a: 1 };
+    Object.setPrototypeOf(object, null);
+    expect(isPlainObject(object)).toBe(true);
+  });
+
+  it("should return true for deep plain-object chains", () => {
+    const grandparent = { level: 1 };
+    const parent = Object.create(grandparent);
+    const child = Object.create(parent);
+
+    expect(isPlainObject(grandparent)).toBe(true);
+    expect(isPlainObject(parent)).toBe(true);
+    expect(isPlainObject(child)).toBe(true);
+  });
+
+  it("should return false for Error instances", () => {
+    expect(isPlainObject(new Error("boom"))).toBe(false);
+    expect(isPlainObject(new TypeError("boom"))).toBe(false);
+  });
+
+  it("should return false for Promises", () => {
+    const promise = Promise.resolve(1);
+    expect(isPlainObject(promise)).toBe(false);
+  });
+
+  it("should return false for typed arrays and ArrayBuffer", () => {
+    expect(isPlainObject(new Uint8Array())).toBe(false);
+    expect(isPlainObject(new Int32Array())).toBe(false);
+    expect(isPlainObject(new ArrayBuffer(0))).toBe(false);
+  });
+
+  it("should return false for boxed primitive wrappers", () => {
+    // biome-ignore lint/style/useConsistentBuiltinInstantiation: testing boxed wrappers
+    expect(isPlainObject(new Number(1))).toBe(false);
+    // biome-ignore lint/style/useConsistentBuiltinInstantiation: testing boxed wrappers
+    expect(isPlainObject(new String("x"))).toBe(false);
+    // biome-ignore lint/style/useConsistentBuiltinInstantiation: testing boxed wrappers
+    expect(isPlainObject(new Boolean(true))).toBe(false);
+  });
+
+  it("should return false for WeakMap and WeakSet", () => {
+    expect(isPlainObject(new WeakMap())).toBe(false);
+    expect(isPlainObject(new WeakSet())).toBe(false);
+  });
+
+  it("should return true for an object whose constructor property shadows Object", () => {
+    // Own constructor property should NOT confuse isPlainObject — the check
+    // looks at the prototype's constructor, not the own key.
+    const object = { constructor: "not a function" };
+    expect(isPlainObject(object)).toBe(true);
+  });
+
+  it("should return true for Object.create(Object.prototype)", () => {
+    expect(isPlainObject(Object.create(Object.prototype))).toBe(true);
+  });
+
+  it("should return false for generator functions and their instances", () => {
+    function* gen() {
+      yield 1;
+    }
+    expect(isPlainObject(gen)).toBe(false);
+    expect(isPlainObject(gen())).toBe(false);
+  });
+
+  it("should return false for objects created via class inheriting from Object", () => {
+    class Extended extends Object {
+      x = 1;
+    }
+    expect(isPlainObject(new Extended())).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/Object/keyBy.test.ts
+++ b/package/main/src/tests/unit/Object/keyBy.test.ts
@@ -108,4 +108,99 @@ describe("keyBy", () => {
     expect(output).toStrictEqual({ safe: { id: "safe", name: "ok" } });
     expect(Object.hasOwn(output, "__proto__")).toBe(false);
   });
+
+  it("should preserve reference equality to the original items", () => {
+    const a = { id: "a", payload: { big: "data" } };
+    const b = { id: "b", payload: { big: "other" } };
+
+    const output = keyBy([a, b], "id") as {
+      a?: typeof a;
+      b?: typeof b;
+    };
+
+    expect(output.a).toBe(a);
+    expect(output.b).toBe(b);
+  });
+
+  it("should support symbol keys produced by iteratee", () => {
+    const sym = Symbol("k");
+    const input = [{ value: 1 }, { value: 2 }];
+
+    const output = keyBy(input, () => sym);
+
+    // Successive items with the same key overwrite earlier ones.
+    expect(output[sym]).toEqual({ value: 2 });
+  });
+
+  it("should support number keys produced by iteratee and coerce them to string own keys", () => {
+    const input = [{ n: 1 }, { n: 2 }];
+    const output = keyBy(input, "n");
+
+    expect(Object.keys(output)).toEqual(["1", "2"]);
+    expect(output[1]).toEqual({ n: 1 });
+    expect(output[2]).toEqual({ n: 2 });
+  });
+
+  it("should demonstrate local prototype pollution with a naive grouping, and confirm keyBy never exposes __proto__ as an own key", () => {
+    // A naive grouping that assigns into a plain `{}` without filtering
+    // triggers the __proto__ setter and locally replaces the result's
+    // prototype with the attacker-controlled object.
+    const input = [
+      { id: "__proto__", value: { injected: "bad" } },
+      { id: "safe", value: 1 },
+    ];
+
+    const naive: Record<string, unknown> = {};
+    for (const item of input) {
+      naive[item.id] = item.value;
+    }
+    expect(Object.getPrototypeOf(naive)).toEqual({ injected: "bad" });
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect((naive as any).injected).toBe("bad");
+
+    // keyBy suffers the same local prototype replacement (documented here),
+    // but its *own* keys never contain the dangerous `__proto__` entry — so
+    // the shape of the returned object is what consumers would expect.
+    const safe = keyBy(input, "id") as Record<string, unknown>;
+    expect(Object.hasOwn(safe, "__proto__")).toBe(false);
+    expect(Object.keys(safe)).toEqual(["safe"]);
+  });
+
+  it("should allow keys that collide with Object.prototype names as shadowing own keys", () => {
+    const input = [
+      { id: "toString", tag: "a" },
+      { id: "hasOwnProperty", tag: "b" },
+      { id: "constructor", tag: "c" },
+    ];
+
+    const output = keyBy(input, "id") as Record<string, unknown>;
+
+    // `toString`, `hasOwnProperty`, and `constructor` are safe as own keys —
+    // they simply shadow the inherited methods within the output.
+    expect(Object.hasOwn(output, "toString")).toBe(true);
+    expect(Object.hasOwn(output, "hasOwnProperty")).toBe(true);
+    expect(Object.hasOwn(output, "constructor")).toBe(true);
+    expect(output.toString).toEqual({ id: "toString", tag: "a" });
+    expect(output.hasOwnProperty).toEqual({
+      id: "hasOwnProperty",
+      tag: "b",
+    });
+    expect(output.constructor).toEqual({ id: "constructor", tag: "c" });
+  });
+
+  it("should return an object whose prototype is Object.prototype when no __proto__ key is produced", () => {
+    const output = keyBy([{ id: "a" }], "id");
+    expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+  });
+
+  it("should treat `prototype` and `constructor` as regular own keys (keyBy only guards __proto__)", () => {
+    // Documents the library's scope: only __proto__ is blocked (by the JS
+    // language itself via the setter). `prototype` and `constructor` become
+    // regular own keys and may collide with usage expectations — callers who
+    // accept untrusted iteratee outputs should sanitize further.
+    const output = keyBy([{ id: "prototype" }, { id: "constructor" }], "id");
+
+    expect(Object.hasOwn(output, "prototype")).toBe(true);
+    expect(Object.hasOwn(output, "constructor")).toBe(true);
+  });
 });

--- a/package/main/src/tests/unit/Object/mapKeys.test.ts
+++ b/package/main/src/tests/unit/Object/mapKeys.test.ts
@@ -41,4 +41,94 @@ describe("mapKeys", () => {
     expect(result).toEqual({});
     expect(Object.hasOwn(result, "__proto__")).toBe(false);
   });
+
+  it("should preserve the order of the source's own keys", () => {
+    const result = mapKeys({ c: 1, a: 2, b: 3 }, (_value, key) =>
+      key.toUpperCase(),
+    );
+    expect(Object.keys(result)).toEqual(["C", "A", "B"]);
+  });
+
+  it("should not touch global Object.prototype when the payload contains __proto__", () => {
+    const malicious = JSON.parse('{"__proto__":{"injected":"x"},"a":1}');
+    mapKeys(malicious, (_value, key) => key);
+
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).injected,
+    ).toBeUndefined();
+    const innocent: { injected?: unknown } = {};
+    expect(innocent.injected).toBeUndefined();
+  });
+
+  it("should demonstrate __proto__-primitive payload is harmlessly swallowed by the setter", () => {
+    // When the value of the own `__proto__` key is a primitive, the __proto__
+    // setter silently rejects it, so mapKeys produces a result without the
+    // dangerous key and with the default Object.prototype.
+    const malicious = JSON.parse('{"__proto__":1,"a":2}');
+
+    const result = mapKeys(malicious, (_value, key) => key);
+
+    expect(result).toEqual({ a: 2 });
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  });
+
+  it("should locally replace the result's prototype when __proto__ value is an object (known limitation)", () => {
+    // Documents the library's current behavior: mapKeys does not filter keys.
+    // An own __proto__ key carrying an object value triggers the setter on
+    // the freshly-allocated result, replacing its prototype locally. The
+    // result's own keys remain safe; callers must still use removePrototype*
+    // if the prototype chain must also be sanitized.
+    const malicious = JSON.parse('{"__proto__":{"injected":"bad"},"a":1}');
+
+    const result = mapKeys(malicious, (_value, key) => key);
+
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(Object.hasOwn(result, "a")).toBe(true);
+    expect(Object.getPrototypeOf(result)).toEqual({ injected: "bad" });
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect((result as any).injected).toBe("bad");
+
+    // Global Object.prototype is untouched.
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).injected,
+    ).toBeUndefined();
+  });
+
+  it("should not copy inherited enumerable properties from the source", () => {
+    const parent = { inherited: 1 };
+    const child = Object.create(parent);
+    child.own = 2;
+
+    const result = mapKeys(child as Record<string, unknown>, (_v, key) => key);
+
+    expect(result).toEqual({ own: 2 });
+  });
+
+  it("should pass `constructor` and `prototype` through as regular own keys (only __proto__ primitives are dropped)", () => {
+    // mapKeys only relies on JavaScript's __proto__ setter semantics for
+    // protection. Own keys named `constructor` or `prototype` are retained
+    // verbatim as regular own keys.
+    const malicious = JSON.parse(
+      '{"a":1,"constructor":2,"b":3,"prototype":4,"c":5,"__proto__":6}',
+    );
+
+    const result = mapKeys(malicious, (_value, key) => key);
+
+    expect(result).toEqual({
+      a: 1,
+      b: 3,
+      c: 5,
+      constructor: 2,
+      prototype: 4,
+    });
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+  });
+
+  it("should accept a transformer returning a numeric-looking key", () => {
+    const result = mapKeys({ a: 1 }, () => "0");
+    expect(result).toEqual({ "0": 1 });
+  });
 });

--- a/package/main/src/tests/unit/Object/mapValues.test.ts
+++ b/package/main/src/tests/unit/Object/mapValues.test.ts
@@ -42,4 +42,87 @@ describe("mapValues", () => {
     expect(result).toEqual({ a: 2 });
     expect(Object.hasOwn(result, "__proto__")).toBe(false);
   });
+
+  it("should preserve the key order of the source's own keys", () => {
+    const result = mapValues({ c: 1, a: 2, b: 3 }, (value) => value);
+    expect(Object.keys(result)).toEqual(["c", "a", "b"]);
+  });
+
+  it("should invoke the transformer once per own key with the correct arguments", () => {
+    const calls: [unknown, string][] = [];
+    mapValues({ x: 1, y: 2 }, (value, key) => {
+      calls.push([value, key]);
+      return value;
+    });
+
+    expect(calls).toEqual([
+      [1, "x"],
+      [2, "y"],
+    ]);
+  });
+
+  it("should return a new object, not the original", () => {
+    const original = { a: 1 };
+    const result = mapValues(original, (value) => value);
+    expect(result).not.toBe(original);
+  });
+
+  it("should not copy inherited enumerable properties", () => {
+    const parent = { inherited: 1 };
+    const child = Object.create(parent);
+    child.own = 2;
+
+    const result = mapValues(
+      child as Record<string, unknown>,
+      (value) => value,
+    );
+
+    expect(result).toEqual({ own: 2 });
+  });
+
+  it("should allow the transformer to return null and undefined", () => {
+    const result = mapValues({ a: 1, b: 2, c: 3 }, (value) =>
+      (value as number) > 1 ? null : undefined,
+    );
+    expect(result).toEqual({ a: undefined, b: null, c: null });
+    expect(Object.hasOwn(result, "a")).toBe(true);
+    expect(Object.hasOwn(result, "b")).toBe(true);
+    expect(Object.hasOwn(result, "c")).toBe(true);
+  });
+
+  it("should leave global Object.prototype untouched when the input has __proto__ own key (primitive value)", () => {
+    const malicious = JSON.parse('{"__proto__":1,"a":2}');
+
+    mapValues(malicious, (v) => v);
+
+    const clean: { polluted?: unknown } = {};
+    expect(clean.polluted).toBeUndefined();
+  });
+
+  it("should demonstrate that a naive loop pollutes the prototype, while mapValues does not (object-valued __proto__)", () => {
+    const malicious = JSON.parse('{"__proto__":{"injected":"bad"},"a":1}');
+
+    // A naive value transformation that iterates own keys and assigns into a
+    // fresh `{}` would hit the __proto__ setter and replace the result's
+    // prototype with the malicious object.
+    const naive: Record<string, unknown> = {};
+    for (const key of Object.keys(malicious)) {
+      naive[key] = malicious[key];
+    }
+    expect(Object.getPrototypeOf(naive)).toEqual({ injected: "bad" });
+
+    // mapValues explicitly uses Object.keys and only writes to safe keys via
+    // the transformer. Since `__proto__` is an own key of the source, mapValues
+    // also writes to it — but the setter assigns an object prototype. The own
+    // key is still absent from the result.
+    const result = mapValues(malicious, (v) => v);
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(Object.hasOwn(result, "a")).toBe(true);
+  });
+
+  it("should preserve reference equality for returned object values", () => {
+    const nested = { inner: 1 };
+    const result = mapValues({ a: nested }, (value) => value);
+    expect(result.a).toBe(nested);
+  });
 });

--- a/package/main/src/tests/unit/Object/merge.test.ts
+++ b/package/main/src/tests/unit/Object/merge.test.ts
@@ -86,4 +86,97 @@ describe("merge", () => {
     expect(Object.keys(result)).not.toContain("constructor");
     expect(Object.keys(result)).not.toContain("prototype");
   });
+
+  it("should demonstrate local prototype pollution when __proto__ payload is merged without sanitization", () => {
+    const malicious = JSON.parse('{"__proto__":{"injected":"local"}}');
+
+    const polluted = merge({}, malicious) as Record<string, unknown>;
+
+    // The result's own prototype was replaced by the injected object.
+    expect(Object.getPrototypeOf(polluted)).toEqual({ injected: "local" });
+    expect((polluted as { injected?: unknown }).injected).toBe("local");
+
+    // Global Object.prototype must remain untouched.
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).injected,
+    ).toBeUndefined();
+
+    // After sanitization, the result is clean.
+    const safe = merge({}, removePrototype(malicious)) as {
+      injected?: unknown;
+    };
+    expect(Object.getPrototypeOf(safe)).toBe(Object.prototype);
+    expect(safe.injected).toBeUndefined();
+  });
+
+  it("should preserve own constructor key on the result when not sanitized", () => {
+    const malicious = JSON.parse('{"constructor":{"polluted":true},"a":1}');
+
+    const result = merge({}, malicious) as {
+      constructor: { polluted?: unknown };
+    };
+
+    // Without sanitization the key flows through — demonstrating the need for removePrototype.
+    expect(Object.hasOwn(result, "constructor")).toBe(true);
+    expect(result.constructor.polluted).toBe(true);
+
+    const safe = merge({}, removePrototype(malicious));
+    expect(Object.hasOwn(safe, "constructor")).toBe(false);
+  });
+
+  it("should merge many sources in left-to-right precedence order", () => {
+    const result = merge({ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 });
+
+    expect(result.a).toBe(5);
+  });
+
+  it("should only copy own enumerable string keys of each source", () => {
+    const parent = { inherited: "parent" };
+    const child = Object.create(parent);
+    child.own = "child";
+
+    const result = merge({ a: 1 }, child as Record<string, unknown>);
+
+    expect(result).toEqual({ a: 1, own: "child" });
+    expect(Object.hasOwn(result, "inherited")).toBe(false);
+  });
+
+  it("should not copy symbol keys from sources", () => {
+    const symbol = Symbol("key");
+    const source = { a: 1, [symbol]: "value" } as Record<string, unknown>;
+
+    const result = merge({}, source) as Record<string | symbol, unknown>;
+
+    expect(Object.getOwnPropertySymbols(result)).toHaveLength(0);
+    expect(result[symbol]).toBeUndefined();
+  });
+
+  it("should return a new object even when there are no sources", () => {
+    const target = { a: 1 };
+
+    const result = merge(target);
+
+    expect(result).toEqual(target);
+    expect(result).not.toBe(target);
+  });
+
+  it("should preserve reference equality for nested values (shallow merge)", () => {
+    const nested = { x: 1 };
+    const source = { nested };
+
+    const result = merge({}, source);
+
+    expect(result.nested).toBe(nested);
+  });
+
+  it("should overwrite nested objects instead of merging them (shallow)", () => {
+    const target = { a: { b: 1, c: 2 } };
+    const source = { a: { d: 3 } };
+
+    const result = merge(target, source);
+
+    expect(result.a).toEqual({ d: 3 });
+    expect(result.a).not.toHaveProperty("b");
+  });
 });

--- a/package/main/src/tests/unit/Object/mergeDeep.test.ts
+++ b/package/main/src/tests/unit/Object/mergeDeep.test.ts
@@ -1,5 +1,6 @@
 import { mergeDeep } from "@/Object/mergeDeep";
 import { removePrototype } from "@/Object/removePrototype";
+import { removePrototypeDeep } from "@/Object/removePrototypeDeep";
 
 describe("mergeDeep", () => {
   it("should deeply merge nested objects", () => {
@@ -187,5 +188,159 @@ describe("mergeDeep", () => {
 
     // biome-ignore lint/suspicious/noExplicitAny: ignore
     expect((result as any).prototype).toBeUndefined();
+  });
+
+  it("should demonstrate __proto__ pollution via a naive deep merge and confirm mergeDeep with sanitization is safe", () => {
+    const malicious = JSON.parse('{"__proto__":{"injected":"global"}}');
+
+    const vulnerableDeepMerge = (
+      target: Record<string, unknown>,
+      source: Record<string, unknown>,
+    ): Record<string, unknown> => {
+      for (const key of Object.keys(source)) {
+        const sourceValue = source[key];
+        const targetValue = target[key];
+        if (
+          sourceValue !== null &&
+          typeof sourceValue === "object" &&
+          !Array.isArray(sourceValue) &&
+          targetValue !== null &&
+          typeof targetValue === "object" &&
+          !Array.isArray(targetValue)
+        ) {
+          vulnerableDeepMerge(
+            targetValue as Record<string, unknown>,
+            sourceValue as Record<string, unknown>,
+          );
+        } else {
+          target[key] = sourceValue;
+        }
+      }
+      return target;
+    };
+
+    try {
+      const victim: Record<string, unknown> = {};
+      vulnerableDeepMerge(victim, malicious);
+
+      // Global pollution confirmed: a freshly created object inherits the property.
+      const innocent: { injected?: unknown } = {};
+      expect(innocent.injected).toBe("global");
+
+      const safe = mergeDeep({}, removePrototypeDeep(malicious));
+      expect(Object.hasOwn(safe, "__proto__")).toBe(false);
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      expect((safe as any).injected).toBe("global");
+      // After cleanup, the injected property must disappear everywhere.
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "injected");
+    }
+
+    const afterCleanup: { injected?: unknown } = {};
+    expect(afterCleanup.injected).toBeUndefined();
+  });
+
+  it("should demonstrate constructor.prototype pollution via a naive deep merge", () => {
+    const malicious = JSON.parse(
+      '{"constructor":{"prototype":{"globallyInjected":"yes"}}}',
+    );
+
+    // A naive merge that recurses into anything "object-like" (including the
+    // Object constructor function). This reaches Object.prototype and writes
+    // to it — the canonical constructor.prototype pollution pattern.
+    const vulnerableDeepMerge = (
+      target: Record<string, unknown>,
+      source: Record<string, unknown>,
+    ): Record<string, unknown> => {
+      for (const key of Object.keys(source)) {
+        const sourceValue = source[key];
+        const targetValue = target[key];
+        const targetIsObjectLike =
+          targetValue !== null &&
+          (typeof targetValue === "object" ||
+            typeof targetValue === "function");
+        if (
+          sourceValue !== null &&
+          typeof sourceValue === "object" &&
+          !Array.isArray(sourceValue) &&
+          targetIsObjectLike
+        ) {
+          vulnerableDeepMerge(
+            targetValue as Record<string, unknown>,
+            sourceValue as Record<string, unknown>,
+          );
+        } else {
+          target[key] = sourceValue;
+        }
+      }
+      return target;
+    };
+
+    try {
+      const victim: Record<string, unknown> = {};
+      vulnerableDeepMerge(victim, malicious);
+
+      const innocent: { globallyInjected?: unknown } = {};
+      expect(innocent.globallyInjected).toBe("yes");
+
+      const safe = mergeDeep({}, removePrototypeDeep(malicious));
+      expect(Object.hasOwn(safe, "constructor")).toBe(false);
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "globallyInjected");
+    }
+  });
+
+  it("should leave Object.prototype untouched even when __proto__ appears in the source", () => {
+    const payload = JSON.parse('{"__proto__":{"leak":"oops"},"safe":1}');
+
+    mergeDeep({}, payload);
+
+    const clean: { leak?: unknown } = {};
+    expect(clean.leak).toBeUndefined();
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).leak,
+    ).toBeUndefined();
+  });
+
+  it("should handle deeply nested merges with many sources", () => {
+    const sources = Array.from({ length: 10 }, (_, i) => ({
+      level: { [`key${i}`]: i },
+    }));
+
+    const result = mergeDeep({ level: { initial: true } }, ...sources);
+
+    expect(result.level.initial).toBe(true);
+    for (let index = 0; index < 10; index++) {
+      // biome-ignore lint/suspicious/noExplicitAny: dynamic shape
+      expect((result.level as any)[`key${index}`]).toBe(index);
+    }
+  });
+
+  it("should not mutate any of the sources with deeply nested data", () => {
+    const source = { a: { b: { c: 1 } } };
+    const sourceCopy = JSON.parse(JSON.stringify(source));
+
+    mergeDeep({ a: { b: { d: 2 } } }, source);
+
+    expect(source).toEqual(sourceCopy);
+  });
+
+  it("should treat arrays as atomic values and not merge them element-wise", () => {
+    const target = { list: [1, 2, 3] };
+    const source = { list: [9] };
+
+    const result = mergeDeep(target, source);
+
+    expect(result.list).toEqual([9]);
+  });
+
+  it("should return a new object, not the target reference", () => {
+    const target = { a: 1 };
+    const source = { b: 2 };
+
+    const result = mergeDeep(target, source);
+
+    expect(result).not.toBe(target);
   });
 });

--- a/package/main/src/tests/unit/Object/omit.test.ts
+++ b/package/main/src/tests/unit/Object/omit.test.ts
@@ -86,4 +86,78 @@ describe("omit", () => {
     expect(result).toEqual({ a: 1, c: true });
     // TypeScript should infer the result type as { a: number; c: boolean; }
   });
+
+  it("should preserve reference equality for retained nested values", () => {
+    const nested = { inner: 1 };
+    const object = { a: nested, b: 2 };
+
+    const result = omit(object, "b") as unknown as { a: typeof nested };
+
+    expect(result.a).toBe(nested);
+  });
+
+  it("should return a new object, not the original", () => {
+    const object = { a: 1 };
+    const result = omit(object);
+
+    expect(result).not.toBe(object);
+  });
+
+  it("should handle symbol keys", () => {
+    const symbol = Symbol("k");
+    const other = Symbol("other");
+    const object = { [symbol]: 1, [other]: 2, a: 3 };
+
+    const result = omit(object, symbol);
+
+    expect(result).toEqual({ [other]: 2, a: 3 });
+    expect(Object.getOwnPropertySymbols(result)).toEqual([other]);
+  });
+
+  it("should handle duplicate keys passed to omit", () => {
+    const object = { a: 1, b: 2, c: 3 };
+
+    const result = omit(object, "b", "b", "b");
+
+    expect(result).toEqual({ a: 1, c: 3 });
+  });
+
+  it("should demonstrate prototype-pollution safety by dropping __proto__ when requested", () => {
+    // omit uses spread + delete, which is safe even with malicious payloads
+    // because delete on __proto__ via bracket notation does not walk the
+    // prototype chain.
+    const malicious = JSON.parse('{"__proto__":{"polluted":true},"a":1}');
+
+    const result = omit(malicious, "__proto__" as never) as { a?: number };
+
+    // __proto__ own property was removed; Object.prototype is untouched.
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (Object.prototype as any).polluted,
+    ).toBeUndefined();
+    expect(result.a).toBe(1);
+  });
+
+  it("should preserve own __proto__ when it is not explicitly omitted", () => {
+    const malicious = JSON.parse('{"__proto__":{"polluted":true},"a":1}');
+
+    const result = omit(malicious, "a") as Record<string, unknown>;
+
+    // Spread preserves the own __proto__ key, since omit only spreads + deletes
+    // the explicitly requested keys. This is why callers must still use
+    // removePrototype for full sanitization.
+    expect(Object.hasOwn(result, "__proto__")).toBe(true);
+  });
+
+  it("should not copy inherited enumerable properties from the source", () => {
+    const parent = { inherited: 1 };
+    const child: { own?: number } = Object.create(parent);
+    child.own = 2;
+
+    const result = omit(child, "own");
+
+    expect(Object.hasOwn(result, "own")).toBe(false);
+    expect(Object.hasOwn(result, "inherited")).toBe(false);
+  });
 });

--- a/package/main/src/tests/unit/Object/pick.test.ts
+++ b/package/main/src/tests/unit/Object/pick.test.ts
@@ -96,4 +96,62 @@ describe("pick function", () => {
     expect("polluted" in clean).toBe(false);
     expect("injected" in clean).toBe(false);
   });
+
+  it("should preserve reference equality for selected nested values", () => {
+    const nested = { inner: 1 };
+    const object = { a: nested, b: 2 };
+
+    const result = pick(object, "a");
+
+    expect(result.a).toBe(nested);
+  });
+
+  it("should return a new object, not the original", () => {
+    const object = { a: 1, b: 2 };
+    const result = pick(object, "a", "b");
+
+    expect(result).toEqual(object);
+    expect(result).not.toBe(object);
+  });
+
+  it("should handle symbol keys", () => {
+    const symbol = Symbol("k");
+    const object = { [symbol]: 1, a: 2 };
+
+    const result = pick(object, symbol);
+
+    expect(Object.getOwnPropertySymbols(result)).toEqual([symbol]);
+    expect((result as Record<symbol, unknown>)[symbol]).toBe(1);
+  });
+
+  it("should assign undefined for requested keys that are not own properties (bracket-access semantics)", () => {
+    const object = { a: 1 } as Record<string, unknown>;
+    const result = pick(object, "b" as keyof typeof object);
+
+    // pick reads via bracket access, so non-existent keys yield undefined.
+    // The resulting object still has the requested key as an own property.
+    expect(Object.hasOwn(result, "b")).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect((result as any).b).toBeUndefined();
+  });
+
+  it("should demonstrate that pick(malicious, '__proto__') produces an unsafe own key without sanitization", () => {
+    const malicious = JSON.parse('{"__proto__":{"polluted":true},"a":1}');
+
+    const result = pick(malicious, "__proto__" as never) as Record<
+      string,
+      unknown
+    >;
+
+    // pick's naive bracket-assignment triggers the __proto__ setter on the
+    // fresh result, so the result's own prototype is replaced.
+    expect(Object.getPrototypeOf(result)).toEqual({ polluted: true });
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect((result as any).polluted).toBe(true);
+
+    // After sanitization, the dangerous key is simply absent.
+    const sanitized = pick(removePrototype(malicious), "a");
+    expect(sanitized).toEqual({ a: 1 });
+    expect(Object.getPrototypeOf(sanitized)).toBe(Object.prototype);
+  });
 });

--- a/package/main/src/tests/unit/Object/pickDeep.test.ts
+++ b/package/main/src/tests/unit/Object/pickDeep.test.ts
@@ -123,8 +123,11 @@ describe("pickDeep function", () => {
 
   test("should prevent prototype pollution via __proto__", () => {
     const payload = JSON.parse('{"__proto__": {"polluted": true}}');
-    // @ts-expect-error - testing invalid keys
-    const result = pickDeep(removePrototype(payload), "__proto__.polluted");
+    const result = pickDeep(
+      removePrototype(payload),
+      // biome-ignore lint/suspicious/noExplicitAny: testing invalid keys
+      "__proto__.polluted" as any,
+    );
     expect(
       // biome-ignore lint/suspicious/noExplicitAny: ignore
       (result as any).polluted,
@@ -164,5 +167,68 @@ describe("pickDeep function", () => {
       // biome-ignore lint/suspicious/noExplicitAny: ignore
       (result as any).prototype,
     ).toBeUndefined();
+  });
+
+  test("should preserve reference equality for fully-picked nested objects", () => {
+    const nested = { b: 1 };
+    const object = { a: nested };
+
+    const result = pickDeep(object, "a");
+
+    expect(result.a).toBe(nested);
+  });
+
+  test("should allocate a new intermediate object when only a sub-path is picked", () => {
+    const object = { a: { b: { c: 1, d: 2 } } };
+
+    const result = pickDeep(object, "a.b.c");
+
+    expect(result.a.b).not.toBe(object.a.b);
+    expect(result.a).not.toBe(object.a);
+  });
+
+  test("should pick all requested paths independently", () => {
+    const object = {
+      a: { b: { c: 1, d: 2 }, e: 3 },
+      f: { g: 4, h: 5 },
+    };
+
+    const result = pickDeep(object, "a.b.c", "a.e", "f.g");
+
+    expect(result).toEqual({ a: { b: { c: 1 }, e: 3 }, f: { g: 4 } });
+  });
+
+  test("should create an empty placeholder when a path steps into a primitive mid-way", () => {
+    const object = { a: 1 } as Record<string, unknown>;
+
+    const result = pickDeep(
+      object,
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      "a.b" as any,
+    );
+
+    // `a` exists but is a primitive, so pickDeep creates an empty intermediate
+    // object at `a` and stops. This documents the library's actual behavior.
+    expect(result).toEqual({ a: {} });
+  });
+
+  test("should merge sibling paths into the same intermediate object", () => {
+    const object = { a: { b: 1, c: 2, d: 3 } };
+
+    const result = pickDeep(object, "a.b", "a.c");
+
+    expect(result).toEqual({ a: { b: 1, c: 2 } });
+    // Both picks shared the same `a` intermediate — verify reference equality
+    // of the intermediate (not the original).
+    expect(result.a).not.toBe(object.a);
+  });
+
+  test("should handle undefined values as valid leaves", () => {
+    const object = { a: { b: undefined, c: 1 } };
+
+    const result = pickDeep(object, "a.b");
+
+    expect(result).toEqual({ a: { b: undefined } });
+    expect(Object.hasOwn(result.a, "b")).toBe(true);
   });
 });

--- a/package/main/src/tests/unit/Object/pickDeep.test.ts
+++ b/package/main/src/tests/unit/Object/pickDeep.test.ts
@@ -122,9 +122,13 @@ describe("pickDeep function", () => {
   });
 
   test("should prevent prototype pollution via __proto__", () => {
-    const payload = JSON.parse('{"__proto__": {"polluted": true}}');
+    const payload = JSON.parse('{"__proto__": {"polluted": true}}') as Record<
+      string,
+      unknown
+    >;
+    const sanitized = removePrototype(payload) as Record<string, unknown>;
     const result = pickDeep(
-      removePrototype(payload),
+      sanitized,
       // biome-ignore lint/suspicious/noExplicitAny: testing invalid keys
       "__proto__.polluted" as any,
     );
@@ -141,10 +145,11 @@ describe("pickDeep function", () => {
   test("should prevent prototype pollution via constructor", () => {
     const payload = JSON.parse(
       '{"constructor": {"prototype": {"polluted": true}}}',
-    );
+    ) as Record<string, unknown>;
+    const sanitized = removePrototype(payload) as Record<string, unknown>;
 
     const result = pickDeep(
-      removePrototype(payload),
+      sanitized,
       // biome-ignore lint/suspicious/noExplicitAny: ignore
       "constructor.prototype.polluted" as any,
     );
@@ -156,10 +161,14 @@ describe("pickDeep function", () => {
   });
 
   test("should prevent prototype pollution via prototype", () => {
-    const payload = JSON.parse('{"prototype": {"polluted": true}}');
+    const payload = JSON.parse('{"prototype": {"polluted": true}}') as Record<
+      string,
+      unknown
+    >;
+    const sanitized = removePrototype(payload) as Record<string, unknown>;
 
     const result = pickDeep(
-      removePrototype(payload),
+      sanitized,
       // biome-ignore lint/suspicious/noExplicitAny: ignore
       "prototype.polluted" as any,
     );

--- a/package/main/src/tests/unit/Object/removePrototype.test.ts
+++ b/package/main/src/tests/unit/Object/removePrototype.test.ts
@@ -65,4 +65,122 @@ describe("removePrototype", () => {
 
     expect(result).toEqual({ a: 1, b: "test" });
   });
+
+  it("should return an object with a null prototype", () => {
+    const object = { a: 1 };
+    const result = removePrototype(object);
+
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it("should not inherit from Object.prototype", () => {
+    const object = { a: 1 };
+    const result = removePrototype(object);
+
+    expect(result).not.toBeInstanceOf(Object);
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (result as any).hasOwnProperty,
+    ).toBeUndefined();
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: ignore
+      (result as any).toString,
+    ).toBeUndefined();
+  });
+
+  it("should handle an empty object", () => {
+    const result = removePrototype({});
+
+    expect(result).toEqual({});
+    expect(Object.keys(result)).toHaveLength(0);
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it("should not copy inherited enumerable properties", () => {
+    const parent = { inherited: "value" };
+    const child = Object.create(parent);
+    child.own = "child";
+
+    const result = removePrototype(child);
+
+    expect(Object.hasOwn(result, "own")).toBe(true);
+    expect(Object.hasOwn(result, "inherited")).toBe(false);
+  });
+
+  it("should not copy symbol keys", () => {
+    const symbol = Symbol("key");
+    const object = { a: 1, [symbol]: "value" } as Record<string, unknown>;
+
+    const result = removePrototype(object);
+
+    expect(Object.getOwnPropertySymbols(result)).toHaveLength(0);
+    expect((result as Record<symbol, unknown>)[symbol]).toBeUndefined();
+  });
+
+  it("should only remove dangerous keys at the top level (shallow)", () => {
+    const object = {
+      safe: JSON.parse('{"__proto__":{"polluted":true},"value":1}'),
+    };
+
+    const result = removePrototype(object);
+
+    expect(Object.hasOwn(result.safe, "__proto__")).toBe(true);
+    expect(result.safe).toBe(object.safe);
+  });
+
+  it("should demonstrate pollution via mutable assignment and confirm removePrototype prevents it", () => {
+    const malicious = JSON.parse('{"__proto__":{"injected":1},"safe":2}');
+
+    // A naive loop assignment uses [[Set]] semantics, which triggers the
+    // __proto__ setter and replaces the target's prototype with the
+    // attacker-controlled object. Object spread ({...obj}) uses
+    // [[DefineOwnProperty]] and would NOT reproduce the attack.
+    const vulnerable: { injected?: unknown } = {};
+    for (const key of Object.keys(malicious)) {
+      (vulnerable as Record<string, unknown>)[key] = malicious[key];
+    }
+    expect(Object.getPrototypeOf(vulnerable)).toEqual({ injected: 1 });
+    expect(vulnerable.injected).toBe(1);
+
+    const safe = removePrototype(malicious) as { injected?: unknown };
+    expect(Object.getPrototypeOf(safe)).toBeNull();
+    expect(safe.injected).toBeUndefined();
+    expect(safe).toEqual({ safe: 2 });
+  });
+
+  it("should demonstrate constructor-based pollution and confirm removePrototype prevents it", () => {
+    const malicious = JSON.parse('{"constructor":{"polluted":true},"a":1}');
+
+    // Unlike __proto__, `constructor` has no special setter — the spread
+    // simply assigns it as a regular own key, so the attacker-controlled
+    // object surfaces on the copy.
+    const vulnerable = { ...malicious } as {
+      constructor: { polluted?: unknown };
+    };
+    expect(vulnerable.constructor.polluted).toBe(true);
+
+    const safe = removePrototype(malicious) as { constructor?: unknown };
+    expect(Object.hasOwn(safe, "constructor")).toBe(false);
+    expect(safe.constructor).toBeUndefined();
+  });
+
+  it("should not share references between successive calls", () => {
+    const object = { a: 1 };
+
+    const first = removePrototype(object);
+    const second = removePrototype(object);
+
+    expect(first).not.toBe(second);
+  });
+
+  it("should handle an object whose keys contain dangerous names mixed with safe ones", () => {
+    const object = JSON.parse(
+      '{"__proto__":1,"a":2,"constructor":3,"b":4,"prototype":5,"c":6}',
+    );
+
+    const result = removePrototype(object);
+
+    expect(Object.keys(result)).toEqual(["a", "b", "c"]);
+    expect(result).toEqual({ a: 2, b: 4, c: 6 });
+  });
 });

--- a/package/main/src/tests/unit/Object/removePrototypeDeep.test.ts
+++ b/package/main/src/tests/unit/Object/removePrototypeDeep.test.ts
@@ -47,4 +47,165 @@ describe("removePrototypeDeep", () => {
     expect(Object.hasOwn(object.safe, "__proto__")).toBe(true);
     expect(Object.hasOwn(object.list[0], "prototype")).toBe(true);
   });
+
+  it("should return a root object with a null prototype", () => {
+    const object = { a: 1 };
+    const result = removePrototypeDeep(object);
+
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it("should give every nested plain object a null prototype", () => {
+    const object = {
+      a: { b: { c: { d: 1 } } },
+      list: [{ x: 1 }, { y: { z: 2 } }],
+    };
+
+    const result = removePrototypeDeep(object);
+
+    expect(Object.getPrototypeOf(result)).toBeNull();
+    expect(Object.getPrototypeOf(result.a)).toBeNull();
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect(Object.getPrototypeOf((result.a as any).b)).toBeNull();
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect(Object.getPrototypeOf((result.a as any).b.c)).toBeNull();
+    expect(Object.getPrototypeOf(result.list[0])).toBeNull();
+    // biome-ignore lint/suspicious/noExplicitAny: ignore
+    expect(Object.getPrototypeOf((result.list[1] as any).y)).toBeNull();
+  });
+
+  it("should handle an empty object", () => {
+    const result = removePrototypeDeep({});
+
+    expect(result).toEqual({});
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it("should preserve primitive values verbatim", () => {
+    const object = {
+      a: 1,
+      b: "text",
+      c: true,
+      d: null,
+      e: undefined,
+    };
+
+    const result = removePrototypeDeep(object);
+
+    expect(result).toEqual(object);
+  });
+
+  it("should pass non-plain objects through by reference", () => {
+    const date = new Date("2024-01-01");
+    const map = new Map([["k", "v"]]);
+    const set = new Set([1, 2]);
+    const regex = /foo/;
+    const object = { date, map, set, regex };
+
+    const result = removePrototypeDeep(object);
+
+    expect(result.date).toBe(date);
+    expect(result.map).toBe(map);
+    expect(result.set).toBe(set);
+    expect(result.regex).toBe(regex);
+  });
+
+  it("should sanitize dangerous keys discovered inside arrays", () => {
+    const object = JSON.parse(
+      '{"list":[{"__proto__":{"polluted":true},"value":1},{"constructor":{"polluted":true},"value":2}]}',
+    );
+
+    const result = removePrototypeDeep(object);
+
+    expect(result.list[0]).toEqual({ value: 1 });
+    expect(result.list[1]).toEqual({ value: 2 });
+    expect(Object.hasOwn(result.list[0], "__proto__")).toBe(false);
+    expect(Object.hasOwn(result.list[1], "constructor")).toBe(false);
+  });
+
+  it("should sanitize dangerous keys at multiple depths", () => {
+    const object = JSON.parse(
+      '{"__proto__":1,"a":{"__proto__":2,"b":{"__proto__":3,"c":4}}}',
+    );
+
+    const result = removePrototypeDeep(object);
+
+    expect(result).toEqual({ a: { b: { c: 4 } } });
+  });
+
+  it("should return a new array (not the same reference)", () => {
+    const inner = [1, 2, 3];
+    const object = { list: inner };
+
+    const result = removePrototypeDeep(object);
+
+    expect(result.list).toEqual(inner);
+    expect(result.list).not.toBe(inner);
+  });
+
+  it("should return new plain objects (not the same reference)", () => {
+    const nested = { b: 1 };
+    const object = { a: nested };
+
+    const result = removePrototypeDeep(object);
+
+    expect(result.a).toEqual(nested);
+    expect(result.a).not.toBe(nested);
+  });
+
+  it("should demonstrate that a naive deep merge pollutes Object.prototype without sanitization", () => {
+    const malicious = JSON.parse('{"__proto__":{"polluted":"bad"}}');
+
+    const vulnerableDeepMerge = (
+      target: Record<string, unknown>,
+      source: Record<string, unknown>,
+    ): void => {
+      for (const key of Object.keys(source)) {
+        const sourceValue = source[key];
+        const targetValue = target[key];
+        if (
+          sourceValue !== null &&
+          typeof sourceValue === "object" &&
+          targetValue !== null &&
+          typeof targetValue === "object"
+        ) {
+          vulnerableDeepMerge(
+            targetValue as Record<string, unknown>,
+            sourceValue as Record<string, unknown>,
+          );
+        } else {
+          target[key] = sourceValue;
+        }
+      }
+    };
+
+    try {
+      const victim: Record<string, unknown> = {};
+      vulnerableDeepMerge(victim, malicious);
+
+      const innocent: { polluted?: unknown } = {};
+      expect(innocent.polluted).toBe("bad");
+
+      const sanitized = removePrototypeDeep(malicious);
+      const victim2: Record<string, unknown> = Object.create(null);
+      vulnerableDeepMerge(victim2, sanitized);
+      expect(Object.hasOwn(victim2, "polluted")).toBe(false);
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "polluted");
+    }
+  });
+
+  it("should recurse through arrays that contain arrays", () => {
+    const object = JSON.parse(
+      '{"matrix":[[[{"__proto__":{"polluted":true},"deep":1}]]]}',
+    );
+
+    const result = removePrototypeDeep(object);
+
+    expect(result).toEqual({ matrix: [[[{ deep: 1 }]]] });
+    // biome-ignore lint/suspicious/noExplicitAny: navigating dynamic shape
+    expect(Object.hasOwn((result as any).matrix[0][0][0], "__proto__")).toBe(
+      false,
+    );
+  });
 });

--- a/package/main/src/tests/unit/Object/removePrototypeMap.test.ts
+++ b/package/main/src/tests/unit/Object/removePrototypeMap.test.ts
@@ -24,4 +24,105 @@ describe("removePrototypeMap", () => {
     // biome-ignore lint/complexity/useLiteralKeys: ignore
     expect(result[1]["nested"]).toBe(nested);
   });
+
+  it("should return an empty array when given an empty array", () => {
+    const result = removePrototypeMap([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return a new array instance", () => {
+    const objects = [{ a: 1 }];
+
+    const result = removePrototypeMap(objects);
+
+    expect(result).not.toBe(objects);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("should preserve element order", () => {
+    const objects = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }];
+
+    const result = removePrototypeMap(objects);
+
+    expect(result.map((item) => item.a)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("should give every returned object a null prototype", () => {
+    const objects = [
+      { a: 1 },
+      JSON.parse('{"__proto__":{"polluted":true},"b":2}'),
+    ];
+
+    const result = removePrototypeMap(objects);
+
+    for (const item of result) {
+      expect(Object.getPrototypeOf(item)).toBeNull();
+    }
+  });
+
+  it("should only sanitize the top level of each element (shallow)", () => {
+    const nestedMalicious = JSON.parse(
+      '{"__proto__":{"polluted":true},"deep":1}',
+    );
+    const objects = [{ nested: nestedMalicious }];
+
+    const result = removePrototypeMap(objects);
+
+    expect(Object.hasOwn(result[0].nested, "__proto__")).toBe(true);
+    expect(result[0].nested).toBe(nestedMalicious);
+  });
+
+  it("should demonstrate that naive loop assignments pollute and the map helper prevents it", () => {
+    const payloads = [
+      JSON.parse('{"__proto__":{"injected":"a"},"safe":1}'),
+      JSON.parse('{"__proto__":{"injected":"b"},"safe":2}'),
+    ];
+
+    // A mutable loop assignment uses [[Set]], which triggers the __proto__
+    // setter and replaces each target's prototype with the attacker's object.
+    // (Spread syntax uses [[DefineOwnProperty]] and would NOT reproduce this.)
+    const vulnerable = payloads.map((p) => {
+      const out: { injected?: unknown } = {};
+      for (const key of Object.keys(p)) {
+        (out as Record<string, unknown>)[key] = (p as Record<string, unknown>)[
+          key
+        ];
+      }
+      return out;
+    });
+    expect(Object.getPrototypeOf(vulnerable[0])).toEqual({ injected: "a" });
+    expect(Object.getPrototypeOf(vulnerable[1])).toEqual({ injected: "b" });
+    expect(vulnerable[0].injected).toBe("a");
+    expect(vulnerable[1].injected).toBe("b");
+
+    const safe = removePrototypeMap(payloads) as { injected?: unknown }[];
+    expect(safe).toEqual([{ safe: 1 }, { safe: 2 }]);
+    for (const item of safe) {
+      expect(Object.getPrototypeOf(item)).toBeNull();
+      expect(item.injected).toBeUndefined();
+    }
+  });
+
+  it("should not mutate any of the input objects", () => {
+    const objects = [
+      JSON.parse('{"__proto__":{"polluted":true},"a":1}'),
+      JSON.parse('{"constructor":{"polluted":true},"b":2}'),
+    ];
+
+    removePrototypeMap(objects);
+
+    expect(Object.hasOwn(objects[0], "__proto__")).toBe(true);
+    expect(Object.hasOwn(objects[1], "constructor")).toBe(true);
+  });
+
+  it("should accept a readonly array", () => {
+    const objects: readonly Record<string, unknown>[] = [
+      JSON.parse('{"__proto__":{"polluted":true},"a":1}'),
+    ];
+
+    const result = removePrototypeMap(objects);
+
+    expect(result).toEqual([{ a: 1 }]);
+  });
 });

--- a/package/main/src/tests/unit/Object/removePrototypeMapDeep.test.ts
+++ b/package/main/src/tests/unit/Object/removePrototypeMapDeep.test.ts
@@ -19,4 +19,133 @@ describe("removePrototypeMapDeep", () => {
     expect(Object.hasOwn(result[1].list[0], "prototype")).toBe(false);
     expect(Object.hasOwn(result[1].meta, "constructor")).toBe(false);
   });
+
+  it("should return an empty array when given an empty array", () => {
+    const result = removePrototypeMapDeep([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return a new array instance", () => {
+    const objects = [{ a: 1 }];
+
+    const result = removePrototypeMapDeep(objects);
+
+    expect(result).not.toBe(objects);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("should preserve element order", () => {
+    const objects = [
+      { id: 1, value: { x: 1 } },
+      { id: 2, value: { x: 2 } },
+      { id: 3, value: { x: 3 } },
+    ];
+
+    const result = removePrototypeMapDeep(objects);
+
+    expect(result.map((item) => item.id)).toEqual([1, 2, 3]);
+  });
+
+  it("should give every nested plain object a null prototype", () => {
+    const objects = [
+      { a: { b: 1 } },
+      JSON.parse('{"__proto__":{"polluted":true},"nested":{"deep":{"x":1}}}'),
+    ];
+
+    const result = removePrototypeMapDeep(objects);
+
+    for (const item of result) {
+      expect(Object.getPrototypeOf(item)).toBeNull();
+    }
+    expect(Object.getPrototypeOf(result[0].a)).toBeNull();
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic shape
+    expect(Object.getPrototypeOf((result[1] as any).nested)).toBeNull();
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic shape
+    expect(Object.getPrototypeOf((result[1] as any).nested.deep)).toBeNull();
+  });
+
+  it("should not mutate any of the input objects", () => {
+    const objects = [
+      JSON.parse('{"outer":{"__proto__":{"polluted":true},"ok":1}}'),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(objects));
+
+    removePrototypeMapDeep(objects);
+
+    // Note: JSON roundtrip drops __proto__, but the original still has it
+    expect(Object.hasOwn(objects[0].outer, "__proto__")).toBe(true);
+    expect(objects[0].outer.ok).toBe(snapshot[0].outer.ok);
+  });
+
+  it("should sanitize dangerous keys nested inside arrays", () => {
+    const objects = [
+      JSON.parse(
+        '{"items":[{"__proto__":{"polluted":true},"a":1},{"constructor":{"polluted":true},"b":2}]}',
+      ),
+    ];
+
+    const result = removePrototypeMapDeep(objects);
+
+    expect(result[0].items).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(Object.hasOwn(result[0].items[0], "__proto__")).toBe(false);
+    expect(Object.hasOwn(result[0].items[1], "constructor")).toBe(false);
+  });
+
+  it("should demonstrate that a naive recursive clone locally pollutes nested prototypes, while the deep map helper prevents it", () => {
+    const payloads = [JSON.parse('{"a":{"__proto__":{"injected":"deep"}}}')];
+
+    const vulnerableClone = (value: unknown): unknown => {
+      if (value === null || typeof value !== "object") {
+        return value;
+      }
+      if (Array.isArray(value)) {
+        return value.map((item) => vulnerableClone(item));
+      }
+      const result: Record<string, unknown> = {};
+      for (const key of Object.keys(value as Record<string, unknown>)) {
+        result[key] = vulnerableClone((value as Record<string, unknown>)[key]);
+      }
+      return result;
+    };
+
+    // The naive clone hits the __proto__ setter when assigning the cloned
+    // value back, so the nested child inherits from the injected object.
+    const cloned = vulnerableClone(payloads[0]) as {
+      a: { injected?: unknown };
+    };
+    expect(Object.getPrototypeOf(cloned.a)).toEqual({ injected: "deep" });
+    expect(cloned.a.injected).toBe("deep");
+
+    // After sanitization the nested object no longer carries the injected
+    // prototype.
+    const safe = removePrototypeMapDeep(payloads) as {
+      a: { injected?: unknown };
+    }[];
+    expect(safe).toEqual([{ a: {} }]);
+    const safeInner = safe[0].a;
+    expect(Object.getPrototypeOf(safeInner)).toBeNull();
+    expect(safeInner.injected).toBeUndefined();
+  });
+
+  it("should accept a readonly array", () => {
+    const objects: readonly Record<string, unknown>[] = [
+      JSON.parse('{"outer":{"__proto__":{"polluted":true},"ok":1}}'),
+    ];
+
+    const result = removePrototypeMapDeep(objects);
+
+    expect(result).toEqual([{ outer: { ok: 1 } }]);
+  });
+
+  it("should handle arrays that mix sanitized and already-safe objects", () => {
+    const objects = [
+      { clean: { a: 1 } },
+      JSON.parse('{"dirty":{"__proto__":{"polluted":true},"b":2}}'),
+    ];
+
+    const result = removePrototypeMapDeep(objects);
+
+    expect(result).toEqual([{ clean: { a: 1 } }, { dirty: { b: 2 } }]);
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds extensive integration and unit test coverage for prototype pollution defense across the Object utility library. The changes demonstrate both the real attack surface (how naive code gets polluted) and how the library's sanitization functions neutralize these threats end-to-end.

## Key Changes

### New Integration Test Suite
- Added `prototype-pollution.test.ts` with 8 comprehensive integration tests covering:
  - `__proto__` pollution via naive deep merge and prevention with `removePrototypeDeep` + `mergeDeep`
  - `constructor.prototype` pollution detection and mitigation
  - Batch sanitization of multiple request objects before merging
  - Safe chaining of `deepClone`, `pick`, and `mergeDeep` on user-controlled input
  - Nested field extraction with `pickDeep` on sanitized input
  - Demonstration that shallow sanitization is insufficient for deeply nested payloads
  - Multi-level prototype pollution chains
  - Safe handling of arrays containing malicious objects

### Enhanced Unit Test Coverage
Added new test cases across multiple Object utility modules to:
- **removePrototypeDeep**: Verify null prototype assignment at all nesting levels, array handling, and dangerous key removal at multiple depths
- **removePrototype**: Confirm null prototype on result, non-inheritance from Object.prototype, and shallow-only sanitization behavior
- **removePrototypeMap/removePrototypeMapDeep**: Validate array instance creation, element ordering, and nested prototype sanitization
- **mergeDeep**: Demonstrate `__proto__` and `constructor.prototype` pollution patterns with vulnerable code examples
- **deepClone**: Show local prototype pollution in clones and safe behavior after sanitization
- **merge**: Illustrate local vs. global pollution distinction and sanitization requirements
- **pick/pickDeep/omit**: Verify reference preservation and prototype pollution safety
- **mapKeys/mapValues**: Document behavior with `__proto__` payloads and primitive vs. object values
- **keyBy**: Demonstrate that dangerous keys never appear as own properties in results
- **getObjectsCommon/getObjectsDiff**: Add edge cases for NaN, strict equality, and inherited property handling
- **has/isEmpty/isPlainObject**: Expand coverage for edge cases and inheritance semantics

## Notable Implementation Details

- All integration tests include proper cleanup in `afterEach` to prevent prototype pollution from leaking to other test files
- Tests include vulnerable code patterns (naive deep merge implementations) to prove the attack surface is real
- Tests verify both that attacks succeed without sanitization and that library functions prevent them
- Documentation of known limitations (e.g., `mapKeys` locally replaces prototype when `__proto__` value is an object)
- Comprehensive coverage of the sanitization chain: `removePrototype*` → helper functions → safe output

https://claude.ai/code/session_014jN9Qji7SZirCew5gh9vVo