### PR TITLE
Release v3.2.2

### DIFF
--- a/package/main/package.json
+++ b/package/main/package.json
@@ -228,5 +228,5 @@
   },
   "type": "module",
   "types": "module/index.d.ts",
-  "version": "3.2.1"
+  "version": "3.2.2"
 }

--- a/package/main/src/Validate/object/core.ts
+++ b/package/main/src/Validate/object/core.ts
@@ -15,6 +15,8 @@ import type {
   ValidateType,
 } from "@/Validate/type";
 
+export type { StandardSchemaV1 } from "@/Validate/standardSchema";
+
 /**
  * Shape map describing per-property validators consumed by `object()`
  */

--- a/package/main/src/Validate/object/omit.ts
+++ b/package/main/src/Validate/object/omit.ts
@@ -9,7 +9,13 @@
  * already exposes an `omit` runtime helper.
  */
 
-import { object, type ObjectShape, type ObjectValidator } from "./core";
+import {
+  type InferObject,
+  object,
+  type ObjectShape,
+  type ObjectValidator,
+  type StandardSchemaV1,
+} from "./core";
 
 /**
  * Removes the given keys from an existing object validator and returns a new
@@ -25,7 +31,11 @@ export const omit_ = <T extends ObjectShape, K extends readonly (keyof T)[]>(
   validator: ObjectValidator<T>,
   keys: K,
   message?: string,
-): ObjectValidator<Omit<T, K[number]>> => {
+): ObjectValidator<Omit<T, K[number]>> &
+  StandardSchemaV1<
+    InferObject<Omit<T, K[number]>>,
+    InferObject<Omit<T, K[number]>>
+  > => {
   const sourceShape = validator.shape;
   const omittedKeys = new Set<keyof T>(keys);
   const nextShape = {} as ObjectShape;
@@ -36,5 +46,9 @@ export const omit_ = <T extends ObjectShape, K extends readonly (keyof T)[]>(
   }
   return object(nextShape, message) as unknown as ObjectValidator<
     Omit<T, K[number]>
-  >;
+  > &
+    StandardSchemaV1<
+      InferObject<Omit<T, K[number]>>,
+      InferObject<Omit<T, K[number]>>
+    >;
 };

--- a/package/main/src/Validate/object/partial.ts
+++ b/package/main/src/Validate/object/partial.ts
@@ -5,7 +5,13 @@
  * optional.
  */
 
-import { object, type ObjectShape, type ObjectValidator } from "./core";
+import {
+  type InferObject,
+  object,
+  type ObjectShape,
+  type ObjectValidator,
+  type StandardSchemaV1,
+} from "./core";
 import { optional, type OptionalValidator } from "./optional";
 
 export type PartialShape<T extends ObjectShape> = {
@@ -32,7 +38,11 @@ export type PartialShape<T extends ObjectShape> = {
 export const partial = <T extends ObjectShape>(
   validator: ObjectValidator<T>,
   message?: string,
-): ObjectValidator<PartialShape<T>> => {
+): ObjectValidator<PartialShape<T>> &
+  StandardSchemaV1<
+    InferObject<PartialShape<T>>,
+    InferObject<PartialShape<T>>
+  > => {
   const sourceShape = validator.shape;
   const nextShape = {} as ObjectShape;
   for (const key of Object.keys(sourceShape)) {
@@ -44,5 +54,9 @@ export const partial = <T extends ObjectShape>(
   }
   return object(nextShape, message) as unknown as ObjectValidator<
     PartialShape<T>
-  >;
+  > &
+    StandardSchemaV1<
+      InferObject<PartialShape<T>>,
+      InferObject<PartialShape<T>>
+    >;
 };

--- a/package/main/src/Validate/object/pick.ts
+++ b/package/main/src/Validate/object/pick.ts
@@ -8,7 +8,13 @@
  * already exposes a `pick` runtime helper.
  */
 
-import { object, type ObjectShape, type ObjectValidator } from "./core";
+import {
+  type InferObject,
+  object,
+  type ObjectShape,
+  type ObjectValidator,
+  type StandardSchemaV1,
+} from "./core";
 
 /**
  * Picks the given keys from an existing object validator and returns a new
@@ -24,7 +30,11 @@ export const pick_ = <T extends ObjectShape, K extends readonly (keyof T)[]>(
   validator: ObjectValidator<T>,
   keys: K,
   message?: string,
-): ObjectValidator<Pick<T, K[number]>> => {
+): ObjectValidator<Pick<T, K[number]>> &
+  StandardSchemaV1<
+    InferObject<Pick<T, K[number]>>,
+    InferObject<Pick<T, K[number]>>
+  > => {
   const sourceShape = validator.shape;
   const nextShape = {} as Pick<T, K[number]>;
   for (const key of keys) {

--- a/package/main/src/Validate/object/required.ts
+++ b/package/main/src/Validate/object/required.ts
@@ -5,7 +5,13 @@
  * see all properties as required again.
  */
 
-import { object, type ObjectShape, type ObjectValidator } from "./core";
+import {
+  type InferObject,
+  object,
+  type ObjectShape,
+  type ObjectValidator,
+  type StandardSchemaV1,
+} from "./core";
 import type { OptionalValidator } from "./optional";
 
 export type UnwrapOptional<V> =
@@ -28,7 +34,11 @@ export type RequiredShape<T extends ObjectShape> = {
 export const required = <T extends ObjectShape>(
   validator: ObjectValidator<T>,
   message?: string,
-): ObjectValidator<RequiredShape<T>> => {
+): ObjectValidator<RequiredShape<T>> &
+  StandardSchemaV1<
+    InferObject<RequiredShape<T>>,
+    InferObject<RequiredShape<T>>
+  > => {
   const sourceShape = validator.shape;
   const nextShape = {} as ObjectShape;
   for (const key of Object.keys(sourceShape)) {
@@ -45,5 +55,9 @@ export const required = <T extends ObjectShape>(
   }
   return object(nextShape, message) as unknown as ObjectValidator<
     RequiredShape<T>
-  >;
+  > &
+    StandardSchemaV1<
+      InferObject<RequiredShape<T>>,
+      InferObject<RequiredShape<T>>
+    >;
 };

--- a/package/main/src/tests/integration/Validate/hono-standard-validator.test.ts
+++ b/package/main/src/tests/integration/Validate/hono-standard-validator.test.ts
@@ -6,7 +6,11 @@ import { number } from "@/Validate/number";
 import { object } from "@/Validate/object/core";
 import { intersection } from "@/Validate/object/intersection";
 import { nullable } from "@/Validate/object/nullable";
+import { omit_ } from "@/Validate/object/omit";
 import { optional } from "@/Validate/object/optional";
+import { partial } from "@/Validate/object/partial";
+import { pick_ } from "@/Validate/object/pick";
+import { required } from "@/Validate/object/required";
 import { union } from "@/Validate/object/union";
 import { string } from "@/Validate/string";
 
@@ -128,5 +132,94 @@ describe("Integration: UMT validators with @hono/standard-validator", () => {
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toStrictEqual({ id: "i1", label: "l1" });
+  });
+
+  it("types c.req.valid('json') from an omit_() derived schema", async () => {
+    const Base = object({ id: string(), name: string(), age: number() });
+    const Schema = omit_(Base, ["age"]);
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string = input.id;
+      const name: string = input.name;
+      return c.json({ id, name });
+    });
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x", name: "n" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: "x", name: "n" });
+  });
+
+  it("types c.req.valid('json') from a pick_() derived schema", async () => {
+    const Base = object({ id: string(), name: string(), age: number() });
+    const Schema = pick_(Base, ["id"]);
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string = input.id;
+      return c.json({ id });
+    });
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: "x" });
+  });
+
+  it("types c.req.valid('json') from a partial() derived schema", async () => {
+    const Base = object({ id: string(), name: string() });
+    const Schema = partial(Base);
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string | undefined = input.id;
+      const name: string | undefined = input.name;
+      return c.json({ id: id ?? null, name: name ?? null });
+    });
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: null, name: null });
+  });
+
+  it("types c.req.valid('json') from a required() derived schema", async () => {
+    const Base = object({ id: string(), nick: optional(string()) });
+    const Schema = required(Base);
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string = input.id;
+      const nick: string = input.nick;
+      return c.json({ id, nick });
+    });
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x", nick: "n" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: "x", nick: "n" });
+  });
+
+  it("types c.req.valid('json') from a partial(omit_()) chained derivation", async () => {
+    const Base = object({ id: string(), name: string(), age: number() });
+    const Schema = partial(omit_(Base, ["age"]));
+    const app = new Hono().post("/u", sValidator("json", Schema), (c) => {
+      const input = c.req.valid("json");
+      const id: string | undefined = input.id;
+      const name: string | undefined = input.name;
+      return c.json({ id: id ?? null, name: name ?? null });
+    });
+    const res = await app.request("/u", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toStrictEqual({ id: "x", name: null });
   });
 });


### PR DESCRIPTION
# Release v3.2.2

Patch release that extends the Standard Schema V1 fix from 3.2.1 to derived object validators (`omit_`, `partial`, `pick_`, `required`). In 3.2.1 the factory `object()` already advertised `& StandardSchemaV1<InferObject<T>, InferObject<T>>`, but the derivative helpers narrowed the return type back to bare `ObjectValidator<NewShape>` via explicit return annotations and `as unknown as` casts, dropping the intersection at the type level. `@hono/standard-validator`'s `sValidator` therefore reduced `c.req.valid("json")` to `unknown` for any schema built via a derivative helper, even when the runtime `~standard` payload was still attached.

## 🛠️ Bug Fixes

* **`Validate/object/omit`**: `omit_()` now returns `ObjectValidator<Omit<T, K[number]>> & StandardSchemaV1<InferObject<Omit<T, K[number]>>, InferObject<Omit<T, K[number]>>>`. Both the function's declared return type and the internal cast were widened so the intersection survives.
* **`Validate/object/partial`**: `partial()` now returns the corresponding `& StandardSchemaV1<InferObject<PartialShape<T>>, InferObject<PartialShape<T>>>` intersection.
* **`Validate/object/pick`**: `pick_()` now returns the corresponding `& StandardSchemaV1<InferObject<Pick<T, K[number]>>, InferObject<Pick<T, K[number]>>>` intersection.
* **`Validate/object/required`**: `required()` now returns the corresponding `& StandardSchemaV1<InferObject<RequiredShape<T>>, InferObject<RequiredShape<T>>>` intersection.

## 🔄 Refactoring & Maintenance

* **`Validate/object/core`**: Added a `export type { StandardSchemaV1 } from "@/Validate/standardSchema"` re-export so derivative files can pull `StandardSchemaV1`, `InferObject`, `ObjectValidator`, and `ObjectShape` from a single `./core` specifier instead of mixing path-alias and relative imports.

## 🧪 Testing

* Extended `src/tests/integration/Validate/hono-standard-validator.test.ts` with five additional `it` blocks covering the derivative path through `@hono/standard-validator`: `omit_()`, `pick_()`, `partial()`, `required()`, and a `partial(omit_())` chained derivation. Each case asserts that `c.req.valid("json")` carries the expected property-level types (the typed annotations would fail to compile if the regression returned) and that the live `Hono` request round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)