### PR TITLE
Release v0.3.0 (umt_wasm)

### DIFF
--- a/package/umt_wasm/Cargo.lock
+++ b/package/umt_wasm/Cargo.lock
@@ -130,11 +130,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -443,7 +445,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "umt-plugin-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "umt_rust",
  "wasm-bindgen",
@@ -451,12 +453,13 @@ dependencies = [
 
 [[package]]
 name = "umt_rust"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9addcd0e45ef6739f399a3c1ecc49a80edad2f311129ac85c5623a5782e5a5"
+checksum = "81036d39809ca28d98daa42cadcbf6e361e09c13c19966ad5f3603abf55ffe17"
 dependencies = [
  "base64",
  "chrono",
+ "getrandom",
  "num-bigint",
  "num-traits",
  "rand",

--- a/package/umt_wasm/Cargo.toml
+++ b/package/umt_wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "umt-plugin-wasm"
-version = "0.2.0"
+version = "0.3.0"
 [lib]
 crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-umt_rust = "0.4.0"
+umt_rust = "0.5.0"
 wasm-bindgen = "0.2.108"


### PR DESCRIPTION
# Release v0.3.0

This release upgrades the underlying `umt_rust` dependency to v0.5.0 and migrates the crate to Rust edition 2024. The build is once again green on `wasm32-unknown-unknown` thanks to the upstream `getrandom` `wasm_js` feature fix.

## 🛠️ Bug Fixes

* **Build**: Fixed broken build on `wasm32-unknown-unknown` by pulling in `umt_rust` 0.5.0, which enables the `getrandom` `wasm_js` feature for the wasm target (#809).

## 🔄 Refactoring & Maintenance

* Bumped Rust edition from 2021 to 2024.
* Bumped `umt_rust` dependency from 0.4.0 to 0.5.0. See the [umt_rust v0.5.0 release notes](https://github.com/riya-amemiya/UMT/pull/812) for the full list of new modules and improvements (`predicate`, `url`, `LruCache`, `TtlCache`, `memoize`, `once`, locale-aware number formatting, deep clone, etc.).