### PR TITLE
Release v3.1.0

### DIFF
--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -225,5 +225,5 @@
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/package/main/src/Date/getDay.ts
+++ b/package/main/src/Date/getDay.ts
@@ -1,6 +1,6 @@
 import type { ArrayToUnion } from "$/logic/arrayToUnion";
 
-interface DayList {
+export interface DayList {
   de: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
   ko: ["일", "월", "화", "수", "목", "금", "토"];
   en: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];

--- a/package/main/src/Object/keyBy.ts
+++ b/package/main/src/Object/keyBy.ts
@@ -1,6 +1,6 @@
-type PropertyName = string | number | symbol;
-type IterateeFunction<T> = (value: T) => PropertyName;
-type Iteratee<T> = IterateeFunction<T> | keyof T;
+export type PropertyName = string | number | symbol;
+export type IterateeFunction<T> = (value: T) => PropertyName;
+export type Iteratee<T> = IterateeFunction<T> | keyof T;
 
 /**
  * Creates an object composed of keys generated from the results of running each element of collection through iteratee

--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -6,7 +6,9 @@ import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 // runtime type). Reading the field directly lets validators that expose the
 // literal union via the `type` field (such as `oneOf`) flow through arrayOf
 // without being collapsed to `string`.
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+export type ArrayOfExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? ValidateType<T>
   : never;
 
@@ -27,7 +29,7 @@ export const arrayOf = <
   validator: V,
   message?: string,
 ) => {
-  type Element = ExtractValidatedType<V>;
+  type Element = ArrayOfExtractValidatedType<V>;
   return (values: Element[]): ValidateCoreReturnType<Element[]> => {
     if (!isArray(values)) {
       return {

--- a/package/main/src/Validate/function/core.ts
+++ b/package/main/src/Validate/function/core.ts
@@ -14,19 +14,21 @@
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
-type AnyValidator = (value: any) => ValidateCoreReturnType<unknown>;
+export type FunctionAnyValidator = (value: any) => ValidateCoreReturnType<unknown>;
 
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+export type FunctionExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? ValidateType<T>
   : never;
 
-type InferInputs<Inputs> = Inputs extends readonly AnyValidator[]
-  ? { [K in keyof Inputs]: ExtractValidatedType<Inputs[K]> }
+export type InferInputs<Inputs> = Inputs extends readonly FunctionAnyValidator[]
+  ? { [K in keyof Inputs]: FunctionExtractValidatedType<Inputs[K]> }
   : // biome-ignore lint/suspicious/noExplicitAny: open signature when no schema provided
     any[];
 
-type InferOutput<Output> = Output extends AnyValidator
-  ? ExtractValidatedType<Output>
+export type InferOutput<Output> = Output extends FunctionAnyValidator
+  ? FunctionExtractValidatedType<Output>
   : // biome-ignore lint/suspicious/noExplicitAny: open signature when no schema provided
     any;
 
@@ -36,12 +38,12 @@ type InferOutput<Output> = Output extends AnyValidator
  * validator only enforces that the value is callable.
  */
 export interface FunctionSchema {
-  input?: readonly AnyValidator[];
-  output?: AnyValidator;
+  input?: readonly FunctionAnyValidator[];
+  output?: FunctionAnyValidator;
 }
 
-type ExtractInput<S> = S extends { input: infer I } ? I : undefined;
-type ExtractOutput<S> = S extends { output: infer O } ? O : undefined;
+export type ExtractInput<S> = S extends { input: infer I } ? I : undefined;
+export type ExtractOutput<S> = S extends { output: infer O } ? O : undefined;
 
 /**
  * Inferred function signature from a `FunctionSchema`. Used by callers via

--- a/package/main/src/Validate/function/core.ts
+++ b/package/main/src/Validate/function/core.ts
@@ -13,8 +13,10 @@
 
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
-// biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
-export type FunctionAnyValidator = (value: any) => ValidateCoreReturnType<unknown>;
+export type FunctionAnyValidator = (
+  // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
+  value: any,
+) => ValidateCoreReturnType<unknown>;
 
 export type FunctionExtractValidatedType<V> = V extends (value: never) => {
   type: infer T;

--- a/package/main/src/Validate/instanceof/core.ts
+++ b/package/main/src/Validate/instanceof/core.ts
@@ -8,7 +8,7 @@
 import type { Types, ValidateCoreReturnType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: a constructor signature must accept any tuple
-type Constructor<T> = new (...arguments_: any[]) => T;
+export type Constructor<T> = new (...arguments_: any[]) => T;
 
 /**
  * Creates a validator that checks whether a value is an instance of the given

--- a/package/main/src/Validate/map/core.ts
+++ b/package/main/src/Validate/map/core.ts
@@ -7,7 +7,9 @@
 
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+export type MapExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? ValidateType<T>
   : never;
 
@@ -32,8 +34,8 @@ export const map = <
   VV extends (value: any) => ValidateCoreReturnType<unknown> = (
     value: unknown,
   ) => ValidateCoreReturnType<unknown>,
-  K = ExtractValidatedType<KV>,
-  V = ExtractValidatedType<VV>,
+  K = MapExtractValidatedType<KV>,
+  V = MapExtractValidatedType<VV>,
 >(
   keyValidator?: KV,
   valueValidator?: VV,

--- a/package/main/src/Validate/object/intersection.ts
+++ b/package/main/src/Validate/object/intersection.ts
@@ -9,7 +9,9 @@ import type {
 // runtime type). Reading the field directly lets validators that expose the
 // literal union via the `type` field (such as `oneOf`) flow through
 // intersection without being collapsed by `Types<T>`.
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+export type IntersectionExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? ValidateType<T>
   : never;
 
@@ -18,11 +20,11 @@ type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
 // validator (e.g. `union(A, B)`), unlike `UnionToIntersection` over
 // `Vs[number]` which would distribute over the inner union and collapse
 // `(A | B) & C` into `A & B & C`.
-type IntersectValidatedTypes<Vs> = Vs extends readonly [
+export type IntersectValidatedTypes<Vs> = Vs extends readonly [
   infer Head,
   ...infer Tail,
 ]
-  ? ExtractValidatedType<Head> & IntersectValidatedTypes<Tail>
+  ? IntersectionExtractValidatedType<Head> & IntersectValidatedTypes<Tail>
   : unknown;
 
 /**

--- a/package/main/src/Validate/object/nullable.ts
+++ b/package/main/src/Validate/object/nullable.ts
@@ -1,4 +1,4 @@
-interface NullReturn {
+export interface NullReturn {
   validate: boolean;
   message: string;
   type: "null";

--- a/package/main/src/Validate/object/optional.ts
+++ b/package/main/src/Validate/object/optional.ts
@@ -1,4 +1,4 @@
-interface UndefinedReturn {
+export interface UndefinedReturn {
   validate: boolean;
   message: string;
   type: "undefined";

--- a/package/main/src/Validate/object/partial.ts
+++ b/package/main/src/Validate/object/partial.ts
@@ -8,7 +8,7 @@
 import { object, type ObjectShape, type ObjectValidator } from "./core";
 import { optional, type OptionalValidator } from "./optional";
 
-type PartialShape<T extends ObjectShape> = {
+export type PartialShape<T extends ObjectShape> = {
   [K in keyof T]: OptionalValidator<
     Parameters<T[K]>[0],
     ReturnType<T[K]> extends {

--- a/package/main/src/Validate/object/required.ts
+++ b/package/main/src/Validate/object/required.ts
@@ -8,10 +8,10 @@
 import { object, type ObjectShape, type ObjectValidator } from "./core";
 import type { OptionalValidator } from "./optional";
 
-type UnwrapOptional<V> =
+export type UnwrapOptional<V> =
   V extends OptionalValidator<infer Inner, infer R> ? (value: Inner) => R : V;
 
-type RequiredShape<T extends ObjectShape> = {
+export type RequiredShape<T extends ObjectShape> = {
   [K in keyof T]: UnwrapOptional<T[K]> extends ObjectShape[string]
     ? UnwrapOptional<T[K]>
     : T[K];

--- a/package/main/src/Validate/object/union.ts
+++ b/package/main/src/Validate/object/union.ts
@@ -9,7 +9,9 @@ import type {
 // runtime type). Reading the field directly lets validators that expose the
 // literal union via the `type` field (such as `oneOf`) flow through union
 // without being collapsed by `Types<T>`.
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+export type UnionExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? ValidateType<T>
   : never;
 
@@ -24,20 +26,20 @@ export const union = <
   ...validators: [...Vs]
 ) => {
   return (
-    value: ExtractValidatedType<Vs[number]>,
-  ): ValidateCoreReturnType<ExtractValidatedType<Vs[number]>> => {
+    value: UnionExtractValidatedType<Vs[number]>,
+  ): ValidateCoreReturnType<UnionExtractValidatedType<Vs[number]>> => {
     let lastMessage = "";
     for (const validator of validators) {
       const result = (
         validator as unknown as (
-          v: ExtractValidatedType<Vs[number]>,
-        ) => ValidateCoreReturnType<ExtractValidatedType<Vs[number]>>
+          v: UnionExtractValidatedType<Vs[number]>,
+        ) => ValidateCoreReturnType<UnionExtractValidatedType<Vs[number]>>
       )(value);
       if (result.validate) {
         return {
           validate: true,
           message: "",
-          type: value as unknown as Types<ExtractValidatedType<Vs[number]>>,
+          type: value as unknown as Types<UnionExtractValidatedType<Vs[number]>>,
         };
       }
       lastMessage = result.message;
@@ -45,7 +47,7 @@ export const union = <
     return {
       validate: false,
       message: lastMessage,
-      type: value as unknown as Types<ExtractValidatedType<Vs[number]>>,
+      type: value as unknown as Types<UnionExtractValidatedType<Vs[number]>>,
     };
   };
 };

--- a/package/main/src/Validate/object/union.ts
+++ b/package/main/src/Validate/object/union.ts
@@ -39,7 +39,9 @@ export const union = <
         return {
           validate: true,
           message: "",
-          type: value as unknown as Types<UnionExtractValidatedType<Vs[number]>>,
+          type: value as unknown as Types<
+            UnionExtractValidatedType<Vs[number]>
+          >,
         };
       }
       lastMessage = result.message;

--- a/package/main/src/Validate/set/core.ts
+++ b/package/main/src/Validate/set/core.ts
@@ -10,7 +10,9 @@
 
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
-type ExtractValidatedType<V> = V extends (value: never) => { type: infer T }
+export type SetExtractValidatedType<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? ValidateType<T>
   : never;
 
@@ -28,7 +30,7 @@ export const set_ = <
   IV extends (value: any) => ValidateCoreReturnType<unknown> = (
     value: unknown,
   ) => ValidateCoreReturnType<unknown>,
-  T = ExtractValidatedType<IV>,
+  T = SetExtractValidatedType<IV>,
 >(
   itemValidator?: IV,
   message?: string,

--- a/package/main/src/Validate/templateLiteral/core.ts
+++ b/package/main/src/Validate/templateLiteral/core.ts
@@ -10,20 +10,22 @@
 import type { ValidateType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
-type AnyValidator = (value?: any) => { type: unknown };
+export type TemplateLiteralAnyValidator = (value?: any) => { type: unknown };
 
 /**
  * Allowed parts of a template literal definition. Each element is either a
  * string literal that must appear verbatim, or a primitive validator whose
  * accepted shape is converted to a regex fragment at construction time.
  */
-export type TemplateLiteralPart = string | AnyValidator;
+export type TemplateLiteralPart = string | TemplateLiteralAnyValidator;
 
-type ExtractValidatorTag<V> = V extends (value: never) => { type: infer T }
+export type ExtractValidatorTag<V> = V extends (value: never) => {
+  type: infer T;
+}
   ? T
   : never;
 
-type TagToTemplate<T> = T extends "string"
+export type TagToTemplate<T> = T extends "string"
   ? string
   : T extends "number"
     ? number
@@ -33,7 +35,7 @@ type TagToTemplate<T> = T extends "string"
         ? bigint
         : ValidateType<T>;
 
-type PartToTemplate<P> = P extends string
+export type PartToTemplate<P> = P extends string
   ? P
   : TagToTemplate<ExtractValidatorTag<P>>;
 
@@ -85,7 +87,7 @@ const tagToPattern = (tag: unknown): string => {
   }
 };
 
-const detectValidatorTag = (validator: AnyValidator): unknown => {
+const detectValidatorTag = (validator: TemplateLiteralAnyValidator): unknown => {
   const result = validator();
   return result?.type;
 };

--- a/package/main/src/Validate/templateLiteral/core.ts
+++ b/package/main/src/Validate/templateLiteral/core.ts
@@ -87,7 +87,9 @@ const tagToPattern = (tag: unknown): string => {
   }
 };
 
-const detectValidatorTag = (validator: TemplateLiteralAnyValidator): unknown => {
+const detectValidatorTag = (
+  validator: TemplateLiteralAnyValidator,
+): unknown => {
   const result = validator();
   return result?.type;
 };

--- a/package/main/src/types/array/chunk.ts
+++ b/package/main/src/types/array/chunk.ts
@@ -1,6 +1,6 @@
 import type { Length } from "$/logic/length";
 
-type Chunk<
+export type Chunk<
   T,
   N extends number,
   C extends unknown[] = [],

--- a/package/main/src/types/array/zip.ts
+++ b/package/main/src/types/array/zip.ts
@@ -1,4 +1,7 @@
-type ZIP<T, O extends unknown[] = []> = T extends [infer Head, ...infer Tail]
+export type ZIP<T, O extends unknown[] = []> = T extends [
+  infer Head,
+  ...infer Tail,
+]
   ? Head extends unknown[]
     ? ZIP<Tail, [...O, Head[number]]>
     : never

--- a/package/main/src/types/logic/binary1bitNor.ts
+++ b/package/main/src/types/logic/binary1bitNor.ts
@@ -7,8 +7,4 @@ export type Binary1bitNor<
 export type Binary1bitNorParser<
   X extends string,
   Y extends string,
-> = X extends "1"
-  ? "0"
-  : Y extends "1"
-    ? "0"
-    : "1";
+> = X extends "1" ? "0" : Y extends "1" ? "0" : "1";

--- a/package/main/src/types/logic/binary1bitNor.ts
+++ b/package/main/src/types/logic/binary1bitNor.ts
@@ -4,7 +4,10 @@ export type Binary1bitNor<
   Y extends `${0 | 1}`,
 > = Binary1bitNorParser<X, Y>;
 
-type Binary1bitNorParser<X extends string, Y extends string> = X extends "1"
+export type Binary1bitNorParser<
+  X extends string,
+  Y extends string,
+> = X extends "1"
   ? "0"
   : Y extends "1"
     ? "0"

--- a/package/main/src/types/logic/binaryFullAdder.ts
+++ b/package/main/src/types/logic/binaryFullAdder.ts
@@ -26,7 +26,7 @@ export type BinaryFullAdder<
     : never;
 
 // Type for multi-byte adder operation
-type BinaryFullAdderParser<
+export type BinaryFullAdderParser<
   X extends string,
   Y extends string,
   A extends string = "",

--- a/package/main/src/types/math/divide.ts
+++ b/package/main/src/types/math/divide.ts
@@ -21,7 +21,11 @@ export type Divide<A extends number, B extends number> = A extends 0
         : DivideHelper<A, B>;
 
 // Helper type for division operation
-type DivideHelper<X extends number, Y extends number, A extends number = 0> =
+export type DivideHelper<
+  X extends number,
+  Y extends number,
+  A extends number = 0,
+> =
   BGreaterThanA<X, Y> extends true
     ? A
     : DivideHelper<Subtract<X, Y>, Y, Add<A, 1>>;

--- a/package/main/src/types/math/multiply.ts
+++ b/package/main/src/types/math/multiply.ts
@@ -5,7 +5,7 @@ import type { Subtract } from "./subtract";
 export type Multiply<A extends number, B extends number> = MultiHelper<A, B>;
 
 // Helper type for multiplication operation
-type MultiHelper<
+export type MultiHelper<
   X extends number,
   Y extends number,
   A extends number = 0,

--- a/package/main/src/types/object/pickDeep.ts
+++ b/package/main/src/types/object/pickDeep.ts
@@ -3,7 +3,7 @@ import type { PickDeepKey } from "./pickDeepKey";
 import type { UnionToIntersection } from "$/logic/unionToIntersection";
 
 // Helper type to get value at nested path
-type GetValueAtPath<
+export type GetValueAtPath<
   T,
   P extends string,
 > = P extends `${infer Key}.${infer Rest}`
@@ -17,7 +17,7 @@ type GetValueAtPath<
     : never;
 
 // Helper type to construct nested object from dot-notation path
-type ConstructNestedObject<
+export type ConstructNestedObject<
   P extends string,
   V,
 > = P extends `${infer Key}.${infer Rest}`
@@ -25,7 +25,10 @@ type ConstructNestedObject<
   : { [K in P]: V };
 
 // Helper to process a tuple of keys with PickDeepKey constraint
-type ProcessKeys<T extends object, K extends readonly PickDeepKey<T>[]> = {
+export type ProcessKeys<
+  T extends object,
+  K extends readonly PickDeepKey<T>[],
+> = {
   [I in keyof K]: K[I] extends string
     ? ConstructNestedObject<K[I], GetValueAtPath<T, K[I]>>
     : never;


### PR DESCRIPTION
# Release v3.1.0

Exposes previously private helper types in `Validate`, `Date`, `Object`, and `types/*` modules so consumers can name them across module boundaries (resolves TS4023 in downstream `.d.ts`).

## ✨ New Features

### 🔧 New Public Type Exports

* **Validate/object**: Exports `NullReturn` (`nullable.ts`), `UndefinedReturn` (`optional.ts`), `PartialShape` (`partial.ts`), `UnwrapOptional` and `RequiredShape` (`required.ts`), `IntersectionExtractValidatedType` and `IntersectValidatedTypes` (`intersection.ts`), `UnionExtractValidatedType` (`union.ts`).
* **Validate/array**: Exports `ArrayOfExtractValidatedType` (`arrayOf.ts`).
* **Validate/function**: Exports `FunctionAnyValidator`, `FunctionExtractValidatedType`, `InferInputs`, `InferOutput`, `ExtractInput`, `ExtractOutput` (`core.ts`).
* **Validate/map**: Exports `MapExtractValidatedType` (`core.ts`).
* **Validate/set**: Exports `SetExtractValidatedType` (`core.ts`).
* **Validate/templateLiteral**: Exports `TemplateLiteralAnyValidator`, `ExtractValidatorTag`, `TagToTemplate`, `PartToTemplate` (`core.ts`).
* **Validate/instanceof**: Exports `Constructor` (`core.ts`).
* **Date**: Exports `DayList` (`getDay.ts`).
* **Object**: Exports `PropertyName`, `IterateeFunction`, `Iteratee` (`keyBy.ts`).
* **types**: Exports `Chunk` (`array/chunk.ts`), `ZIP` (`array/zip.ts`), `Binary1bitNorParser` (`logic/binary1bitNor.ts`), `BinaryFullAdderParser` (`logic/binaryFullAdder.ts`), `DivideHelper` (`math/divide.ts`), `MultiHelper` (`math/multiply.ts`), `GetValueAtPath`, `ConstructNestedObject`, `ProcessKeys` (`object/pickDeep.ts`).

## 🔄 Refactoring & Maintenance

* Renamed per-file helpers that shared identifiers across barrel-re-exported modules to avoid TS2308 ambiguity: `ExtractValidatedType` → `ArrayOfExtractValidatedType` / `FunctionExtractValidatedType` / `MapExtractValidatedType` / `IntersectionExtractValidatedType` / `UnionExtractValidatedType` / `SetExtractValidatedType`; `AnyValidator` → `FunctionAnyValidator` / `TemplateLiteralAnyValidator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)