### PR TITLE
Release v2.19.0

### DIFF
--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -7,23 +7,23 @@
   "devDependencies": {
     "@babel/cli": "7.28.6",
     "@babel/core": "7.29.0",
-    "@babel/preset-env": "7.29.2",
+    "@babel/preset-env": "7.29.5",
     "@babel/preset-typescript": "7.28.5",
-    "@biomejs/biome": "2.4.13",
+    "@biomejs/biome": "2.4.14",
     "@codecov/bundle-analyzer": "2.0.1",
     "@eslint/js": "10.0.1",
-    "@swc/core": "1.15.32",
+    "@swc/core": "1.15.33",
     "@swc/jest": "0.2.39",
     "@types/bun": "1.3.13",
     "@types/jest": "30.0.0",
     "@types/lodash": "4.17.24",
     "@types/node": "25.6.0",
-    "@typescript-eslint/eslint-plugin": "8.59.1",
-    "@typescript-eslint/parser": "8.59.1",
+    "@typescript-eslint/eslint-plugin": "8.59.2",
+    "@typescript-eslint/parser": "8.59.2",
     "bun-types": "1.3.13",
-    "dependency-cruiser": "17.3.10",
-    "es-toolkit": "1.46.0",
-    "eslint": "10.2.1",
+    "dependency-cruiser": "17.4.0",
+    "es-toolkit": "1.46.1",
+    "eslint": "10.3.0",
     "eslint-plugin-baseline-js": "0.6.2",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-unicorn": "64.0.0",
@@ -35,12 +35,12 @@
     "mitata": "1.0.34",
     "ts-jest": "29.4.9",
     "ts-node": "10.9.2",
-    "tsc-alias": "1.8.16",
+    "tsc-alias": "1.8.17",
     "typedoc": "0.28.19",
     "typedoc-github-wiki-theme": "2.1.0",
     "typedoc-plugin-markdown": "4.11.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.59.1"
+    "typescript-eslint": "8.59.2"
   },
   "exports": {
     ".": {
@@ -225,5 +225,5 @@
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "2.18.0"
+  "version": "2.19.0"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "2.18.0"
+  "version": "2.19.0"
 }


### PR DESCRIPTION
# Release v2.19.0

This release adds an `arrayOf` validator for validating arrays whose elements satisfy a given validator, refines the `SchemaToInterface` type to apply `ValidateType` for accurate inference, and bumps several dev dependencies.

## ✨ New Features

### 🔧 New Functions in Existing Modules

* **Validate/array**: Added `arrayOf` to wrap any element validator into an array validator. Returns failure when the input is not an array, or when any element fails the wrapped validator (#825).

## 🔄 Refactoring & Maintenance

* **Validate/type**: `SchemaToInterface` now applies `ValidateType` to the validator's `type` field instead of returning it raw, so inferred schema interfaces correctly map primitive marker strings to their concrete types (#825).

## 🧪 Testing

* Added unit tests for `Validate/array/arrayOf` (320 lines).
* Added unit tests for `Validate/object/nullable` (46 lines).
* Added unit tests for `Validate/object/optional` (31 lines).

## 🔧 Dependencies

* Bumped dev dependencies via the `bun-dependencies` group (#822):
  * `@babel/preset-env` 7.29.2 → 7.29.5
  * `@biomejs/biome` 2.4.13 → 2.4.14
  * `@swc/core` 1.15.32 → 1.15.33
  * `@typescript-eslint/eslint-plugin` 8.59.1 → 8.59.2
  * `@typescript-eslint/parser` 8.59.1 → 8.59.2
  * `dependency-cruiser` 17.3.10 → 17.4.0
  * `es-toolkit` 1.46.0 → 1.46.1
  * `eslint` 10.2.1 → 10.3.0
  * `tsc-alias` 1.8.16 → 1.8.17
  * `typescript-eslint` 8.59.1 → 8.59.2
