### PR TITLE
Release v3.0.1

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Setup Bun

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@7d7d3055f1fdc9a97a040c69ead9ba392fa6326a # v1.0.113
+        uses: anthropics/claude-code-action@f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8 # v1.0.121
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Setup Bun ${{ matrix.bun-version }}
@@ -48,7 +48,7 @@ jobs:
           components: clippy, rustfmt
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@7d7d3055f1fdc9a97a040c69ead9ba392fa6326a # v1.0.113
+        uses: anthropics/claude-code-action@f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8 # v1.0.121
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/main-package-benchmark.yml
+++ b/.github/workflows/main-package-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache

--- a/.github/workflows/main-package-bun.yml
+++ b/.github/workflows/main-package-bun.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache

--- a/.github/workflows/main-package-node.yml
+++ b/.github/workflows/main-package-node.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-publish-main.yml
+++ b/.github/workflows/npm-publish-main.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Setup Node.js for npm publish

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Restore Dependencies Cache

--- a/.github/workflows/wasm-plugin-ci.yml
+++ b/.github/workflows/wasm-plugin-ci.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@nightly
       - name: Setup Nix
-        uses: DeterminateSystems/determinate-nix-action@7c4cc317e802185875512bfcb68259257279d767 # v3.19.1
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - name: Run Tests(Cargo)

--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -225,5 +225,5 @@
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/package/main/src/Validate/object/nullable.ts
+++ b/package/main/src/Validate/object/nullable.ts
@@ -1,9 +1,3 @@
-interface NullReturn {
-  validate: boolean;
-  message: string;
-  type: "null";
-}
-
 /**
  * Wraps a validator to accept null values
  * @template T - The type of value the wrapped validator expects
@@ -16,8 +10,12 @@ export const nullable = <
   R extends { type: unknown; message: string; validate: boolean },
 >(
   validator: (value: T) => R,
-): ((value: T | null) => R | NullReturn) => {
-  const nullableValidator = (value: T | null): R | NullReturn => {
+): ((
+  value: T | null,
+) => R | { validate: boolean; message: string; type: "null" }) => {
+  const nullableValidator = (
+    value: T | null,
+  ): R | { validate: boolean; message: string; type: "null" } => {
     if (value === null) {
       return {
         validate: true,

--- a/package/main/src/Validate/object/optional.ts
+++ b/package/main/src/Validate/object/optional.ts
@@ -1,9 +1,3 @@
-interface UndefinedReturn {
-  validate: boolean;
-  message: string;
-  type: "undefined";
-}
-
 /**
  * Optional validator augmented with a reference to the wrapped validator,
  * used by `required()` to unwrap optional layers when rebuilding a shape
@@ -17,7 +11,9 @@ export type OptionalValidator<
     message: string;
     validate: boolean;
   },
-> = ((value?: T) => R | UndefinedReturn) & {
+> = ((
+  value?: T,
+) => R | { validate: boolean; message: string; type: "undefined" }) & {
   inner: (value: T) => R;
   isOptional: true;
 };
@@ -35,7 +31,9 @@ export const optional = <
 >(
   validator: (value: T) => R,
 ): OptionalValidator<T, R> => {
-  const optionalValidator = ((value?: T): R | UndefinedReturn => {
+  const optionalValidator = ((
+    value?: T,
+  ): R | { validate: boolean; message: string; type: "undefined" } => {
     if (value === undefined) {
       return {
         validate: true,


### PR DESCRIPTION
## Summary

Fixes TS4023 reported by a downstream package consuming `umt@3.0.0`:

```
src/git.ts:17:7 - error TS4023: Exported variable 'BranchInfoSchema' has or is using name 'NullReturn' from external module "...umt/module/Validate/object/nullable" but cannot be named.
```

The exported `nullable` (and symmetrically the exported `OptionalValidator` type) referenced module-local `NullReturn` / `UndefinedReturn` interfaces that were not part of the public surface, so the emitted `.d.ts` could not be re-referenced by consumers.

Inlined the structural shape `{ validate: boolean; message: string; type: "null" | "undefined" }` directly in the public signatures of `nullable` and `OptionalValidator`. No new symbols are added to the public API — strictly patch-scope.

Bumps the package to `3.0.1`.

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bunx biome check src/Validate/object/{nullable,optional}.ts`
- [x] `bunx jest src/tests/unit/Validate/object src/tests/integration/Validate` — 130/130 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyvwRT7TP18A4kGrbMkA1k)_