### PR TITLE
Add arrayOf validator for validating arrays with element validators

### DIFF
--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -1,0 +1,61 @@
+/**
+ * Array validation module for arrays whose elements are validated by a single validator
+ * Useful for expressing arrays of objects, arrays of unions, and other structured element types
+ */
+
+import { isArray } from "@/Validate/isArray";
+import type {
+  Types,
+  ValidateCoreReturnType,
+  ValidateType,
+} from "@/Validate/type";
+
+// Extract the validated element type by reading the validator's `type` field
+// (and applying `ValidateType` to map type tags like "string" back to the
+// runtime type). Reading the field directly preserves literal unions and
+// object shapes that would otherwise be collapsed by `Types<T>`.
+type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+  ? ValidateType<T>
+  : never;
+
+/**
+ * Creates an array validator that validates every element with a single validator
+ * @template V - Validator function type for array elements
+ * @param {V} validator - Validator applied to each element (e.g. an object validator)
+ * @param {string} [message] - Custom error message for array type validation
+ * @returns {Function} - Validator function for arrays whose elements satisfy the given validator
+ */
+export const arrayOf = <
+  V extends (value: never) => ValidateCoreReturnType<unknown>,
+>(
+  validator: V,
+  message?: string,
+) => {
+  type Element = ExtractValidatedType<V>;
+  return (values: Element[]): ValidateCoreReturnType<Element[]> => {
+    if (!isArray(values)) {
+      return {
+        validate: false,
+        message: message ?? "",
+        type: values as unknown as Types<Element[]>,
+      };
+    }
+    for (const value of values) {
+      const result = (
+        validator as unknown as (v: Element) => ValidateCoreReturnType<Element>
+      )(value);
+      if (!result.validate) {
+        return {
+          validate: false,
+          message: result.message,
+          type: values as unknown as Types<Element[]>,
+        };
+      }
+    }
+    return {
+      validate: true,
+      message: "",
+      type: values as unknown as Types<Element[]>,
+    };
+  };
+};

--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -1,8 +1,3 @@
-/**
- * Array validation module for arrays whose elements are validated by a single validator
- * Useful for expressing arrays of objects, arrays of unions, and other structured element types
- */
-
 import { isArray } from "@/Validate/isArray";
 import type {
   Types,
@@ -10,10 +5,6 @@ import type {
   ValidateType,
 } from "@/Validate/type";
 
-// Extract the validated element type by reading the validator's `type` field
-// (and applying `ValidateType` to map type tags like "string" back to the
-// runtime type). Reading the field directly preserves literal unions and
-// object shapes that would otherwise be collapsed by `Types<T>`.
 type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
   ? ValidateType<T>
   : never;

--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -1,52 +1,39 @@
 import { isArray } from "@/Validate/isArray";
-import type {
-  Types,
-  ValidateCoreReturnType,
-  ValidateType,
-} from "@/Validate/type";
-
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
-  ? ValidateType<T>
-  : never;
+import type { ValidateCoreReturnType } from "@/Validate/type";
 
 /**
  * Creates an array validator that validates every element with a single validator
- * @template V - Validator function type for array elements
- * @param {V} validator - Validator applied to each element (e.g. an object validator)
+ * @template T - Element type validated by the wrapped validator
+ * @param {Function} validator - Validator applied to each element (e.g. an object validator)
  * @param {string} [message] - Custom error message for array type validation
  * @returns {Function} - Validator function for arrays whose elements satisfy the given validator
  */
-export const arrayOf = <
-  V extends (value: never) => ValidateCoreReturnType<unknown>,
->(
-  validator: V,
+export const arrayOf = <T>(
+  validator: (value: T) => ValidateCoreReturnType<T>,
   message?: string,
 ) => {
-  type Element = ExtractValidatedType<V>;
-  return (values: Element[]): ValidateCoreReturnType<Element[]> => {
+  return (values: T[]): ValidateCoreReturnType<T[]> => {
     if (!isArray(values)) {
       return {
         validate: false,
         message: message ?? "",
-        type: values as unknown as Types<Element[]>,
+        type: values,
       };
     }
     for (const value of values) {
-      const result = (
-        validator as unknown as (v: Element) => ValidateCoreReturnType<Element>
-      )(value);
+      const result = validator(value);
       if (!result.validate) {
         return {
           validate: false,
           message: result.message,
-          type: values as unknown as Types<Element[]>,
+          type: values,
         };
       }
     }
     return {
       validate: true,
       message: "",
-      type: values as unknown as Types<Element[]>,
+      type: values,
     };
   };
 };

--- a/package/main/src/Validate/array/index.ts
+++ b/package/main/src/Validate/array/index.ts
@@ -1,1 +1,2 @@
+export * from "./arrayOf";
 export * from "./core";

--- a/package/main/src/Validate/type.ts
+++ b/package/main/src/Validate/type.ts
@@ -79,7 +79,7 @@ export type ValidateType<T> = T extends "string" | "number" | "boolean"
 export type SchemaToInterface<
   // biome-ignore lint/suspicious/noExplicitAny: ignore
   T extends (value: any) => ValidateCoreReturnType<any>,
-> = ReturnType<T>["type"];
+> = ValidateType<ReturnType<T>["type"]>;
 
 export type OptionalKeys<T> = {
   [K in keyof T]: undefined extends T[K] ? K : never;

--- a/package/main/src/tests/unit/Validate/array/arrayOf.test.ts
+++ b/package/main/src/tests/unit/Validate/array/arrayOf.test.ts
@@ -1,8 +1,13 @@
 import { arrayOf } from "@/Validate/array/arrayOf";
 import { number } from "@/Validate/number";
+import { minValue } from "@/Validate/number/minValue";
 import { object } from "@/Validate/object/core";
+import { intersection } from "@/Validate/object/intersection";
+import { nullable } from "@/Validate/object/nullable";
 import { optional } from "@/Validate/object/optional";
+import { union } from "@/Validate/object/union";
 import { string } from "@/Validate/string";
+import type { SchemaToInterface } from "@/Validate/type";
 
 describe("arrayOf validation", () => {
   it("should validate an empty array", () => {
@@ -43,9 +48,25 @@ describe("arrayOf validation", () => {
   it("should fail when the value is not an array", () => {
     const validator = arrayOf(object({ name: string() }), "not an array");
     // @ts-expect-error null is not an array
+    const nullResult = validator(null);
+    expect(nullResult.validate).toBe(false);
+    expect(nullResult.message).toBe("not an array");
+    // @ts-expect-error undefined is not an array
+    const undefinedResult = validator(undefined);
+    expect(undefinedResult.validate).toBe(false);
+    expect(undefinedResult.message).toBe("not an array");
+    // @ts-expect-error string is not an array
+    const stringResult = validator("not array");
+    expect(stringResult.validate).toBe(false);
+    expect(stringResult.message).toBe("not an array");
+  });
+
+  it("should default the message to empty string when none is provided", () => {
+    const validator = arrayOf(object({ name: string() }));
+    // @ts-expect-error null is not an array
     const result = validator(null);
     expect(result.validate).toBe(false);
-    expect(result.message).toBe("not an array");
+    expect(result.message).toBe("");
   });
 
   it("should propagate the element validation message", () => {
@@ -81,18 +102,214 @@ describe("arrayOf validation", () => {
         }),
       ),
     });
-    const result = validator({
+    const validResult = validator({
       users: [
         { name: "John", age: 30 },
         { name: "Jane", age: 25 },
       ],
     });
-    expect(result.validate).toBe(true);
+    expect(validResult.validate).toBe(true);
+    const invalidResult = validator({
+      // @ts-expect-error invalid nested age
+      users: [{ name: "John", age: "30" }],
+    });
+    expect(invalidResult.validate).toBe(false);
   });
 
-  it("should preserve the original array in the return type field", () => {
+  it("should preserve the original array in the type field", () => {
     const data = [{ name: "John" }];
     const validator = arrayOf(object({ name: string() }));
     expect(validator(data).type).toBe(data);
+  });
+
+  it("should validate arrays of strings using a primitive validator", () => {
+    const validator = arrayOf(string());
+    expect(validator(["a", "b", "c"]).validate).toBe(true);
+    // @ts-expect-error mixed element type
+    expect(validator(["a", 1]).validate).toBe(false);
+  });
+
+  it("should validate arrays of numbers with rule chains", () => {
+    const validator = arrayOf(number([minValue(0)]));
+    expect(validator([0, 1, 2]).validate).toBe(true);
+    expect(validator([0, -1]).validate).toBe(false);
+  });
+
+  it("should validate arrays of union elements", () => {
+    const validator = arrayOf(union(string(), number()));
+    expect(validator(["a", 1, "b"]).validate).toBe(true);
+    // @ts-expect-error boolean is not in the union
+    expect(validator(["a", true]).validate).toBe(false);
+  });
+
+  it("should validate arrays whose elements may be null via nullable", () => {
+    const validator = arrayOf(nullable(string()));
+    expect(validator(["a", null, "b"]).validate).toBe(true);
+    // @ts-expect-error number is not allowed
+    expect(validator(["a", 1]).validate).toBe(false);
+  });
+
+  it("should accept null when the whole array is wrapped by nullable", () => {
+    const validator = nullable(arrayOf(string()));
+    expect(validator(null).validate).toBe(true);
+    expect(validator(["a", "b"]).validate).toBe(true);
+    // @ts-expect-error number is not allowed
+    expect(validator(["a", 1]).validate).toBe(false);
+  });
+
+  it("should accept undefined when the whole array is wrapped by optional", () => {
+    const validator = optional(arrayOf(string()));
+    expect(validator(undefined).validate).toBe(true);
+    expect(validator(["a"]).validate).toBe(true);
+    // @ts-expect-error number is not allowed
+    expect(validator(["a", 1]).validate).toBe(false);
+  });
+
+  it("should validate arrays of intersection elements", () => {
+    const validator = arrayOf(
+      intersection(object({ name: string() }), object({ age: number() })),
+    );
+    expect(validator([{ name: "John", age: 30 }]).validate).toBe(true);
+    // @ts-expect-error missing age
+    expect(validator([{ name: "John" }]).validate).toBe(false);
+  });
+
+  it("should support nested arrayOf for matrix-like data", () => {
+    const validator = arrayOf(arrayOf(number()));
+    expect(
+      validator([
+        [1, 2],
+        [3, 4],
+      ]).validate,
+    ).toBe(true);
+    // @ts-expect-error inner element wrong type
+    expect(validator([[1, "2"]]).validate).toBe(false);
+  });
+
+  it("should stop at the first failing element", () => {
+    const calls: number[] = [];
+    const trackingValidator = (value: number) => {
+      calls.push(value);
+      return {
+        validate: value >= 0,
+        message: value >= 0 ? "" : "negative",
+        type: value,
+      };
+    };
+    const validator = arrayOf(trackingValidator);
+    const result = validator([1, -1, -2]);
+    expect(result.validate).toBe(false);
+    expect(result.message).toBe("negative");
+    expect(calls).toEqual([1, -1]);
+  });
+
+  it("should infer the schema as an array of objects via SchemaToInterface", () => {
+    const validator = arrayOf(
+      object({
+        name: string(),
+        age: number(),
+      }),
+    );
+    type Schema = SchemaToInterface<typeof validator>;
+    const valid: Schema = [
+      { name: "John", age: 30 },
+      { name: "Jane", age: 25 },
+    ];
+    expect(validator(valid).validate).toBe(true);
+    // @ts-expect-error age must be a number, not a string
+    const wrongValueType: Schema = [{ name: "John", age: "30" }];
+    expect(wrongValueType).toHaveLength(1);
+    // @ts-expect-error missing the age property
+    const missingProperty: Schema = [{ name: "John" }];
+    expect(missingProperty).toHaveLength(1);
+    // @ts-expect-error must be an array, not a single object
+    const notArray: Schema = { name: "John", age: 30 };
+    expect(notArray).toBeDefined();
+  });
+
+  it("should infer the schema for an object containing arrayOf", () => {
+    const schema = object({
+      users: arrayOf(
+        object({
+          name: string(),
+          age: number(),
+        }),
+      ),
+    });
+    type Schema = SchemaToInterface<typeof schema>;
+    const valid: Schema = {
+      users: [
+        { name: "John", age: 30 },
+        { name: "Jane", age: 25 },
+      ],
+    };
+    expect(schema(valid).validate).toBe(true);
+    // @ts-expect-error name must be a string
+    const wrong: Schema = { users: [{ name: 1, age: 30 }] };
+    expect(wrong.users).toHaveLength(1);
+  });
+
+  it("should infer optional properties on inferred schemas", () => {
+    const validator = arrayOf(
+      object({
+        name: string(),
+        age: optional(number()),
+      }),
+    );
+    type Schema = SchemaToInterface<typeof validator>;
+    const withAge: Schema = [{ name: "John", age: 30 }];
+    const withoutAge: Schema = [{ name: "Jane" }];
+    expect(validator(withAge).validate).toBe(true);
+    expect(validator(withoutAge).validate).toBe(true);
+  });
+
+  it("should infer primitive element types via SchemaToInterface", () => {
+    const stringArrayValidator = arrayOf(string());
+    type StringSchema = SchemaToInterface<typeof stringArrayValidator>;
+    const strings: StringSchema = ["a", "b"];
+    expect(stringArrayValidator(strings).validate).toBe(true);
+    // @ts-expect-error number is not assignable to string
+    const wrong: StringSchema = ["a", 1];
+    expect(wrong).toHaveLength(2);
+
+    const numberArrayValidator = arrayOf(number([minValue(0)]));
+    type NumberSchema = SchemaToInterface<typeof numberArrayValidator>;
+    const numbers: NumberSchema = [1, 2];
+    expect(numberArrayValidator(numbers).validate).toBe(true);
+  });
+
+  it("should infer union element types via SchemaToInterface", () => {
+    const validator = arrayOf(union(string(), number()));
+    type Schema = SchemaToInterface<typeof validator>;
+    const mixed: Schema = ["a", 1, "b", 2];
+    expect(validator(mixed).validate).toBe(true);
+    // @ts-expect-error boolean is not in the union
+    const wrong: Schema = ["a", true];
+    expect(wrong).toHaveLength(2);
+  });
+
+  it("should infer intersection element types via SchemaToInterface", () => {
+    const validator = arrayOf(
+      intersection(object({ name: string() }), object({ age: number() })),
+    );
+    type Schema = SchemaToInterface<typeof validator>;
+    const valid: Schema = [{ name: "John", age: 30 }];
+    expect(validator(valid).validate).toBe(true);
+    // @ts-expect-error missing the age property required by the intersection
+    const wrong: Schema = [{ name: "John" }];
+    expect(wrong).toHaveLength(1);
+  });
+
+  it("should infer nested arrayOf as a 2D array via SchemaToInterface", () => {
+    const validator = arrayOf(arrayOf(number()));
+    type Schema = SchemaToInterface<typeof validator>;
+    const matrix: Schema = [
+      [1, 2],
+      [3, 4],
+    ];
+    expect(validator(matrix).validate).toBe(true);
+    // @ts-expect-error inner element must be number
+    const wrong: Schema = [["a"]];
+    expect(wrong).toHaveLength(1);
   });
 });

--- a/package/main/src/tests/unit/Validate/array/arrayOf.test.ts
+++ b/package/main/src/tests/unit/Validate/array/arrayOf.test.ts
@@ -1,0 +1,98 @@
+import { arrayOf } from "@/Validate/array/arrayOf";
+import { number } from "@/Validate/number";
+import { object } from "@/Validate/object/core";
+import { optional } from "@/Validate/object/optional";
+import { string } from "@/Validate/string";
+
+describe("arrayOf validation", () => {
+  it("should validate an empty array", () => {
+    const validator = arrayOf(object({ name: string() }));
+    expect(validator([]).validate).toBe(true);
+  });
+
+  it("should validate an array of valid objects", () => {
+    const validator = arrayOf(
+      object({
+        name: string(),
+        age: number(),
+      }),
+    );
+    const result = validator([
+      { name: "John", age: 30 },
+      { name: "Jane", age: 25 },
+    ]);
+    expect(result.validate).toBe(true);
+    expect(result.message).toBe("");
+  });
+
+  it("should fail when an element does not match the object validator", () => {
+    const validator = arrayOf(
+      object({
+        name: string(),
+        age: number(),
+      }),
+    );
+    const result = validator([
+      { name: "John", age: 30 },
+      // @ts-expect-error invalid age type
+      { name: "Jane", age: "twenty-five" },
+    ]);
+    expect(result.validate).toBe(false);
+  });
+
+  it("should fail when the value is not an array", () => {
+    const validator = arrayOf(object({ name: string() }), "not an array");
+    // @ts-expect-error null is not an array
+    const result = validator(null);
+    expect(result.validate).toBe(false);
+    expect(result.message).toBe("not an array");
+  });
+
+  it("should propagate the element validation message", () => {
+    const message = "name must be a string";
+    const validator = arrayOf(
+      object({
+        name: string([], message),
+      }),
+    );
+    // @ts-expect-error name has wrong type
+    const result = validator([{ name: 1 }]);
+    expect(result.validate).toBe(false);
+    expect(result.message).toBe(message);
+  });
+
+  it("should validate arrays of objects with optional properties", () => {
+    const validator = arrayOf(
+      object({
+        name: string(),
+        age: optional(number()),
+      }),
+    );
+    const result = validator([{ name: "John" }, { name: "Jane", age: 25 }]);
+    expect(result.validate).toBe(true);
+  });
+
+  it("should support nesting arrayOf inside object", () => {
+    const validator = object({
+      users: arrayOf(
+        object({
+          name: string(),
+          age: number(),
+        }),
+      ),
+    });
+    const result = validator({
+      users: [
+        { name: "John", age: 30 },
+        { name: "Jane", age: 25 },
+      ],
+    });
+    expect(result.validate).toBe(true);
+  });
+
+  it("should preserve the original array in the return type field", () => {
+    const data = [{ name: "John" }];
+    const validator = arrayOf(object({ name: string() }));
+    expect(validator(data).type).toBe(data);
+  });
+});

--- a/package/main/src/tests/unit/Validate/array/arrayOf.test.ts
+++ b/package/main/src/tests/unit/Validate/array/arrayOf.test.ts
@@ -7,7 +7,10 @@ import { nullable } from "@/Validate/object/nullable";
 import { optional } from "@/Validate/object/optional";
 import { union } from "@/Validate/object/union";
 import { string } from "@/Validate/string";
-import type { SchemaToInterface } from "@/Validate/type";
+import type {
+  SchemaToInterface,
+  ValidateCoreReturnType,
+} from "@/Validate/type";
 
 describe("arrayOf validation", () => {
   it("should validate an empty array", () => {
@@ -188,12 +191,14 @@ describe("arrayOf validation", () => {
 
   it("should stop at the first failing element", () => {
     const calls: number[] = [];
-    const trackingValidator = (value: number) => {
+    const trackingValidator = (
+      value: number,
+    ): ValidateCoreReturnType<number> => {
       calls.push(value);
       return {
         validate: value >= 0,
         message: value >= 0 ? "" : "negative",
-        type: value,
+        type: "number",
       };
     };
     const validator = arrayOf(trackingValidator);

--- a/package/main/src/tests/unit/Validate/object/nullable.test.ts
+++ b/package/main/src/tests/unit/Validate/object/nullable.test.ts
@@ -6,6 +6,7 @@ import { nullable } from "@/Validate/object/nullable";
 import { optional } from "@/Validate/object/optional";
 import { union } from "@/Validate/object/union";
 import { string, validateEmail } from "@/Validate/string";
+import type { SchemaToInterface } from "@/Validate/type";
 
 describe("nullable function", () => {
   it("should allow null values for nullable properties in objects", () => {
@@ -403,5 +404,50 @@ describe("nullable function", () => {
     expect(validateObjectA(fromA).validate).toBe(true);
     expect(validateObjectB(fromB).validate).toBe(true);
     expect(validateObjectA(backToA).validate).toBe(true);
+  });
+
+  it("should infer nullable(string()) as string | null via SchemaToInterface", () => {
+    const validate = nullable(string());
+    type Schema = SchemaToInterface<typeof validate>;
+    const s: Schema = "hello";
+    const n: Schema = null;
+    expect(validate(s).validate).toBe(true);
+    expect(validate(n).validate).toBe(true);
+    // @ts-expect-error number is not assignable to string | null
+    const wrong: Schema = 1;
+    expect(wrong).toBe(1);
+  });
+
+  it("should infer nullable(number()) as number | null via SchemaToInterface", () => {
+    const validate = nullable(number());
+    type Schema = SchemaToInterface<typeof validate>;
+    const v: Schema = 42;
+    const n: Schema = null;
+    expect(validate(v).validate).toBe(true);
+    expect(validate(n).validate).toBe(true);
+    // @ts-expect-error string is not assignable to number | null
+    const wrong: Schema = "nope";
+    expect(wrong).toBe("nope");
+  });
+
+  it("should infer nullable(boolean()) as boolean | null via SchemaToInterface", () => {
+    const validate = nullable(boolean());
+    type Schema = SchemaToInterface<typeof validate>;
+    const v: Schema = true;
+    const n: Schema = null;
+    expect(validate(v).validate).toBe(true);
+    expect(validate(n).validate).toBe(true);
+  });
+
+  it("should infer nullable wrapping object as the object shape or null via SchemaToInterface", () => {
+    const validate = nullable(object({ name: string(), age: number() }));
+    type Schema = SchemaToInterface<typeof validate>;
+    const v: Schema = { name: "John", age: 30 };
+    const n: Schema = null;
+    expect(validate(v).validate).toBe(true);
+    expect(validate(n).validate).toBe(true);
+    // @ts-expect-error missing age
+    const wrong: Schema = { name: "John" };
+    expect(wrong).toBeDefined();
   });
 });

--- a/package/main/src/tests/unit/Validate/object/optional.test.ts
+++ b/package/main/src/tests/unit/Validate/object/optional.test.ts
@@ -2,6 +2,7 @@ import { number } from "@/Validate/number";
 import { object } from "@/Validate/object/core";
 import { optional } from "@/Validate/object/optional";
 import { string } from "@/Validate/string";
+import type { SchemaToInterface } from "@/Validate/type";
 
 describe("optional function", () => {
   it("should allow omitting optional properties in objects", () => {
@@ -120,5 +121,35 @@ describe("optional function", () => {
     expect(test2).toBeDefined();
     expect(test3).toBeDefined();
     expect(test4).toBeDefined();
+  });
+
+  it("should infer optional(string()) as string | undefined via SchemaToInterface", () => {
+    const validate = optional(string());
+    type Schema = SchemaToInterface<typeof validate>;
+    const s: Schema = "hello";
+    const u: Schema = undefined;
+    expect(validate(s).validate).toBe(true);
+    expect(validate(u).validate).toBe(true);
+    // @ts-expect-error number is not assignable to string | undefined
+    const wrong: Schema = 1;
+    expect(wrong).toBe(1);
+  });
+
+  it("should infer optional(number()) as number | undefined via SchemaToInterface", () => {
+    const validate = optional(number());
+    type Schema = SchemaToInterface<typeof validate>;
+    const v: Schema = 42;
+    const u: Schema = undefined;
+    expect(validate(v).validate).toBe(true);
+    expect(validate(u).validate).toBe(true);
+  });
+
+  it("should infer optional wrapping object as the object shape or undefined via SchemaToInterface", () => {
+    const validate = optional(object({ name: string(), age: number() }));
+    type Schema = SchemaToInterface<typeof validate>;
+    const v: Schema = { name: "John", age: 30 };
+    const u: Schema = undefined;
+    expect(validate(v).validate).toBe(true);
+    expect(validate(u).validate).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
This PR introduces a new `arrayOf` validator that enables validation of arrays where each element must satisfy a given validator. This complements the existing validation system and allows for flexible array validation with any validator type (primitives, objects, unions, intersections, etc.).

## Key Changes
- **New `arrayOf` validator**: Created `src/Validate/array/arrayOf.ts` that validates arrays by applying a single validator to each element, stopping at the first failure
- **Comprehensive test suite**: Added 30+ test cases covering:
  - Basic array validation (empty arrays, valid/invalid elements)
  - Nested structures (arrays of objects, nested arrays)
  - Integration with other validators (union, intersection, nullable, optional)
  - Type inference via `SchemaToInterface`
  - Early termination on validation failure
- **Type inference support**: Implemented proper TypeScript type extraction so `SchemaToInterface<typeof arrayOf(...)>` correctly infers array types
- **Enhanced existing tests**: Added `SchemaToInterface` type inference tests to `nullable.test.ts` and `optional.test.ts` to verify proper type inference for wrapped validators
- **Export updates**: Updated `src/Validate/array/index.ts` to export the new `arrayOf` validator

## Implementation Details
- The validator uses a generic type parameter to extract the element type from the provided validator
- Validation short-circuits on the first failing element for efficiency
- Supports custom error messages for non-array inputs
- Properly preserves the original array in the return type
- Works seamlessly with all existing validators (object, string, number, union, intersection, nullable, optional)

https://claude.ai/code/session_01JtK8evGAoYmmJvjneUwodd