### PR TITLE
Release v3.2.1

### DIFF
--- a/package/main/bun.lock
+++ b/package/main/bun.lock
@@ -12,6 +12,7 @@
         "@biomejs/biome": "2.4.15",
         "@codecov/bundle-analyzer": "2.0.1",
         "@eslint/js": "10.0.1",
+        "@hono/standard-validator": "0.2.2",
         "@swc/core": "1.15.33",
         "@swc/jest": "0.2.39",
         "@types/bun": "1.3.14",
@@ -29,6 +30,7 @@
         "eslint-plugin-unicorn": "64.0.0",
         "fast-sort": "3.4.1",
         "gh-pages": "6.3.0",
+        "hono": "4.12.19",
         "jest": "30.4.2",
         "jest-junit": "17.0.0",
         "lodash": "4.18.1",
@@ -323,6 +325,8 @@
 
     "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
 
+    "@hono/standard-validator": ["@hono/standard-validator@0.2.2", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=3.9.0" } }, "sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -436,6 +440,8 @@
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/core": ["@swc/core@1.15.33", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.33", "@swc/core-darwin-x64": "1.15.33", "@swc/core-linux-arm-gnueabihf": "1.15.33", "@swc/core-linux-arm64-gnu": "1.15.33", "@swc/core-linux-arm64-musl": "1.15.33", "@swc/core-linux-ppc64-gnu": "1.15.33", "@swc/core-linux-s390x-gnu": "1.15.33", "@swc/core-linux-x64-gnu": "1.15.33", "@swc/core-linux-x64-musl": "1.15.33", "@swc/core-win32-arm64-msvc": "1.15.33", "@swc/core-win32-ia32-msvc": "1.15.33", "@swc/core-win32-x64-msvc": "1.15.33" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ=="],
 
@@ -922,6 +928,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.19", "", {}, "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/package/main/common-module/package.json
+++ b/package/main/common-module/package.json
@@ -12,6 +12,7 @@
     "@biomejs/biome": "2.4.15",
     "@codecov/bundle-analyzer": "2.0.1",
     "@eslint/js": "10.0.1",
+    "@hono/standard-validator": "0.2.2",
     "@swc/core": "1.15.33",
     "@swc/jest": "0.2.39",
     "@types/bun": "1.3.14",
@@ -29,6 +30,7 @@
     "eslint-plugin-unicorn": "64.0.0",
     "fast-sort": "3.4.1",
     "gh-pages": "6.3.0",
+    "hono": "4.12.19",
     "jest": "30.4.2",
     "jest-junit": "17.0.0",
     "lodash": "4.18.1",
@@ -225,5 +227,5 @@
   },
   "type": "commonjs",
   "types": "module/index.d.ts",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }

--- a/package/main/package.json
+++ b/package/main/package.json
@@ -12,6 +12,7 @@
     "@biomejs/biome": "2.4.15",
     "@codecov/bundle-analyzer": "2.0.1",
     "@eslint/js": "10.0.1",
+    "@hono/standard-validator": "0.2.2",
     "@swc/core": "1.15.33",
     "@swc/jest": "0.2.39",
     "@types/bun": "1.3.14",
@@ -29,6 +30,7 @@
     "eslint-plugin-unicorn": "64.0.0",
     "fast-sort": "3.4.1",
     "gh-pages": "6.3.0",
+    "hono": "4.12.19",
     "jest": "30.4.2",
     "jest-junit": "17.0.0",
     "lodash": "4.18.1",
@@ -226,5 +228,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }

--- a/package/main/src/Validate/object/core.ts
+++ b/package/main/src/Validate/object/core.ts
@@ -24,28 +24,37 @@ export interface ObjectShape {
 }
 
 /**
+ * Resolved property map produced by applying `ValidateType` to every shape
+ * entry. Each property maps a `ValidateType` tag (such as `"string"`,
+ * `"number"`) back to the runtime type expected at that key.
+ */
+export type ObjectShapeProperties<T extends ObjectShape> = {
+  [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]>;
+};
+
+/**
+ * Inferred object type produced by `object()`. Splits the property map into
+ * required and optional halves via `PickPartial` + `OptionalKeys` so optional
+ * properties surface with `?:` in the resulting type.
+ */
+export type InferObject<T extends ObjectShape> = {
+  [key in keyof PickPartial<
+    ObjectShapeProperties<T>,
+    OptionalKeys<ObjectShapeProperties<T>>
+  >]: PickPartial<
+    ObjectShapeProperties<T>,
+    OptionalKeys<ObjectShapeProperties<T>>
+  >[key];
+};
+
+/**
  * Object validator augmented with the original `shape` map. The shape map is
  * exposed so derived helpers such as `pick()`, `omit()`, `partial()`, and
  * `required()` can compose new object validators from existing ones.
  */
-export type ObjectValidator<
-  T extends ObjectShape,
-  U = {
-    [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]>;
-  },
-> = ((
-  value: {
-    [key in keyof PickPartial<U, OptionalKeys<U>>]: PickPartial<
-      U,
-      OptionalKeys<U>
-    >[key];
-  },
-) => ValidateCoreReturnType<{
-  [key in keyof PickPartial<U, OptionalKeys<U>>]: PickPartial<
-    U,
-    OptionalKeys<U>
-  >[key];
-}>) & {
+export type ObjectValidator<T extends ObjectShape> = ((
+  value: InferObject<T>,
+) => ValidateCoreReturnType<InferObject<T>>) & {
   shape: T;
 };
 
@@ -59,16 +68,8 @@ export type ObjectValidator<
 export const object = <T extends ObjectShape>(
   option: T = {} as T,
   message?: string,
-): ObjectValidator<T> & StandardSchemaV1<unknown, unknown> => {
-  type U = {
-    [key in keyof T]: ValidateType<ReturnType<T[key]>["type"]>;
-  };
-  type Inferred = {
-    [key in keyof PickPartial<U, OptionalKeys<U>>]: PickPartial<
-      U,
-      OptionalKeys<U>
-    >[key];
-  };
+): ObjectValidator<T> & StandardSchemaV1<InferObject<T>, InferObject<T>> => {
+  type Inferred = InferObject<T>;
 
   const validator = ((value: Inferred): ValidateCoreReturnType<Inferred> => {
     if (!isDictionaryObject(value)) {

--- a/package/main/src/tests/integration/Validate/hono-standard-validator.test.ts
+++ b/package/main/src/tests/integration/Validate/hono-standard-validator.test.ts
@@ -1,0 +1,194 @@
+import { sValidator } from "@hono/standard-validator";
+import { Hono } from "hono";
+import { arrayOf } from "@/Validate/array/arrayOf";
+import { boolean } from "@/Validate/boolean";
+import { number } from "@/Validate/number";
+import { object } from "@/Validate/object/core";
+import { intersection } from "@/Validate/object/intersection";
+import { nullable } from "@/Validate/object/nullable";
+import { optional } from "@/Validate/object/optional";
+import { union } from "@/Validate/object/union";
+import { string } from "@/Validate/string";
+
+/**
+ * Regression tests covering UMT validators consumed through
+ * `@hono/standard-validator`. The previous release advertised
+ * `StandardSchemaV1<unknown, unknown>` for `object()`, which collapsed
+ * `c.req.valid("json")` to `unknown` and produced `TS18046` at every
+ * field access. These tests fail to compile if the inferred output type
+ * regresses to `unknown`, and fail at runtime if the validator's
+ * `~standard.validate` reports invalid input as valid.
+ */
+describe("Integration: UMT validators with @hono/standard-validator", () => {
+  it("infers c.req.valid('json') as the object shape and round-trips a valid request", async () => {
+    const UpsertProfileInputSchema = object({
+      displayName: string(),
+      bio: string(),
+      isPublic: boolean(),
+    });
+
+    const app = new Hono().post(
+      "/profile",
+      sValidator("json", UpsertProfileInputSchema),
+      (c) => {
+        const input = c.req.valid("json");
+        // The following annotations would fail if `c.req.valid("json")`
+        // collapsed back to `unknown`, guarding against the previous
+        // regression where object() advertised StandardSchemaV1<unknown, unknown>.
+        const displayName: string = input.displayName;
+        const bio: string = input.bio;
+        const isPublic: boolean = input.isPublic;
+        return c.json({ displayName, bio, isPublic });
+      },
+    );
+
+    const response = await app.request("/profile", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        displayName: "yuta",
+        bio: "engineer",
+        isPublic: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({
+      displayName: "yuta",
+      bio: "engineer",
+      isPublic: true,
+    });
+  });
+
+  it("rejects a request that violates the object shape with status 400", async () => {
+    const UpsertProfileInputSchema = object({
+      displayName: string(),
+      isPublic: boolean(),
+    });
+
+    const app = new Hono().post(
+      "/profile",
+      sValidator("json", UpsertProfileInputSchema),
+      (c) => c.json(c.req.valid("json")),
+    );
+
+    const response = await app.request("/profile", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ displayName: 42, isPublic: "yes" }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("preserves optional() keys as `?:` in the inferred output type", async () => {
+    const Schema = object({
+      id: string(),
+      nickname: optional(string()),
+    });
+
+    const app = new Hono().post(
+      "/optional",
+      sValidator("json", Schema),
+      (c) => {
+        const input = c.req.valid("json");
+        const id: string = input.id;
+        const nickname: string | undefined = input.nickname;
+        return c.json({ id, nickname: nickname ?? null });
+      },
+    );
+
+    const withoutNickname = await app.request("/optional", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "u1" }),
+    });
+    expect(withoutNickname.status).toBe(200);
+    expect(await withoutNickname.json()).toStrictEqual({
+      id: "u1",
+      nickname: null,
+    });
+
+    const withNickname = await app.request("/optional", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "u2", nickname: "yuta" }),
+    });
+    expect(withNickname.status).toBe(200);
+    expect(await withNickname.json()).toStrictEqual({
+      id: "u2",
+      nickname: "yuta",
+    });
+  });
+
+  it("flows nullable() into the inferred output type as `T | null`", async () => {
+    const Schema = object({
+      avatarUrl: nullable(string()),
+    });
+
+    const app = new Hono().post("/nullable", sValidator("json", Schema), (c) =>
+      c.json(c.req.valid("json")),
+    );
+
+    const nullCase = await app.request("/nullable", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ avatarUrl: null }),
+    });
+    expect(nullCase.status).toBe(200);
+    expect(await nullCase.json()).toStrictEqual({ avatarUrl: null });
+
+    const stringCase = await app.request("/nullable", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ avatarUrl: "https://example.com/a.png" }),
+    });
+    expect(stringCase.status).toBe(200);
+  });
+
+  it("supports arrayOf, union, and intersection at top level", async () => {
+    const ListSchema = arrayOf(object({ id: number(), label: string() }));
+    const UnionSchema = union(string(), number());
+    const IntersectionSchema = intersection(
+      object({ id: string() }),
+      object({ label: string() }),
+    );
+
+    const app = new Hono()
+      .post("/list", sValidator("json", ListSchema), (c) =>
+        c.json({ count: c.req.valid("json").length }),
+      )
+      .post("/either", sValidator("json", UnionSchema), (c) =>
+        c.json({ value: c.req.valid("json") }),
+      )
+      .post("/both", sValidator("json", IntersectionSchema), (c) => {
+        const input = c.req.valid("json");
+        const id: string = input.id;
+        const label: string = input.label;
+        return c.json({ id, label });
+      });
+
+    const list = await app.request("/list", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([{ id: 1, label: "a" }]),
+    });
+    expect(list.status).toBe(200);
+    expect(await list.json()).toStrictEqual({ count: 1 });
+
+    const either = await app.request("/either", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify("hello"),
+    });
+    expect(either.status).toBe(200);
+
+    const both = await app.request("/both", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "i1", label: "l1" }),
+    });
+    expect(both.status).toBe(200);
+    expect(await both.json()).toStrictEqual({ id: "i1", label: "l1" });
+  });
+});

--- a/package/main/src/tests/integration/Validate/hono-standard-validator.test.ts
+++ b/package/main/src/tests/integration/Validate/hono-standard-validator.test.ts
@@ -10,185 +10,123 @@ import { optional } from "@/Validate/object/optional";
 import { union } from "@/Validate/object/union";
 import { string } from "@/Validate/string";
 
-/**
- * Regression tests covering UMT validators consumed through
- * `@hono/standard-validator`. The previous release advertised
- * `StandardSchemaV1<unknown, unknown>` for `object()`, which collapsed
- * `c.req.valid("json")` to `unknown` and produced `TS18046` at every
- * field access. These tests fail to compile if the inferred output type
- * regresses to `unknown`, and fail at runtime if the validator's
- * `~standard.validate` reports invalid input as valid.
- */
 describe("Integration: UMT validators with @hono/standard-validator", () => {
-  it("infers c.req.valid('json') as the object shape and round-trips a valid request", async () => {
-    const UpsertProfileInputSchema = object({
-      displayName: string(),
-      bio: string(),
-      isPublic: boolean(),
-    });
-
-    const app = new Hono().post(
-      "/profile",
-      sValidator("json", UpsertProfileInputSchema),
-      (c) => {
-        const input = c.req.valid("json");
-        // The following annotations would fail if `c.req.valid("json")`
-        // collapsed back to `unknown`, guarding against the previous
-        // regression where object() advertised StandardSchemaV1<unknown, unknown>.
-        const displayName: string = input.displayName;
-        const bio: string = input.bio;
-        const isPublic: boolean = input.isPublic;
-        return c.json({ displayName, bio, isPublic });
-      },
-    );
-
-    const response = await app.request("/profile", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        displayName: "yuta",
-        bio: "engineer",
-        isPublic: true,
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toStrictEqual({
-      displayName: "yuta",
-      bio: "engineer",
-      isPublic: true,
-    });
-  });
-
-  it("rejects a request that violates the object shape with status 400", async () => {
-    const UpsertProfileInputSchema = object({
-      displayName: string(),
-      isPublic: boolean(),
-    });
-
-    const app = new Hono().post(
-      "/profile",
-      sValidator("json", UpsertProfileInputSchema),
-      (c) => c.json(c.req.valid("json")),
-    );
-
-    const response = await app.request("/profile", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ displayName: 42, isPublic: "yes" }),
-    });
-
-    expect(response.status).toBe(400);
-  });
-
-  it("preserves optional() keys as `?:` in the inferred output type", async () => {
+  it("types c.req.valid('json') from an object() schema by property", async () => {
     const Schema = object({
-      id: string(),
-      nickname: optional(string()),
+      name: string(),
+      age: number(),
+      active: boolean(),
     });
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const name: string = input.name;
+      const age: number = input.age;
+      const active: boolean = input.active;
+      return c.json({ name, age, active });
+    });
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "x", age: 1, active: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ name: "x", age: 1, active: true });
+  });
 
-    const app = new Hono().post(
-      "/optional",
-      sValidator("json", Schema),
-      (c) => {
-        const input = c.req.valid("json");
-        const id: string = input.id;
-        const nickname: string | undefined = input.nickname;
-        return c.json({ id, nickname: nickname ?? null });
-      },
+  it("returns 400 for an object() request with a wrong-typed property", async () => {
+    const Schema = object({ name: string() });
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) =>
+      c.json(c.req.valid("json")),
     );
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: 42 }),
+    });
+    expect(res.status).toBe(400);
+  });
 
-    const withoutNickname = await app.request("/optional", {
+  it("types optional() as T | undefined in c.req.valid('json')", async () => {
+    const Schema = object({ id: string(), nick: optional(string()) });
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string = input.id;
+      const nick: string | undefined = input.nick;
+      return c.json({ id, nick: nick ?? null });
+    });
+    const res = await app.request("/u", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ id: "u1" }),
     });
-    expect(withoutNickname.status).toBe(200);
-    expect(await withoutNickname.json()).toStrictEqual({
-      id: "u1",
-      nickname: null,
-    });
-
-    const withNickname = await app.request("/optional", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ id: "u2", nickname: "yuta" }),
-    });
-    expect(withNickname.status).toBe(200);
-    expect(await withNickname.json()).toStrictEqual({
-      id: "u2",
-      nickname: "yuta",
-    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: "u1", nick: null });
   });
 
-  it("flows nullable() into the inferred output type as `T | null`", async () => {
-    const Schema = object({
-      avatarUrl: nullable(string()),
+  it("types nullable() as T | null in c.req.valid('json')", async () => {
+    const Schema = object({ url: nullable(string()) });
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const url: string | null = c.req.valid("json").url;
+      return c.json({ url });
     });
-
-    const app = new Hono().post("/nullable", sValidator("json", Schema), (c) =>
-      c.json(c.req.valid("json")),
-    );
-
-    const nullCase = await app.request("/nullable", {
+    const res = await app.request("/u", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ avatarUrl: null }),
+      body: JSON.stringify({ url: null }),
     });
-    expect(nullCase.status).toBe(200);
-    expect(await nullCase.json()).toStrictEqual({ avatarUrl: null });
-
-    const stringCase = await app.request("/nullable", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ avatarUrl: "https://example.com/a.png" }),
-    });
-    expect(stringCase.status).toBe(200);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ url: null });
   });
 
-  it("supports arrayOf, union, and intersection at top level", async () => {
-    const ListSchema = arrayOf(object({ id: number(), label: string() }));
-    const UnionSchema = union(string(), number());
-    const IntersectionSchema = intersection(
-      object({ id: string() }),
-      object({ label: string() }),
-    );
-
-    const app = new Hono()
-      .post("/list", sValidator("json", ListSchema), (c) =>
-        c.json({ count: c.req.valid("json").length }),
-      )
-      .post("/either", sValidator("json", UnionSchema), (c) =>
-        c.json({ value: c.req.valid("json") }),
-      )
-      .post("/both", sValidator("json", IntersectionSchema), (c) => {
-        const input = c.req.valid("json");
-        const id: string = input.id;
-        const label: string = input.label;
-        return c.json({ id, label });
-      });
-
-    const list = await app.request("/list", {
+  it("types arrayOf(object()) elements in c.req.valid('json')", async () => {
+    const Schema = arrayOf(object({ id: number(), label: string() }));
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const list = c.req.valid("json");
+      const firstId: number = list[0].id;
+      const firstLabel: string = list[0].label;
+      return c.json({ firstId, firstLabel });
+    });
+    const res = await app.request("/u", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify([{ id: 1, label: "a" }]),
     });
-    expect(list.status).toBe(200);
-    expect(await list.json()).toStrictEqual({ count: 1 });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ firstId: 1, firstLabel: "a" });
+  });
 
-    const either = await app.request("/either", {
+  it("types union() of primitives in c.req.valid('json')", async () => {
+    const Schema = union(string(), number());
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const value: string | number = c.req.valid("json");
+      return c.json({ value });
+    });
+    const res = await app.request("/u", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify("hello"),
     });
-    expect(either.status).toBe(200);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ value: "hello" });
+  });
 
-    const both = await app.request("/both", {
+  it("types intersection() of objects in c.req.valid('json')", async () => {
+    const Schema = intersection(
+      object({ id: string() }),
+      object({ label: string() }),
+    );
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string = input.id;
+      const label: string = input.label;
+      return c.json({ id, label });
+    });
+    const res = await app.request("/u", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ id: "i1", label: "l1" }),
     });
-    expect(both.status).toBe(200);
-    expect(await both.json()).toStrictEqual({ id: "i1", label: "l1" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: "i1", label: "l1" });
   });
 });


### PR DESCRIPTION
# Release v3.2.1

Patch release that restores end-to-end type inference for `object()` when consumed through Standard Schema V1 adapters such as `@hono/standard-validator`.

## 🛠️ Bug Fixes

* **`Validate/object`**: `object()` no longer advertises `StandardSchemaV1<unknown, unknown>` in its declared return signature. The factory now flows the inferred shape type into both the `Input` and `Output` parameters of `StandardSchemaV1`, so Standard Schema consumers (Hono's `sValidator`, Zod-/Valibot-style integrations, etc.) recover the concrete object type at the boundary. Previously, `c.req.valid("json")` collapsed to `unknown` and every field access produced `TS18046`.

## 🔄 Refactoring & Maintenance

* **`Validate/object`**: Extracted the inferred-shape derivation into the public `ObjectShapeProperties<T>` and `InferObject<T>` helper types. `ObjectValidator<T>` now references `InferObject<T>` instead of recomputing the optional-key split inline, eliminating duplication between the validator type, its return type, and the Standard Schema generics.

## 🧪 Testing

* Added `src/tests/integration/Validate/hono-standard-validator.test.ts` covering UMT validators consumed via `@hono/standard-validator`. The suite exercises `object`, `optional`, `nullable`, `arrayOf`, `union`, and `intersection` against a live `Hono` app, asserts that `c.req.valid("json")` is strongly typed (the type annotations on every field would fail to compile if the regression returned), and verifies the 400-on-invalid-input contract.
* Added `hono` and `@hono/standard-validator` to `devDependencies` (pinned exactly).

## ✅ Validation Scope

Audited every Standard Schema integration in the package — `any`, `array/arrayOf`, `bigint`, `boolean`, `date`, `file`, `function`, `instanceof`, `map`, `never`, `number`, `object/intersection`, `object/nullable`, `object/optional`, `object/union`, `set`, `string`, `templateLiteral`, `unknown`. All other factories were already flowing concrete inferred types into `StandardSchemaV1`; only `object/core` was affected. `unknown()` is intentionally left as `StandardSchemaV1<unknown, unknown>` because its semantic output is `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)