### PR TITLE
Release v0.5.0 (umt_rust)

### DIFF
--- a/package/umt_rust/Cargo.lock
+++ b/package/umt_rust/Cargo.lock
@@ -281,11 +281,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -697,11 +699,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "umt_rust"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
  "criterion",
+ "getrandom",
  "num-bigint",
  "num-traits",
  "rand",

--- a/package/umt_rust/Cargo.toml
+++ b/package/umt_rust/Cargo.toml
@@ -6,7 +6,7 @@ exclude = [".github", ".gitignore", "tests"]
 license = "MIT"
 name = "umt_rust"
 repository = "https://github.com/riya-amemiya/UMT"
-version = "0.4.0"
+version = "0.5.0"
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
# Release v0.5.0

This release introduces two new modules — `predicate` and `url` — along with major additions to existing modules: caching primitives (LRU/TTL), function utilities (`memoize`, `once`), `Result` combinators, locale-aware number formatting, deep clone, and key/value mapping for objects. Performance and security fixes for `unique_f64`, `levenshtein_distance`, and `fuzzy_search` are also included.

## ✨ New Features

### 🧩 New Modules

* **`predicate`** (`umt_every`, `umt_some`, `umt_not`, `umt_matches`, `umt_is_nullish`, `umt_is_not_nullish`): Higher-order combinators for composing predicate functions, with a shared `BoxPredicate<T>` type alias (#709).
* **`url`** (`umt_build_url`, `umt_is_absolute_url`, `umt_join_path`, `umt_parse_query_string`): URL construction, RFC 3986 absolute-URL detection, path joining, and query-string parsing (#700, #734, #746).

### 🔧 New Functions in Existing Modules

* **`data_structure`**: Added `LruCache` (#677) and `TtlCache` (#698).
* **`error`**: Added `umt_map_result`, `umt_flat_map_result`, and `umt_match_result` Result combinators (#727).
* **`function`**: Added `umt_memoize` (#766) and `umt_once` (#753).
* **`number`**: Added `umt_format_number`, `umt_format_number_default`, `FormatNumberOptions`, and `FormatStyle` for locale-aware number formatting (#797).
* **`object`**: Added `umt_deep_clone` (#774), `umt_map_keys` (#676), and `umt_map_values` (#712).

## 🛡️ Security Fixes

* **`umt_fuzzy_search`**: Replaced `partial_cmp(...).unwrap()` with `unwrap_or(Ordering::Equal)` to prevent panics on `NaN` scores (#710).

## ⚡ Performance Optimizations

* **`umt_unique_f64`**: Replaced `Vec::contains` linear scan with `HashSet<u64>` keyed on `f64::to_bits()`, reducing deduplication from O(N²) to O(N) (#712).
* **`umt_levenshtein_distance`**: Added equality early-exit, single-row algorithm (eliminates the second `Vec` allocation), and shorter-string-first swap to cap space at O(min(n, m)) (#710).

## 🛠️ Bug Fixes

* **wasm32 target**: Enabled the `getrandom` `wasm_js` feature for `wasm32-unknown-unknown` so downstream wasm crates (e.g., `umt_wasm`) build successfully (#809).

## 🔄 Refactoring & Maintenance

* Bumped `rand` to 0.10.1 (#776).

## 🧪 Testing

* Ported `getObjectsCommon` test suite from TypeScript to keep behavior parity with `package/main` (#800).