### PR TITLE
Add object_get utility function for nested property access

### DIFF
--- a/package/umt_python/src/__init__.py
+++ b/package/umt_python/src/__init__.py
@@ -172,6 +172,7 @@ from .number import (
 )
 from .object import (
     deep_clone,
+    object_get,
     object_has,
     object_is_empty,
     object_map_values,
@@ -428,6 +429,7 @@ __all__ = [
     "normalize_time_unit",
     "not_",
     "now_simple",
+    "object_get",
     "object_has",
     "object_is_empty",
     "object_map_values",

--- a/package/umt_python/src/object/__init__.py
+++ b/package/umt_python/src/object/__init__.py
@@ -1,6 +1,7 @@
 from .deep_clone import deep_clone
 from .get_objects_common import get_objects_common
 from .get_objects_diff import get_objects_diff
+from .object_get import object_get
 from .object_has import object_has
 from .object_is_empty import object_is_empty
 from .object_is_plain import object_is_plain
@@ -18,6 +19,7 @@ __all__ = [
     "get_objects_common",
     "get_objects_diff",
     "map_keys",
+    "object_get",
     "object_has",
     "object_is_empty",
     "object_is_plain",

--- a/package/umt_python/src/object/object_get.py
+++ b/package/umt_python/src/object/object_get.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+
+def object_get(obj: Any, path: str | list[str], default_value: Any = None) -> Any:  # noqa: ANN401
+    """
+    Reads a deeply nested property by string or string-list path.
+    Returns the default value if any segment is missing along the path.
+
+    Mirrors the TypeScript `Object/get` semantics from package/main, with one
+    Python-idiomatic adaptation: TS distinguishes `undefined` (missing) from
+    `null` (explicit) and only swaps in the default for `undefined`. Python
+    collapses both to `None`, so we preserve the distinction structurally by
+    checking key presence in the parent dict (mirroring `object_has`). An
+    explicit `None` value at the final segment is returned as-is, while a
+    missing segment returns `default_value`.
+
+    Args:
+        obj: Source object (dict-like) or any value
+        path: Dot-separated string or list of path segments
+        default_value: Returned when any segment along the path is missing
+
+    Returns:
+        The resolved value, or default_value when any segment is missing
+
+    Example:
+        >>> object_get({"a": {"b": {"c": 1}}}, "a.b.c")
+        1
+        >>> object_get({"a": {"b": 1}}, ["a", "x"], 0)
+        0
+        >>> object_get({"a": None}, "a.b", 7)
+        7
+    """
+    segments = path.split(".") if isinstance(path, str) else path
+    current: Any = obj
+    for key in segments:
+        if not isinstance(current, dict) or key not in current:
+            return default_value
+        current = current[key]
+    return current

--- a/package/umt_python/tests/unit/object/test_object_get.py
+++ b/package/umt_python/tests/unit/object/test_object_get.py
@@ -1,0 +1,41 @@
+import unittest
+
+from src.object import object_get
+
+
+class TestObjectGet(unittest.TestCase):
+    def test_reads_top_level_property(self):
+        self.assertEqual(object_get({"a": 1}, "a"), 1)
+
+    def test_reads_nested_property_by_dotted_path(self):
+        self.assertEqual(object_get({"a": {"b": {"c": 42}}}, "a.b.c"), 42)
+
+    def test_reads_nested_property_by_list_path(self):
+        self.assertEqual(object_get({"a": {"b": {"c": 42}}}, ["a", "b", "c"]), 42)
+
+    def test_returns_default_when_segment_missing(self):
+        self.assertEqual(object_get({"a": {"b": 1}}, "a.x", "fallback"), "fallback")
+
+    def test_returns_default_when_traversing_through_none(self):
+        self.assertEqual(object_get({"a": None}, "a.b", "fallback"), "fallback")
+
+    def test_returns_none_when_no_default_and_missing(self):
+        self.assertIsNone(object_get({"a": 1}, "x"))
+
+    def test_returns_explicit_none_value(self):
+        self.assertIsNone(object_get({"a": None}, "a", "fallback"))
+
+    def test_handles_none_root(self):
+        self.assertEqual(object_get(None, "a.b", 7), 7)
+
+    def test_returns_default_for_non_dict_intermediate(self):
+        self.assertEqual(object_get({"a": 1}, "a.b", "fallback"), "fallback")
+
+    def test_docstring_example(self):
+        self.assertEqual(object_get({"a": {"b": {"c": 1}}}, "a.b.c"), 1)
+        self.assertEqual(object_get({"a": {"b": 1}}, ["a", "x"], 0), 0)
+        self.assertEqual(object_get({"a": None}, "a.b", 7), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds a new `object_get` utility function that enables safe, deep property access on nested dictionaries with support for both dot-notation and list-based paths, along with customizable default values.

## Key Changes
- **New function**: `object_get()` in `src/object/object_get.py`
  - Safely reads deeply nested properties from dictionaries
  - Supports both string paths (`"a.b.c"`) and list paths (`["a", "b", "c"]`)
  - Returns a default value when any segment in the path is missing
  - Distinguishes between explicit `None` values and missing keys (matching TypeScript semantics)
  
- **Comprehensive test coverage**: Added 8 unit tests covering:
  - Top-level and nested property access
  - Both path formats (dotted strings and lists)
  - Default value behavior for missing segments
  - Edge cases (None root, non-dict intermediates, explicit None values)

- **Module exports**: Updated `src/object/__init__.py` and `src/__init__.py` to export the new function

## Implementation Details
The function iterates through path segments, checking both that the current value is a dictionary and that the key exists within it. This approach preserves the distinction between an explicit `None` value at the final segment (returned as-is) and a missing segment (returns default_value), mirroring the TypeScript implementation's handling of `undefined` vs `null`.

https://claude.ai/code/session_01QGeUoM9MmK2E3apJV3GzV3