### PR TITLE
fix(umt_rust): enable getrandom wasm_js feature for wasm32 target

### DIFF
--- a/package/umt_rust/Cargo.toml
+++ b/package/umt_rust/Cargo.toml
@@ -24,6 +24,9 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 unicode-normalization = "0.1.25"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
 [dev-dependencies]
 criterion = "0.8.2"
 rand = "0.10.1"


### PR DESCRIPTION
## Summary

- umt_wasm の `wasm-pack build --target nodejs` が getrandom v0.4.x の wasm32-unknown-unknown 非対応エラーで失敗していた
- umt_rust/Cargo.toml に wasm32-unknown-unknown ターゲット限定で `getrandom` を `wasm_js` feature 付きで追加
- ネイティブビルドには影響なし (cargo test 274 件パス)

## Background

依存ツリー umt_wasm → umt_rust → rand 0.10.1 → rand_core 0.10.1 → getrandom 0.4.2 の getrandom が wasm32-unknown-unknown 向けに以下のエラーを出してビルド不能だった

```
error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" crate feature.
```

## Test plan

- [x] cargo build (umt_rust)
- [x] cargo test (umt_rust, 274 passed)
- [x] wasm-pack build --target nodejs (umt_wasm, ローカルパス参照に切り替えて検証成功)

🤖 Generated with [Claude Code](https://claude.com/claude-code)