### PR TITLE
Release v3.0.1

### DIFF
--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -225,5 +225,5 @@
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/package/main/src/Date/getDay.ts
+++ b/package/main/src/Date/getDay.ts
@@ -1,6 +1,6 @@
 import type { ArrayToUnion } from "$/logic/arrayToUnion";
 
-interface DayList {
+export interface DayList {
   de: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
   ko: ["일", "월", "화", "수", "목", "금", "토"];
   en: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];

--- a/package/main/src/Object/keyBy.ts
+++ b/package/main/src/Object/keyBy.ts
@@ -1,6 +1,6 @@
-type PropertyName = string | number | symbol;
+export type PropertyName = string | number | symbol;
 type IterateeFunction<T> = (value: T) => PropertyName;
-type Iteratee<T> = IterateeFunction<T> | keyof T;
+export type Iteratee<T> = IterateeFunction<T> | keyof T;
 
 /**
  * Creates an object composed of keys generated from the results of running each element of collection through iteratee

--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -1,14 +1,14 @@
 import { isArray } from "@/Validate/isArray";
-import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
+import type {
+  ExtractValidatedType,
+  ValidateCoreReturnType,
+} from "@/Validate/type";
 
 // Extract the validated value type by reading the validator's `type` field
 // (and applying `ValidateType` to map type tags like "string" back to the
 // runtime type). Reading the field directly lets validators that expose the
 // literal union via the `type` field (such as `oneOf`) flow through arrayOf
 // without being collapsed to `string`.
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
-  ? ValidateType<T>
-  : never;
 
 /**
  * Creates an array validator that validates every element with a single validator

--- a/package/main/src/Validate/function/core.ts
+++ b/package/main/src/Validate/function/core.ts
@@ -14,18 +14,18 @@
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
-type AnyValidator = (value: any) => ValidateCoreReturnType<unknown>;
+export type AnyValidator = (value: any) => ValidateCoreReturnType<unknown>;
 
 type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
   ? ValidateType<T>
   : never;
 
-type InferInputs<Inputs> = Inputs extends readonly AnyValidator[]
+export type InferInputs<Inputs> = Inputs extends readonly AnyValidator[]
   ? { [K in keyof Inputs]: ExtractValidatedType<Inputs[K]> }
   : // biome-ignore lint/suspicious/noExplicitAny: open signature when no schema provided
     any[];
 
-type InferOutput<Output> = Output extends AnyValidator
+export type InferOutput<Output> = Output extends AnyValidator
   ? ExtractValidatedType<Output>
   : // biome-ignore lint/suspicious/noExplicitAny: open signature when no schema provided
     any;
@@ -40,8 +40,8 @@ export interface FunctionSchema {
   output?: AnyValidator;
 }
 
-type ExtractInput<S> = S extends { input: infer I } ? I : undefined;
-type ExtractOutput<S> = S extends { output: infer O } ? O : undefined;
+export type ExtractInput<S> = S extends { input: infer I } ? I : undefined;
+export type ExtractOutput<S> = S extends { output: infer O } ? O : undefined;
 
 /**
  * Inferred function signature from a `FunctionSchema`. Used by callers via

--- a/package/main/src/Validate/instanceof/core.ts
+++ b/package/main/src/Validate/instanceof/core.ts
@@ -8,7 +8,7 @@
 import type { Types, ValidateCoreReturnType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: a constructor signature must accept any tuple
-type Constructor<T> = new (...arguments_: any[]) => T;
+export type Constructor<T> = new (...arguments_: any[]) => T;
 
 /**
  * Creates a validator that checks whether a value is an instance of the given

--- a/package/main/src/Validate/map/core.ts
+++ b/package/main/src/Validate/map/core.ts
@@ -5,11 +5,10 @@
  * `arrayOf()` validates each element of an array.
  */
 
-import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
-
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
-  ? ValidateType<T>
-  : never;
+import type {
+  ExtractValidatedType,
+  ValidateCoreReturnType,
+} from "@/Validate/type";
 
 /**
  * Creates a Map validator. The validator can optionally accept per-entry key

--- a/package/main/src/Validate/object/intersection.ts
+++ b/package/main/src/Validate/object/intersection.ts
@@ -18,7 +18,7 @@ type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
 // validator (e.g. `union(A, B)`), unlike `UnionToIntersection` over
 // `Vs[number]` which would distribute over the inner union and collapse
 // `(A | B) & C` into `A & B & C`.
-type IntersectValidatedTypes<Vs> = Vs extends readonly [
+export type IntersectValidatedTypes<Vs> = Vs extends readonly [
   infer Head,
   ...infer Tail,
 ]

--- a/package/main/src/Validate/object/nullable.ts
+++ b/package/main/src/Validate/object/nullable.ts
@@ -1,4 +1,4 @@
-interface NullReturn {
+export interface NullReturn {
   validate: boolean;
   message: string;
   type: "null";

--- a/package/main/src/Validate/object/optional.ts
+++ b/package/main/src/Validate/object/optional.ts
@@ -1,4 +1,4 @@
-interface UndefinedReturn {
+export interface UndefinedReturn {
   validate: boolean;
   message: string;
   type: "undefined";

--- a/package/main/src/Validate/object/partial.ts
+++ b/package/main/src/Validate/object/partial.ts
@@ -8,7 +8,7 @@
 import { object, type ObjectShape, type ObjectValidator } from "./core";
 import { optional, type OptionalValidator } from "./optional";
 
-type PartialShape<T extends ObjectShape> = {
+export type PartialShape<T extends ObjectShape> = {
   [K in keyof T]: OptionalValidator<
     Parameters<T[K]>[0],
     ReturnType<T[K]> extends {

--- a/package/main/src/Validate/object/required.ts
+++ b/package/main/src/Validate/object/required.ts
@@ -11,7 +11,7 @@ import type { OptionalValidator } from "./optional";
 type UnwrapOptional<V> =
   V extends OptionalValidator<infer Inner, infer R> ? (value: Inner) => R : V;
 
-type RequiredShape<T extends ObjectShape> = {
+export type RequiredShape<T extends ObjectShape> = {
   [K in keyof T]: UnwrapOptional<T[K]> extends ObjectShape[string]
     ? UnwrapOptional<T[K]>
     : T[K];

--- a/package/main/src/Validate/object/union.ts
+++ b/package/main/src/Validate/object/union.ts
@@ -1,7 +1,7 @@
 import type {
+  ExtractValidatedType,
   Types,
   ValidateCoreReturnType,
-  ValidateType,
 } from "@/Validate/type";
 
 // Extract the validated value type by reading the validator's `type` field
@@ -9,9 +9,6 @@ import type {
 // runtime type). Reading the field directly lets validators that expose the
 // literal union via the `type` field (such as `oneOf`) flow through union
 // without being collapsed by `Types<T>`.
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
-  ? ValidateType<T>
-  : never;
 
 /**
  * Creates a union validator that passes if any of the given validators pass

--- a/package/main/src/Validate/set/core.ts
+++ b/package/main/src/Validate/set/core.ts
@@ -8,11 +8,10 @@
  * already exposes a `set` runtime helper.
  */
 
-import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
-
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
-  ? ValidateType<T>
-  : never;
+import type {
+  ExtractValidatedType,
+  ValidateCoreReturnType,
+} from "@/Validate/type";
 
 /**
  * Creates a Set validator. When a per-element validator is supplied, every

--- a/package/main/src/Validate/templateLiteral/core.ts
+++ b/package/main/src/Validate/templateLiteral/core.ts
@@ -10,14 +10,17 @@
 import type { ValidateType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
-export type TemplateLiteralValidator = (value?: any) => { type: unknown };
+type AnyValidator = (value?: any) => { type: unknown };
 
 /**
  * Allowed parts of a template literal definition. Each element is either a
  * string literal that must appear verbatim, or a primitive validator whose
  * accepted shape is converted to a regex fragment at construction time.
  */
-export type TemplateLiteralPart = string | TemplateLiteralValidator;
+export type TemplateLiteralPart =
+  | string
+  // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
+  | ((value?: any) => { type: unknown });
 
 type ExtractValidatorTag<V> = V extends (value: never) => { type: infer T }
   ? T
@@ -85,7 +88,7 @@ const tagToPattern = (tag: unknown): string => {
   }
 };
 
-const detectValidatorTag = (validator: TemplateLiteralValidator): unknown => {
+const detectValidatorTag = (validator: AnyValidator): unknown => {
   const result = validator();
   return result?.type;
 };

--- a/package/main/src/Validate/templateLiteral/core.ts
+++ b/package/main/src/Validate/templateLiteral/core.ts
@@ -10,14 +10,14 @@
 import type { ValidateType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
-type AnyValidator = (value?: any) => { type: unknown };
+export type TemplateLiteralValidator = (value?: any) => { type: unknown };
 
 /**
  * Allowed parts of a template literal definition. Each element is either a
  * string literal that must appear verbatim, or a primitive validator whose
  * accepted shape is converted to a regex fragment at construction time.
  */
-export type TemplateLiteralPart = string | AnyValidator;
+export type TemplateLiteralPart = string | TemplateLiteralValidator;
 
 type ExtractValidatorTag<V> = V extends (value: never) => { type: infer T }
   ? T
@@ -33,7 +33,7 @@ type TagToTemplate<T> = T extends "string"
         ? bigint
         : ValidateType<T>;
 
-type PartToTemplate<P> = P extends string
+export type PartToTemplate<P> = P extends string
   ? P
   : TagToTemplate<ExtractValidatorTag<P>>;
 
@@ -85,7 +85,7 @@ const tagToPattern = (tag: unknown): string => {
   }
 };
 
-const detectValidatorTag = (validator: AnyValidator): unknown => {
+const detectValidatorTag = (validator: TemplateLiteralValidator): unknown => {
   const result = validator();
   return result?.type;
 };

--- a/package/main/src/Validate/type.ts
+++ b/package/main/src/Validate/type.ts
@@ -119,3 +119,14 @@ export type SchemaToInterface<
 export type OptionalKeys<T> = {
   [K in keyof T]: undefined extends T[K] ? K : never;
 }[keyof T];
+
+/**
+ * Extracts the validated TypeScript type from a validator function's return tag
+ * @template V - The validator function
+ * @returns The TypeScript type encoded in the validator's return `type` tag
+ */
+export type ExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
+  ? ValidateType<T>
+  : never;

--- a/package/main/src/types/array/chunk.ts
+++ b/package/main/src/types/array/chunk.ts
@@ -1,6 +1,6 @@
 import type { Length } from "$/logic/length";
 
-type Chunk<
+export type Chunk<
   T,
   N extends number,
   C extends unknown[] = [],

--- a/package/main/src/types/array/zip.ts
+++ b/package/main/src/types/array/zip.ts
@@ -1,4 +1,7 @@
-type ZIP<T, O extends unknown[] = []> = T extends [infer Head, ...infer Tail]
+export type ZIP<T, O extends unknown[] = []> = T extends [
+  infer Head,
+  ...infer Tail,
+]
   ? Head extends unknown[]
     ? ZIP<Tail, [...O, Head[number]]>
     : never

--- a/package/main/src/types/logic/binary1bitNor.ts
+++ b/package/main/src/types/logic/binary1bitNor.ts
@@ -4,8 +4,7 @@ export type Binary1bitNor<
   Y extends `${0 | 1}`,
 > = Binary1bitNorParser<X, Y>;
 
-type Binary1bitNorParser<X extends string, Y extends string> = X extends "1"
-  ? "0"
-  : Y extends "1"
-    ? "0"
-    : "1";
+export type Binary1bitNorParser<
+  X extends string,
+  Y extends string,
+> = X extends "1" ? "0" : Y extends "1" ? "0" : "1";

--- a/package/main/src/types/logic/binaryFullAdder.ts
+++ b/package/main/src/types/logic/binaryFullAdder.ts
@@ -26,7 +26,7 @@ export type BinaryFullAdder<
     : never;
 
 // Type for multi-byte adder operation
-type BinaryFullAdderParser<
+export type BinaryFullAdderParser<
   X extends string,
   Y extends string,
   A extends string = "",

--- a/package/main/src/types/math/divide.ts
+++ b/package/main/src/types/math/divide.ts
@@ -21,7 +21,11 @@ export type Divide<A extends number, B extends number> = A extends 0
         : DivideHelper<A, B>;
 
 // Helper type for division operation
-type DivideHelper<X extends number, Y extends number, A extends number = 0> =
+export type DivideHelper<
+  X extends number,
+  Y extends number,
+  A extends number = 0,
+> =
   BGreaterThanA<X, Y> extends true
     ? A
     : DivideHelper<Subtract<X, Y>, Y, Add<A, 1>>;

--- a/package/main/src/types/math/multiply.ts
+++ b/package/main/src/types/math/multiply.ts
@@ -5,7 +5,7 @@ import type { Subtract } from "./subtract";
 export type Multiply<A extends number, B extends number> = MultiHelper<A, B>;
 
 // Helper type for multiplication operation
-type MultiHelper<
+export type MultiHelper<
   X extends number,
   Y extends number,
   A extends number = 0,

--- a/package/main/src/types/object/pickDeep.ts
+++ b/package/main/src/types/object/pickDeep.ts
@@ -25,7 +25,10 @@ type ConstructNestedObject<
   : { [K in P]: V };
 
 // Helper to process a tuple of keys with PickDeepKey constraint
-type ProcessKeys<T extends object, K extends readonly PickDeepKey<T>[]> = {
+export type ProcessKeys<
+  T extends object,
+  K extends readonly PickDeepKey<T>[],
+> = {
   [I in keyof K]: K[I] extends string
     ? ConstructNestedObject<K[I], GetValueAtPath<T, K[I]>>
     : never;


### PR DESCRIPTION
## Summary

Fixes TypeScript error `TS4023` ("Exported variable X has or is using name Y from external module ... but cannot be named") observed in downstream packages consuming `umt`. Several exported declarations referenced local interfaces / type aliases that were not exported from the package, so the emitted `.d.ts` could not be re-referenced by consumers.

The fix was driven by an AST walk over `src/**` that flagged every unexported `interface` / `type` referenced by an exported declaration in the same file. The 25 identified types are now exported.

### Notable adjustments while resolving conflicts in the `Validate/*` barrel

- Hoisted the duplicated `ExtractValidatedType<V>` helper (previously redeclared in `Validate/array/arrayOf.ts`, `Validate/map/core.ts`, `Validate/set/core.ts`, `Validate/object/union.ts`) into `Validate/type.ts` so all four importers share a single definition.
- Renamed `AnyValidator` in `Validate/templateLiteral/core.ts` to `TemplateLiteralValidator` to avoid colliding with the (different) `AnyValidator` exported from `Validate/function/core.ts`.

Bumps the package version to `3.0.1`.

## Test plan

- [x] `bunx tsc --noEmit` passes for both `tsconfig.json` and `tsconfig.cjs.json`
- [x] `bunx jest` — 323 suites / 3200 tests pass
- [x] `bunx eslint src/` clean
- [x] `bunx biome check src/` clean

Reported downstream symptom:

```
src/git.ts:17:7 - error TS4023: Exported variable 'BranchInfoSchema' has or is using name 'NullReturn' from external module "...umt/module/Validate/object/nullable" but cannot be named.
```

`NullReturn` (and `UndefinedReturn`, plus 23 other peer types found by the AST sweep) are now part of the public surface, so the inferred type of `BranchInfoSchema` and similar declarations can be named again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyvwRT7TP18A4kGrbMkA1k)_