### PR TITLE
Release v3.2.0

### DIFF
--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -9,18 +9,18 @@
     "@babel/core": "7.29.0",
     "@babel/preset-env": "7.29.5",
     "@babel/preset-typescript": "7.28.5",
-    "@biomejs/biome": "2.4.14",
+    "@biomejs/biome": "2.4.15",
     "@codecov/bundle-analyzer": "2.0.1",
     "@eslint/js": "10.0.1",
     "@swc/core": "1.15.33",
     "@swc/jest": "0.2.39",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "@types/jest": "30.0.0",
     "@types/lodash": "4.17.24",
-    "@types/node": "25.6.0",
-    "@typescript-eslint/eslint-plugin": "8.59.2",
-    "@typescript-eslint/parser": "8.59.2",
-    "bun-types": "1.3.13",
+    "@types/node": "25.7.0",
+    "@typescript-eslint/eslint-plugin": "8.59.3",
+    "@typescript-eslint/parser": "8.59.3",
+    "bun-types": "1.3.14",
     "dependency-cruiser": "17.4.0",
     "es-toolkit": "1.46.1",
     "eslint": "10.3.0",
@@ -29,7 +29,7 @@
     "eslint-plugin-unicorn": "64.0.0",
     "fast-sort": "3.4.1",
     "gh-pages": "6.3.0",
-    "jest": "30.3.0",
+    "jest": "30.4.2",
     "jest-junit": "17.0.0",
     "lodash": "4.18.1",
     "mitata": "1.0.34",
@@ -40,7 +40,7 @@
     "typedoc-github-wiki-theme": "2.1.0",
     "typedoc-plugin-markdown": "4.11.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.59.2"
+    "typescript-eslint": "8.59.3"
   },
   "exports": {
     ".": {
@@ -225,5 +225,5 @@
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }


### PR DESCRIPTION
# Release v3.2.0

This release makes every UMT validator a Standard Schema V1 implementation so that Zod / Valibot / ArkType ecosystem tools can consume UMT validators without adapters. It also adds the cross-runtime PR benchmark workflow on CI.

## ✨ New Features

### 🔧 New Functions in Existing Modules

* **Validate**: Every validator factory (`string`, `number`, `object`, `arrayOf`, `union`, `intersection`, `optional`, `nullable`, etc.) now carries a `~standard` property conforming to [Standard Schema V1](https://standardschema.dev), exposing the new `attachStandard()` helper plus spec types (`StandardSchemaV1`, `StandardSchemaV1Properties`, `StandardSchemaV1Result`, `StandardSchemaV1Issue`, `StandardSchemaV1PathSegment`, `StandardSchemaV1Types`, `StandardSchemaV1InferInput`, `StandardSchemaV1InferOutput`) from `Validate/standardSchema.ts` (#841).

## 🧪 Testing

* Added `src/tests/unit/Validate/standardSchema.test.ts` covering `~standard.version`, `~standard.vendor`, success / failure issue shape, and inferred input / output types across every factory (#841).

## 🛠️ Tooling & CI

* Added a PR benchmark workflow plus supporting scripts (`scripts/benchmark/runAll.mjs`, `scripts/benchmark/compare.mjs`, `scripts/benchmark/bundleBenchmarks.mjs`) for cross-runtime comparison on pull requests (#842).

## 🔄 Maintenance

* Bumped grouped `bun-dependencies` across Babel / Biome / `@types/*` / `typescript-eslint` / Jest (#835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)