### PR TITLE
Release v2.18.0

### DIFF
--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -37,6 +37,8 @@
     "ts-node": "10.9.2",
     "tsc-alias": "1.8.16",
     "typedoc": "0.28.19",
+    "typedoc-github-wiki-theme": "2.1.0",
+    "typedoc-plugin-markdown": "4.11.0",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.1"
   },
@@ -216,11 +218,12 @@
     "format": "nix develop --command make format",
     "lint": "nix develop --command make lint",
     "lint:ci": "nix develop --command make lint-ci",
+    "readme": "nix develop --command make readme",
     "test": "nix develop --command make test",
     "test-debug": "nix develop --command make test-debug",
     "ts-node": "nix develop --command make ts-node"
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "2.17.0"
+  "version": "2.18.0"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "2.17.0"
+  "version": "2.18.0"
 }


### PR DESCRIPTION
# Release v2.18.0

This release introduces two new validators (`oneOf` for string literal unions and `nullable` for null-tolerant validation), along with tooling for auto-generating the README function list and a CI workflow for publishing the wiki.

## ✨ New Features

### 🔧 New Functions in Existing Modules

* **Validate/string**: Added `oneOf` for validating string literal unions (e.g. `'standard' | 'squat' | 'decanter'`). The validator captures the literal union via `const T` and exposes it through the `type` field so the inferred type flows through `object()`, `union()`, and `intersection()` without being collapsed to `string` (#817, #818).
* **Validate/object**: Added `nullable` to wrap any validator and accept `null` values, useful for representing optional null-tolerant fields (#819).

## 🔄 Refactoring & Maintenance

* **Validate/object**: `intersection` and `union` now extract the validated value type by reading the validator's `type` field (and applying `ValidateType`) instead of inferring through `ValidateCoreReturnType<T>`, allowing literal-union-aware validators like `oneOf` to flow through without collapse (#818).

## 🛠️ Tooling

* Added `scripts/generateReadmeFunctionList.ts` and a corresponding command to auto-generate the README function list from typedoc output (#816).
* Added a `publish-wiki` GitHub Actions workflow for `package/main` (#815).

## 🧪 Testing

* Added unit tests for `Validate/string/oneOf` (193 lines).
* Added unit tests for `Validate/object/nullable` (407 lines).