### PR TITLE
feat(main): make Validate factories implement Standard Schema V1

### DIFF
--- a/package/main/src/Validate/any/core.ts
+++ b/package/main/src/Validate/any/core.ts
@@ -5,6 +5,11 @@
  * `union()`, `intersection()`, and other compositional helpers.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+
 /**
  * Return type produced by an `any` validator. Exposes the literal `"any"`
  * tag through the `type` field so `ValidateType<"any">` can map it back to
@@ -23,9 +28,21 @@ const anyValidator = (_value: any): AnyReturnType => ({
   type: "any",
 });
 
+const standardAnyValidator = attachStandard<
+  // biome-ignore lint/suspicious/noExplicitAny: any() carries any through Standard Schema
+  any,
+  // biome-ignore lint/suspicious/noExplicitAny: any() carries any through Standard Schema
+  any,
+  typeof anyValidator
+>(anyValidator);
+
 /**
  * Creates a validator that accepts any value
  * @returns {Function} - Validator that always succeeds
  */
-// biome-ignore lint/suspicious/noExplicitAny: any() must accept and infer any value
-export const any = (): ((value: any) => AnyReturnType) => anyValidator;
+export const any = (): ((
+  // biome-ignore lint/suspicious/noExplicitAny: any() must accept and infer any value
+  value: any,
+) => AnyReturnType) &
+  // biome-ignore lint/suspicious/noExplicitAny: Standard Schema infers any in/out for any()
+  StandardSchemaV1<any, any> => standardAnyValidator;

--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -1,4 +1,8 @@
 import { isArray } from "@/Validate/isArray";
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
 // Extract the validated value type by reading the validator's `type` field
@@ -28,9 +32,17 @@ export const arrayOf = <
 >(
   validator: V,
   message?: string,
-) => {
+): ((
+  values: ArrayOfExtractValidatedType<V>[],
+) => ValidateCoreReturnType<ArrayOfExtractValidatedType<V>[]>) &
+  StandardSchemaV1<
+    ArrayOfExtractValidatedType<V>[],
+    ArrayOfExtractValidatedType<V>[]
+  > => {
   type Element = ArrayOfExtractValidatedType<V>;
-  return (values: Element[]): ValidateCoreReturnType<Element[]> => {
+  const arrayValidator = (
+    values: Element[],
+  ): ValidateCoreReturnType<Element[]> => {
     if (!isArray(values)) {
       return {
         validate: false,
@@ -59,4 +71,7 @@ export const arrayOf = <
       type: values,
     };
   };
+  return attachStandard<Element[], Element[], typeof arrayValidator>(
+    arrayValidator,
+  );
 };

--- a/package/main/src/Validate/bigint/core.ts
+++ b/package/main/src/Validate/bigint/core.ts
@@ -3,6 +3,10 @@
  * Provides the base validation functionality for bigint values
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateReturnType } from "@/Validate/type";
 
 /**
@@ -27,8 +31,8 @@ export interface BigIntReturnType {
 export const bigint = <T extends ValidateReturnType<bigint>[]>(
   option: T = [] as unknown as T,
   message?: string,
-) => {
-  return (value: bigint): BigIntReturnType => {
+): ((value: bigint) => BigIntReturnType) & StandardSchemaV1<bigint, bigint> => {
+  const validator = (value: bigint): BigIntReturnType => {
     if (typeof value !== "bigint") {
       return {
         validate: false,
@@ -51,4 +55,5 @@ export const bigint = <T extends ValidateReturnType<bigint>[]>(
       type: "bigint",
     };
   };
+  return attachStandard<bigint, bigint, typeof validator>(validator);
 };

--- a/package/main/src/Validate/boolean/core.ts
+++ b/package/main/src/Validate/boolean/core.ts
@@ -4,6 +4,10 @@
  */
 
 import { core } from "@/Validate/core";
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType } from "@/Validate/type";
 
 /**
@@ -11,7 +15,11 @@ import type { ValidateCoreReturnType } from "@/Validate/type";
  * @param {string} [message] - Custom error message for type validation
  * @returns {Function} - Validator function that checks if the value is a boolean
  */
-export const boolean = (message?: string) => {
-  return (value: boolean): ValidateCoreReturnType<boolean> =>
+export const boolean = (
+  message?: string,
+): ((value: boolean) => ValidateCoreReturnType<boolean>) &
+  StandardSchemaV1<boolean, boolean> => {
+  const validator = (value: boolean): ValidateCoreReturnType<boolean> =>
     core<boolean>("boolean")(value, [], message);
+  return attachStandard<boolean, boolean, typeof validator>(validator);
 };

--- a/package/main/src/Validate/date/core.ts
+++ b/package/main/src/Validate/date/core.ts
@@ -3,6 +3,10 @@
  * Provides the base validation functionality for Date instances
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType } from "@/Validate/type";
 
 /**
@@ -13,8 +17,11 @@ import type { ValidateCoreReturnType } from "@/Validate/type";
  * @param {string} [message] - Custom error message for type validation
  * @returns {Function} - Validator function that checks if the value is a Date instance
  */
-export const date = (message?: string) => {
-  return (value: Date): ValidateCoreReturnType<Date> => {
+export const date = (
+  message?: string,
+): ((value: Date) => ValidateCoreReturnType<Date>) &
+  StandardSchemaV1<Date, Date> => {
+  const validator = (value: Date): ValidateCoreReturnType<Date> => {
     if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
       return {
         validate: false,
@@ -28,4 +35,5 @@ export const date = (message?: string) => {
       type: value,
     };
   };
+  return attachStandard<Date, Date, typeof validator>(validator);
 };

--- a/package/main/src/Validate/file/core.ts
+++ b/package/main/src/Validate/file/core.ts
@@ -4,6 +4,10 @@
  * the global `File` constructor is unavailable.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType } from "@/Validate/type";
 
 const hasFileConstructor = typeof File !== "undefined";
@@ -15,8 +19,11 @@ const hasBlobConstructor = typeof Blob !== "undefined";
  * @param {string} [message] - Custom error message for type validation
  * @returns {Function} - Validator function for File / Blob instances
  */
-export const file = (message?: string) => {
-  return (value: File): ValidateCoreReturnType<File> => {
+export const file = (
+  message?: string,
+): ((value: File) => ValidateCoreReturnType<File>) &
+  StandardSchemaV1<File, File> => {
+  const validator = (value: File): ValidateCoreReturnType<File> => {
     const isFile = hasFileConstructor && value instanceof File;
     const isBlob = hasBlobConstructor && value instanceof Blob;
     if (!(isFile || isBlob)) {
@@ -32,4 +39,5 @@ export const file = (message?: string) => {
       type: value,
     };
   };
+  return attachStandard<File, File, typeof validator>(validator);
 };

--- a/package/main/src/Validate/function/core.ts
+++ b/package/main/src/Validate/function/core.ts
@@ -11,6 +11,10 @@
  * the schema on every call.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
 export type FunctionAnyValidator = (
@@ -94,7 +98,11 @@ export interface FunctionValidator<Inputs, Output> {
 export const function_ = <const S extends FunctionSchema = FunctionSchema>(
   schema?: S,
   message?: string,
-): FunctionValidator<ExtractInput<S>, ExtractOutput<S>> => {
+): FunctionValidator<ExtractInput<S>, ExtractOutput<S>> &
+  StandardSchemaV1<
+    InferFunction<ExtractInput<S>, ExtractOutput<S>>,
+    InferFunction<ExtractInput<S>, ExtractOutput<S>>
+  > => {
   type Inputs = ExtractInput<S>;
   type Output = ExtractOutput<S>;
   const inputs = schema?.input;
@@ -147,5 +155,9 @@ export const function_ = <const S extends FunctionSchema = FunctionSchema>(
     return wrapped;
   };
 
-  return validator;
+  return attachStandard<
+    InferFunction<Inputs, Output>,
+    InferFunction<Inputs, Output>,
+    typeof validator
+  >(validator);
 };

--- a/package/main/src/Validate/index.ts
+++ b/package/main/src/Validate/index.ts
@@ -12,6 +12,7 @@ export * from "./never";
 export * from "./number";
 export * from "./object";
 export * from "./set";
+export * from "./standardSchema";
 export * from "./string";
 export * from "./templateLiteral";
 export * from "./type";

--- a/package/main/src/Validate/instanceof/core.ts
+++ b/package/main/src/Validate/instanceof/core.ts
@@ -5,6 +5,10 @@
  * `instanceof_` because `instanceof` is a reserved keyword in JavaScript.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { Types, ValidateCoreReturnType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: a constructor signature must accept any tuple
@@ -22,8 +26,8 @@ export type Constructor<T> = new (...arguments_: any[]) => T;
 export const instanceof_ = <T>(
   classConstructor: Constructor<T>,
   message?: string,
-) => {
-  return (value: T): ValidateCoreReturnType<T> => {
+): ((value: T) => ValidateCoreReturnType<T>) & StandardSchemaV1<T, T> => {
+  const validator = (value: T): ValidateCoreReturnType<T> => {
     if (!(value instanceof classConstructor)) {
       return {
         validate: false,
@@ -37,4 +41,5 @@ export const instanceof_ = <T>(
       type: value as unknown as Types<T>,
     };
   };
+  return attachStandard<T, T, typeof validator>(validator);
 };

--- a/package/main/src/Validate/map/core.ts
+++ b/package/main/src/Validate/map/core.ts
@@ -5,6 +5,10 @@
  * `arrayOf()` validates each element of an array.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
 export type MapExtractValidatedType<V> = V extends (value: never) => {
@@ -40,8 +44,11 @@ export const map = <
   keyValidator?: KV,
   valueValidator?: VV,
   message?: string,
-) => {
-  return (value: Map<K, V>): ValidateCoreReturnType<Map<K, V>> => {
+): ((value: Map<K, V>) => ValidateCoreReturnType<Map<K, V>>) &
+  StandardSchemaV1<Map<K, V>, Map<K, V>> => {
+  const mapValidator = (
+    value: Map<K, V>,
+  ): ValidateCoreReturnType<Map<K, V>> => {
     if (!(value instanceof Map)) {
       return {
         validate: false,
@@ -84,4 +91,7 @@ export const map = <
       type: value,
     };
   };
+  return attachStandard<Map<K, V>, Map<K, V>, typeof mapValidator>(
+    mapValidator,
+  );
 };

--- a/package/main/src/Validate/never/core.ts
+++ b/package/main/src/Validate/never/core.ts
@@ -5,6 +5,11 @@
  * union members that should be unreachable at the type level).
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+
 /**
  * Return type produced by a `never` validator. Exposes the literal `"never"`
  * tag through the `type` field so `ValidateType<"never">` can map it back to
@@ -21,14 +26,18 @@ export interface NeverReturnType {
  * @param {string} [message] - Custom error message for validation failure
  * @returns {Function} - Validator that always returns a failing result
  */
-// biome-ignore lint/suspicious/noExplicitAny: never() is widened to accept any input from union/intersection
-export const never = (message?: string): ((value: any) => NeverReturnType) => {
+export const never = (
+  message?: string,
+): ((
+  // biome-ignore lint/suspicious/noExplicitAny: never() is widened to accept any input from union/intersection
+  value: any,
+) => NeverReturnType) &
+  StandardSchemaV1<never, never> => {
   // biome-ignore lint/suspicious/noExplicitAny: signature mirrors the public type
-  return (_value: any): NeverReturnType => {
-    return {
-      validate: false,
-      message: message ?? "",
-      type: "never",
-    };
-  };
+  const neverValidator = (_value: any): NeverReturnType => ({
+    validate: false,
+    message: message ?? "",
+    type: "never",
+  });
+  return attachStandard<never, never, typeof neverValidator>(neverValidator);
 };

--- a/package/main/src/Validate/number/core.ts
+++ b/package/main/src/Validate/number/core.ts
@@ -4,7 +4,14 @@
  */
 
 import { core } from "@/Validate/core";
-import type { ValidateReturnType } from "@/Validate/type";
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+import type {
+  ValidateCoreReturnType,
+  ValidateReturnType,
+} from "@/Validate/type";
 
 /**
  * Creates a number validator with optional validation rules
@@ -16,6 +23,9 @@ import type { ValidateReturnType } from "@/Validate/type";
 export const number = <T extends ValidateReturnType<number>[]>(
   option?: T,
   message?: string,
-) => {
-  return (value: number) => core<number>("number")(value, option, message);
+): ((value: number) => ValidateCoreReturnType<number>) &
+  StandardSchemaV1<number, number> => {
+  const validator = (value: number) =>
+    core<number>("number")(value, option, message);
+  return attachStandard<number, number, typeof validator>(validator);
 };

--- a/package/main/src/Validate/object/core.ts
+++ b/package/main/src/Validate/object/core.ts
@@ -5,6 +5,10 @@
 
 import type { PickPartial } from "$/object";
 import { isDictionaryObject } from "@/Validate/isDictionaryObject";
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type {
   OptionalKeys,
   ValidateCoreReturnType,
@@ -55,7 +59,7 @@ export type ObjectValidator<
 export const object = <T extends ObjectShape>(
   option: T = {} as T,
   message?: string,
-): ObjectValidator<T> => {
+): ObjectValidator<T> & StandardSchemaV1<unknown, unknown> => {
   type U = {
     [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]>;
   };
@@ -96,5 +100,5 @@ export const object = <T extends ObjectShape>(
   }) as ObjectValidator<T>;
 
   validator.shape = option;
-  return validator;
+  return attachStandard<Inferred, Inferred, typeof validator>(validator);
 };

--- a/package/main/src/Validate/object/intersection.ts
+++ b/package/main/src/Validate/object/intersection.ts
@@ -1,3 +1,7 @@
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type {
   Types,
   ValidateCoreReturnType,
@@ -36,8 +40,14 @@ export const intersection = <
   Vs extends ((value: never) => ValidateCoreReturnType<unknown>)[],
 >(
   ...validators: [...Vs]
-) => {
-  return (
+): ((
+  value: IntersectValidatedTypes<Vs>,
+) => ValidateCoreReturnType<IntersectValidatedTypes<Vs>>) &
+  StandardSchemaV1<
+    IntersectValidatedTypes<Vs>,
+    IntersectValidatedTypes<Vs>
+  > => {
+  const intersectionValidator = (
     value: IntersectValidatedTypes<Vs>,
   ): ValidateCoreReturnType<IntersectValidatedTypes<Vs>> => {
     for (const validator of validators) {
@@ -60,4 +70,9 @@ export const intersection = <
       type: value as unknown as Types<IntersectValidatedTypes<Vs>>,
     };
   };
+  return attachStandard<
+    IntersectValidatedTypes<Vs>,
+    IntersectValidatedTypes<Vs>,
+    typeof intersectionValidator
+  >(intersectionValidator);
 };

--- a/package/main/src/Validate/object/nullable.ts
+++ b/package/main/src/Validate/object/nullable.ts
@@ -1,3 +1,8 @@
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+
 export interface NullReturn {
   validate: boolean;
   message: string;
@@ -16,7 +21,8 @@ export const nullable = <
   R extends { type: unknown; message: string; validate: boolean },
 >(
   validator: (value: T) => R,
-): ((value: T | null) => R | NullReturn) => {
+): ((value: T | null) => R | NullReturn) &
+  StandardSchemaV1<T | null, T | null> => {
   const nullableValidator = (value: T | null): R | NullReturn => {
     if (value === null) {
       return {
@@ -28,5 +34,7 @@ export const nullable = <
     return validator(value);
   };
 
-  return nullableValidator;
+  return attachStandard<T | null, T | null, typeof nullableValidator>(
+    nullableValidator,
+  );
 };

--- a/package/main/src/Validate/object/optional.ts
+++ b/package/main/src/Validate/object/optional.ts
@@ -1,3 +1,8 @@
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+
 export interface UndefinedReturn {
   validate: boolean;
   message: string;
@@ -34,7 +39,7 @@ export const optional = <
   R extends { type: unknown; message: string; validate: boolean },
 >(
   validator: (value: T) => R,
-): OptionalValidator<T, R> => {
+): OptionalValidator<T, R> & StandardSchemaV1<T | undefined, T | undefined> => {
   const optionalValidator = ((value?: T): R | UndefinedReturn => {
     if (value === undefined) {
       return {
@@ -49,5 +54,7 @@ export const optional = <
   optionalValidator.inner = validator;
   optionalValidator.isOptional = true;
 
-  return optionalValidator;
+  return attachStandard<T | undefined, T | undefined, typeof optionalValidator>(
+    optionalValidator,
+  );
 };

--- a/package/main/src/Validate/object/union.ts
+++ b/package/main/src/Validate/object/union.ts
@@ -1,3 +1,7 @@
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type {
   Types,
   ValidateCoreReturnType,
@@ -24,8 +28,14 @@ export const union = <
   Vs extends ((value: never) => ValidateCoreReturnType<unknown>)[],
 >(
   ...validators: [...Vs]
-) => {
-  return (
+): ((
+  value: UnionExtractValidatedType<Vs[number]>,
+) => ValidateCoreReturnType<UnionExtractValidatedType<Vs[number]>>) &
+  StandardSchemaV1<
+    UnionExtractValidatedType<Vs[number]>,
+    UnionExtractValidatedType<Vs[number]>
+  > => {
+  const unionValidator = (
     value: UnionExtractValidatedType<Vs[number]>,
   ): ValidateCoreReturnType<UnionExtractValidatedType<Vs[number]>> => {
     let lastMessage = "";
@@ -52,4 +62,9 @@ export const union = <
       type: value as unknown as Types<UnionExtractValidatedType<Vs[number]>>,
     };
   };
+  return attachStandard<
+    UnionExtractValidatedType<Vs[number]>,
+    UnionExtractValidatedType<Vs[number]>,
+    typeof unionValidator
+  >(unionValidator);
 };

--- a/package/main/src/Validate/set/core.ts
+++ b/package/main/src/Validate/set/core.ts
@@ -8,6 +8,10 @@
  * already exposes a `set` runtime helper.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateCoreReturnType, ValidateType } from "@/Validate/type";
 
 export type SetExtractValidatedType<V> = V extends (value: never) => {
@@ -34,8 +38,9 @@ export const set_ = <
 >(
   itemValidator?: IV,
   message?: string,
-) => {
-  return (value: Set<T>): ValidateCoreReturnType<Set<T>> => {
+): ((value: Set<T>) => ValidateCoreReturnType<Set<T>>) &
+  StandardSchemaV1<Set<T>, Set<T>> => {
+  const setValidator = (value: Set<T>): ValidateCoreReturnType<Set<T>> => {
     if (!(value instanceof Set)) {
       return {
         validate: false,
@@ -66,4 +71,5 @@ export const set_ = <
       type: value,
     };
   };
+  return attachStandard<Set<T>, Set<T>, typeof setValidator>(setValidator);
 };

--- a/package/main/src/Validate/standardSchema.ts
+++ b/package/main/src/Validate/standardSchema.ts
@@ -1,0 +1,146 @@
+/**
+ * Standard Schema V1 integration
+ *
+ * Defines the public Standard Schema V1 surface (https://standardschema.dev)
+ * and exposes the `attachStandard()` helper used by every UMT validator
+ * factory to advertise itself as a Standard Schema V1 implementation. The
+ * `~standard` property added by `attachStandard()` lets external tools
+ * (Zod-, Valibot-, ArkType-style ecosystems) consume UMT validators without
+ * adapters.
+ *
+ * Biome's `noNamespace` lint rule forbids TypeScript namespaces, so the spec
+ * is mirrored with flat interface/type names that remain structurally
+ * compatible with the official `StandardSchemaV1` interface published by
+ * `@standard-schema/spec`.
+ */
+
+/** The Standard Schema V1 interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly "~standard": StandardSchemaV1Properties<Input, Output>;
+}
+
+/** The Standard Schema V1 properties interface. */
+export interface StandardSchemaV1Properties<Input = unknown, Output = Input> {
+  /** The version number of the standard. */
+  readonly version: 1;
+  /** The vendor name of the schema library. */
+  readonly vendor: string;
+  /** Validates unknown input values. */
+  readonly validate: (
+    value: unknown,
+  ) => StandardSchemaV1Result<Output> | Promise<StandardSchemaV1Result<Output>>;
+  /** Inferred types associated with the schema. */
+  readonly types?: StandardSchemaV1Types<Input, Output> | undefined;
+}
+
+/** The result type produced by `Props.validate`. */
+export type StandardSchemaV1Result<Output> =
+  | StandardSchemaV1SuccessResult<Output>
+  | StandardSchemaV1FailureResult;
+
+/** The result interface when validation succeeds. */
+export interface StandardSchemaV1SuccessResult<Output> {
+  readonly value: Output;
+  readonly issues?: undefined;
+}
+
+/** The result interface when validation fails. */
+export interface StandardSchemaV1FailureResult {
+  readonly issues: readonly StandardSchemaV1Issue[];
+}
+
+/** The issue interface returned on failure. */
+export interface StandardSchemaV1Issue {
+  readonly message: string;
+  readonly path?:
+    | readonly (PropertyKey | StandardSchemaV1PathSegment)[]
+    | undefined;
+}
+
+/** The path segment interface for nested issues. */
+export interface StandardSchemaV1PathSegment {
+  readonly key: PropertyKey;
+}
+
+/** The Standard Schema V1 types interface. */
+export interface StandardSchemaV1Types<Input = unknown, Output = Input> {
+  /** The input type of the schema. */
+  readonly input: Input;
+  /** The output type of the schema. */
+  readonly output: Output;
+}
+
+/** Infers the input type of a Standard Schema V1 implementation. */
+export type StandardSchemaV1InferInput<
+  // biome-ignore lint/suspicious/noExplicitAny: schema may be any spec-compliant value
+  Schema extends StandardSchemaV1<any, any>,
+> = NonNullable<Schema["~standard"]["types"]>["input"];
+
+/** Infers the output type of a Standard Schema V1 implementation. */
+export type StandardSchemaV1InferOutput<
+  // biome-ignore lint/suspicious/noExplicitAny: schema may be any spec-compliant value
+  Schema extends StandardSchemaV1<any, any>,
+> = NonNullable<Schema["~standard"]["types"]>["output"];
+
+/**
+ * Vendor identifier used by all UMT validators when advertising Standard
+ * Schema V1 compatibility. External tools may key off this value to attach
+ * UMT-specific behavior.
+ */
+export const STANDARD_SCHEMA_VENDOR = "umt";
+
+/** Minimal shape of UMT validator results consumed by `attachStandard`. */
+export interface UmtValidatorResult {
+  validate: boolean;
+  message: string;
+  type: unknown;
+}
+
+/**
+ * Attaches a Standard Schema V1 `~standard` property to a UMT validator
+ * function in place. The validator's existing call signature, attached
+ * helpers (such as `shape` on `object()` or `implement` on `function_()`),
+ * and return type are preserved untouched; only the `~standard` property is
+ * added.
+ *
+ * Validation is delegated to the wrapped validator. On success the input
+ * value is returned through the Standard Schema `value` field; on failure a
+ * single issue carrying the validator's message is emitted. UMT validators
+ * never transform their input, so `Input` and `Output` default to the same
+ * type.
+ *
+ * @template Input - The input type advertised through `~standard.types`
+ * @template Output - The output type advertised through `~standard.types`
+ * @template F - The validator function being augmented
+ * @param {F} validator - The validator function to augment
+ * @returns {F & StandardSchemaV1<Input, Output>} The same function with `~standard` attached
+ */
+export const attachStandard = <
+  Input,
+  Output = Input,
+  // biome-ignore lint/suspicious/noExplicitAny: validator argument shapes vary across factories
+  F extends (...arguments_: any[]) => UmtValidatorResult = (
+    // biome-ignore lint/suspicious/noExplicitAny: fallback signature accepts any input
+    ...arguments_: any[]
+  ) => UmtValidatorResult,
+>(
+  validator: F,
+): F & StandardSchemaV1<Input, Output> => {
+  const properties: StandardSchemaV1Properties<Input, Output> = {
+    version: 1,
+    vendor: STANDARD_SCHEMA_VENDOR,
+    validate: (value: unknown): StandardSchemaV1Result<Output> => {
+      const result = (
+        validator as unknown as (input: unknown) => UmtValidatorResult
+      )(value);
+      if (result.validate) {
+        return { value: value as Output };
+      }
+      return {
+        issues: [{ message: result.message || "Validation failed" }],
+      };
+    },
+  };
+  (validator as unknown as Record<string, unknown>)["~standard"] = properties;
+  return validator as F & StandardSchemaV1<Input, Output>;
+};

--- a/package/main/src/Validate/string/core.ts
+++ b/package/main/src/Validate/string/core.ts
@@ -4,7 +4,14 @@
  */
 
 import { core } from "@/Validate/core";
-import type { ValidateReturnType } from "@/Validate/type";
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+import type {
+  ValidateCoreReturnType,
+  ValidateReturnType,
+} from "@/Validate/type";
 
 /**
  * Creates a string validator with optional validation rules
@@ -13,7 +20,12 @@ import type { ValidateReturnType } from "@/Validate/type";
  * @param {string} [message] - Custom error message for type validation
  * @returns {Function} - Validator function that checks if the value is a string and applies validation rules
  */
-export const string =
-  <T extends ValidateReturnType<string>[]>(option?: T, message?: string) =>
-  (value: string) =>
+export const string = <T extends ValidateReturnType<string>[]>(
+  option?: T,
+  message?: string,
+): ((value: string) => ValidateCoreReturnType<string>) &
+  StandardSchemaV1<string, string> => {
+  const validator = (value: string) =>
     core<string>("string")(value, option, message);
+  return attachStandard<string, string, typeof validator>(validator);
+};

--- a/package/main/src/Validate/templateLiteral/core.ts
+++ b/package/main/src/Validate/templateLiteral/core.ts
@@ -7,6 +7,10 @@
  * inferred type is the corresponding TypeScript template literal type.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
 import type { ValidateType } from "@/Validate/type";
 
 // biome-ignore lint/suspicious/noExplicitAny: validator signatures vary
@@ -109,7 +113,13 @@ export const templateLiteral = <
 >(
   parts: Parts,
   message?: string,
-) => {
+): ((
+  value: BuildTemplateLiteral<Parts>,
+) => TemplateLiteralReturnType<BuildTemplateLiteral<Parts>>) &
+  StandardSchemaV1<
+    BuildTemplateLiteral<Parts>,
+    BuildTemplateLiteral<Parts>
+  > => {
   let pattern = "^";
   for (const part of parts) {
     pattern +=
@@ -120,7 +130,7 @@ export const templateLiteral = <
   pattern += "$";
   const regex = new RegExp(pattern);
 
-  return (
+  const templateValidator = (
     value: BuildTemplateLiteral<Parts>,
   ): TemplateLiteralReturnType<BuildTemplateLiteral<Parts>> => {
     if (typeof value !== "string" || !regex.test(value)) {
@@ -136,4 +146,9 @@ export const templateLiteral = <
       type: value,
     };
   };
+  return attachStandard<
+    BuildTemplateLiteral<Parts>,
+    BuildTemplateLiteral<Parts>,
+    typeof templateValidator
+  >(templateValidator);
 };

--- a/package/main/src/Validate/unknown/core.ts
+++ b/package/main/src/Validate/unknown/core.ts
@@ -4,6 +4,11 @@
  * to keep callers honest about narrowing before use.
  */
 
+import {
+  attachStandard,
+  type StandardSchemaV1,
+} from "@/Validate/standardSchema";
+
 /**
  * Return type produced by an `unknown` validator. Exposes the literal
  * `"unknown"` tag through the `type` field so `ValidateType<"unknown">` can
@@ -22,9 +27,15 @@ const unknownValidator = (_value: unknown): UnknownReturnType => ({
   type: "unknown",
 });
 
+const standardUnknownValidator = attachStandard<
+  unknown,
+  unknown,
+  typeof unknownValidator
+>(unknownValidator);
+
 /**
  * Creates a validator that accepts any value but typed as unknown
  * @returns {Function} - Validator that always succeeds
  */
-export const unknown = (): ((value: unknown) => UnknownReturnType) =>
-  unknownValidator;
+export const unknown = (): ((value: unknown) => UnknownReturnType) &
+  StandardSchemaV1<unknown, unknown> => standardUnknownValidator;

--- a/package/main/src/tests/unit/Validate/standardSchema.test.ts
+++ b/package/main/src/tests/unit/Validate/standardSchema.test.ts
@@ -1,0 +1,166 @@
+import { any } from "@/Validate/any";
+import { arrayOf } from "@/Validate/array";
+import { bigint } from "@/Validate/bigint";
+import { boolean } from "@/Validate/boolean";
+import { date } from "@/Validate/date";
+import { file } from "@/Validate/file";
+import { function_ } from "@/Validate/function";
+import { instanceof_ } from "@/Validate/instanceof";
+import { map } from "@/Validate/map";
+import { never } from "@/Validate/never";
+import { number } from "@/Validate/number";
+import { object } from "@/Validate/object";
+import { intersection } from "@/Validate/object/intersection";
+import { nullable } from "@/Validate/object/nullable";
+import { optional } from "@/Validate/object/optional";
+import { union } from "@/Validate/object/union";
+import { set_ } from "@/Validate/set";
+import {
+  STANDARD_SCHEMA_VENDOR,
+  type StandardSchemaV1,
+  type StandardSchemaV1FailureResult,
+  type StandardSchemaV1SuccessResult,
+} from "@/Validate/standardSchema";
+import { string } from "@/Validate/string";
+import { templateLiteral } from "@/Validate/templateLiteral";
+import { unknown } from "@/Validate/unknown";
+
+type SyncResult<O> =
+  | StandardSchemaV1SuccessResult<O>
+  | StandardSchemaV1FailureResult;
+
+const syncValidate = <I, O>(
+  schema: StandardSchemaV1<I, O>,
+  value: unknown,
+): SyncResult<O> => {
+  const result = schema["~standard"].validate(value);
+  if (result instanceof Promise) {
+    throw new TypeError("Expected synchronous validation result");
+  }
+  return result;
+};
+
+const expectedProps = {
+  version: 1,
+  vendor: STANDARD_SCHEMA_VENDOR,
+  // biome-ignore lint/suspicious/noExplicitAny: matcher is expect.any
+  validate: expect.any(Function) as unknown as (value: unknown) => any,
+};
+
+describe("Standard Schema V1 compatibility", () => {
+  it("string validator exposes the spec interface", () => {
+    const validator = string();
+    expect(validator["~standard"]).toMatchObject(expectedProps);
+    const ok = syncValidate(validator, "hello");
+    expect(ok.issues).toBeUndefined();
+    expect((ok as StandardSchemaV1SuccessResult<string>).value).toBe("hello");
+
+    const ng = syncValidate(validator, 123);
+    expect((ng as StandardSchemaV1FailureResult).issues.length).toBe(1);
+  });
+
+  it("number validator surfaces the configured message on failure", () => {
+    const validator = number([], "must be a number");
+    expect(validator["~standard"]).toMatchObject(expectedProps);
+    const result = syncValidate(validator, "not-a-number");
+    expect((result as StandardSchemaV1FailureResult).issues[0]?.message).toBe(
+      "must be a number",
+    );
+  });
+
+  it("boolean / bigint / date / file validators implement the spec", () => {
+    expect(boolean()["~standard"]).toMatchObject(expectedProps);
+    expect(bigint()["~standard"]).toMatchObject(expectedProps);
+    expect(date()["~standard"]).toMatchObject(expectedProps);
+    expect(file()["~standard"]).toMatchObject(expectedProps);
+  });
+
+  it("any / unknown / never validators implement the spec", () => {
+    const anyValidator = any();
+    const unknownValidator = unknown();
+    const neverValidator = never("never message");
+    expect(anyValidator["~standard"]).toMatchObject(expectedProps);
+    expect(unknownValidator["~standard"]).toMatchObject(expectedProps);
+    expect(neverValidator["~standard"]).toMatchObject(expectedProps);
+
+    expect(syncValidate(anyValidator, Symbol("x")).issues).toBeUndefined();
+    expect(syncValidate(unknownValidator, null).issues).toBeUndefined();
+
+    const neverResult = syncValidate(neverValidator, 1);
+    expect(
+      (neverResult as StandardSchemaV1FailureResult).issues[0]?.message,
+    ).toBe("never message");
+  });
+
+  it("instanceof / arrayOf / set_ / map validators implement the spec", () => {
+    class Sample {
+      readonly id = 1;
+    }
+    expect(instanceof_(Sample)["~standard"]).toMatchObject(expectedProps);
+    expect(arrayOf(string())["~standard"]).toMatchObject(expectedProps);
+    expect(set_(string())["~standard"]).toMatchObject(expectedProps);
+    expect(map(string(), number())["~standard"]).toMatchObject(expectedProps);
+  });
+
+  it("templateLiteral validator validates input through the spec", () => {
+    const validator = templateLiteral(["user-", number()]);
+    expect(validator["~standard"]).toMatchObject(expectedProps);
+    expect(syncValidate(validator, "user-1").issues).toBeUndefined();
+    expect(syncValidate(validator, "admin-1").issues?.length).toBe(1);
+  });
+
+  it("object validator implements the spec and validates payloads", () => {
+    const validator = object({
+      name: string(),
+      age: number(),
+    });
+    expect(validator["~standard"]).toMatchObject(expectedProps);
+    const ok = syncValidate(validator, { name: "Alice", age: 30 });
+    expect(ok.issues).toBeUndefined();
+    const ng = syncValidate(validator, { name: "Alice" });
+    expect(ng.issues?.length).toBe(1);
+  });
+
+  it("union / intersection / optional / nullable validators implement the spec", () => {
+    const stringOrNumber = union(string(), number());
+    const both = intersection(object({ a: string() }), object({ b: number() }));
+    const maybeString = optional(string());
+    const stringOrNull = nullable(string());
+
+    expect(stringOrNumber["~standard"]).toMatchObject(expectedProps);
+    expect(both["~standard"]).toMatchObject(expectedProps);
+    expect(maybeString["~standard"]).toMatchObject(expectedProps);
+    expect(stringOrNull["~standard"]).toMatchObject(expectedProps);
+
+    expect(syncValidate(stringOrNumber, "x").issues).toBeUndefined();
+    expect(syncValidate(stringOrNumber, 1).issues).toBeUndefined();
+    expect(syncValidate(stringOrNumber, true).issues?.length).toBe(1);
+
+    expect(syncValidate(both, { a: "x", b: 1 }).issues).toBeUndefined();
+    expect(syncValidate(both, { a: "x" }).issues?.length).toBe(1);
+
+    expect(syncValidate(maybeString, undefined).issues).toBeUndefined();
+    expect(syncValidate(maybeString, "x").issues).toBeUndefined();
+
+    expect(syncValidate(stringOrNull, null).issues).toBeUndefined();
+    expect(syncValidate(stringOrNull, "x").issues).toBeUndefined();
+  });
+
+  it("function_ validator implements the spec", () => {
+    const validator = function_({
+      input: [string()],
+      output: number(),
+    });
+    expect(validator["~standard"]).toMatchObject(expectedProps);
+    expect(syncValidate(validator, () => 1).issues).toBeUndefined();
+    expect(syncValidate(validator, "not a function").issues?.length).toBe(1);
+  });
+
+  it("emits a default issue message when the validator has none", () => {
+    const validator = string();
+    const result = syncValidate(validator, 123);
+    expect((result as StandardSchemaV1FailureResult).issues[0]?.message).toBe(
+      "Validation failed",
+    );
+  });
+});


### PR DESCRIPTION
Every validator returned by `string()`, `number()`, `object()`, `arrayOf()`, `union()`, `intersection()`, `optional()`, `nullable()`, etc. now carries a `~standard` property conforming to https://standardschema.dev, so the validators can be consumed by Standard Schema-aware tools (Zod / Valibot / ArkType ecosystems) without adapters. The new `attachStandard()` helper and spec types live in `Validate/standardSchema.ts`.

https://claude.ai/code/session_014JJ1jremwbwdLKR4DrjYH5