### PR TITLE
Add Map module with group_by_to_map and zip_to_map functions

### DIFF
--- a/.jules/sync.md
+++ b/.jules/sync.md
@@ -21,3 +21,7 @@
 ## 2026-04-16 - Intl.NumberFormat Port to Python
 **Mismatch:** `formatNumber` in `package/main` delegates to `Intl.NumberFormat`, which has full ICU locale data and supports hundreds of locales, currencies, and rounding modes. Python's zero-dependency policy rules out Babel/ICU, and the stdlib `locale` module mutates global process state so it can't be used safely in a library.
 **Resolution:** Ported a curated implementation that covers the common cases documented in the TS JSDoc examples (decimal/percent/currency styles, minimum/maximum fraction digits, en-US/de-DE/ja-JP/fr-FR/etc. locales) and falls back to en-US for unknown locales. Emulated JS `Math.round` half-away-from-zero semantics explicitly because Python's built-in `round` uses banker's rounding and would diverge on half values.
+
+## 2026-05-28 - Map Module Port to Python
+**Mismatch:** TS `Map/zipToMap` and `Map/groupByToMap` rely on JS `Map`, which preserves insertion order and accepts any object as a key (including mutable objects via reference equality). Python's stdlib `dict` only accepts hashable keys, but it does preserve insertion order since 3.7.
+**Resolution:** Ported both functions to a new `umt_python/src/map` module returning plain `dict[K, V]` instances and constrained the key TypeVar with `bound=Hashable` to keep parity with Python semantics. Tests substituted tuple keys for the TS object-key cases because unhashable types like `dict` cannot be used as Python dict keys, while still validating the "non-string key" branch.

--- a/package/umt_python/src/__init__.py
+++ b/package/umt_python/src/__init__.py
@@ -118,6 +118,10 @@ from .iterator import (
     lazy_map,
     lazy_take,
 )
+from .map import (
+    group_by_to_map,
+    zip_to_map,
+)
 from .math import (
     PrimeFactor,
     ProbabilityFraction,
@@ -375,6 +379,7 @@ __all__ = [
     "get_network_address",
     "get_timezone_offset_string",
     "group_by",
+    "group_by_to_map",
     "has_no_letters",
     "hexa_to_rgba",
     "hsla_to_rgba",
@@ -499,4 +504,5 @@ __all__ = [
     "xoshiro256",
     "zip_arrays",
     "zip_longest",
+    "zip_to_map",
 ]

--- a/package/umt_python/src/map/__init__.py
+++ b/package/umt_python/src/map/__init__.py
@@ -1,0 +1,7 @@
+from .group_by_to_map import group_by_to_map
+from .zip_to_map import zip_to_map
+
+__all__ = [
+    "group_by_to_map",
+    "zip_to_map",
+]

--- a/package/umt_python/src/map/group_by_to_map.py
+++ b/package/umt_python/src/map/group_by_to_map.py
@@ -1,0 +1,40 @@
+from collections.abc import Callable, Hashable
+from typing import TypeVar
+
+T = TypeVar("T")
+K = TypeVar("K", bound=Hashable)
+
+
+def group_by_to_map(
+    array: list[T],
+    iteratee: Callable[[T, int, list[T]], K],
+) -> dict[K, list[T]]:
+    """
+    Groups elements of a list into a dict based on a given iteratee function.
+
+    Unlike group_by which returns a dict[str | int, list[T]], this preserves
+    insertion order and allows any hashable key type. Python's dict preserves
+    insertion order (3.7+), mirroring the TS Map semantics.
+
+    Args:
+        array: List to group.
+        iteratee: Function to determine the group key for each element.
+
+    Returns:
+        Dict with grouped elements keyed by the iteratee result.
+
+    Example:
+        >>> group_by_to_map([6.1, 4.2, 6.3], lambda x, i, arr: int(x))
+        {6: [6.1, 6.3], 4: [4.2]}
+        >>> group_by_to_map(["one", "two", "three"], lambda x, i, arr: len(x))
+        {3: ['one', 'two'], 5: ['three']}
+    """
+    result: dict[K, list[T]] = {}
+    for index, value in enumerate(array):
+        key = iteratee(value, index, array)
+        bucket = result.get(key)
+        if bucket is None:
+            result[key] = [value]
+        else:
+            bucket.append(value)
+    return result

--- a/package/umt_python/src/map/zip_to_map.py
+++ b/package/umt_python/src/map/zip_to_map.py
@@ -1,0 +1,33 @@
+from collections.abc import Hashable
+from typing import TypeVar
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+
+def zip_to_map(keys: list[K], values: list[V]) -> dict[K, V]:
+    """
+    Creates a dict from two arrays, using the first as keys and the second as values.
+
+    Pairs are formed at corresponding positions; iteration stops at the shorter
+    length, matching the behavior of zip. Duplicate keys keep the latest value.
+    Python's dict preserves insertion order (3.7+), mirroring the TS Map semantics.
+
+    Args:
+        keys: List of keys.
+        values: List of values.
+
+    Returns:
+        Dict pairing keys with values at the same index.
+
+    Example:
+        >>> zip_to_map(["a", "b"], [1, 2])
+        {'a': 1, 'b': 2}
+        >>> zip_to_map(["a", "b", "c"], [1, 2])
+        {'a': 1, 'b': 2}
+    """
+    length = min(len(keys), len(values))
+    result: dict[K, V] = {}
+    for index in range(length):
+        result[keys[index]] = values[index]
+    return result

--- a/package/umt_python/tests/unit/map/test_group_by_to_map.py
+++ b/package/umt_python/tests/unit/map/test_group_by_to_map.py
@@ -1,0 +1,62 @@
+import unittest
+
+from src.map import group_by_to_map
+
+
+class TestGroupByToMap(unittest.TestCase):
+    def test_groups_numbers_into_odd_and_even(self):
+        array = [1, 2, 3, 4, 5]
+        result = group_by_to_map(
+            array, lambda num, _i, _arr: "even" if num % 2 == 0 else "odd"
+        )
+        self.assertEqual(result, {"odd": [1, 3, 5], "even": [2, 4]})
+
+    def test_preserves_insertion_order_of_keys(self):
+        array = [3, 1, 2, 1, 3, 2]
+        result = group_by_to_map(array, lambda num, _i, _arr: num)
+        self.assertEqual(list(result.keys()), [3, 1, 2])
+
+    def test_accepts_tuple_keys(self):
+        a = (1, "a")
+        b = (1, "b")
+        array = [
+            {"tag": a, "value": 1},
+            {"tag": b, "value": 2},
+            {"tag": a, "value": 3},
+        ]
+        result = group_by_to_map(array, lambda item, _i, _arr: item["tag"])
+        self.assertEqual(
+            result[a],
+            [{"tag": a, "value": 1}, {"tag": a, "value": 3}],
+        )
+        self.assertEqual(result[b], [{"tag": b, "value": 2}])
+
+    def test_groups_strings_by_length(self):
+        array = ["one", "two", "three", "four", "five"]
+        result = group_by_to_map(array, lambda s, _i, _arr: len(s))
+        self.assertEqual(result[3], ["one", "two"])
+        self.assertEqual(result[5], ["three"])
+        self.assertEqual(result[4], ["four", "five"])
+
+    def test_passes_index_and_array_to_iteratee(self):
+        array = ["a", "b", "c", "d"]
+        received_indices: list[int] = []
+
+        def iteratee(_value: str, index: int, source: list[str]) -> int:
+            self.assertIs(source, array)
+            received_indices.append(index)
+            return index % 2
+
+        group_by_to_map(array, iteratee)
+        self.assertEqual(received_indices, [0, 1, 2, 3])
+
+    def test_returns_empty_dict_for_empty_array(self):
+        empty: list[int] = []
+        result = group_by_to_map(
+            empty, lambda num, _i, _arr: "even" if num % 2 == 0 else "odd"
+        )
+        self.assertEqual(result, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package/umt_python/tests/unit/map/test_zip_to_map.py
+++ b/package/umt_python/tests/unit/map/test_zip_to_map.py
@@ -1,0 +1,42 @@
+import unittest
+
+from src.map import zip_to_map
+
+
+class TestZipToMap(unittest.TestCase):
+    def test_pairs_keys_and_values_at_same_index(self):
+        result = zip_to_map(["a", "b", "c"], [1, 2, 3])
+        self.assertEqual(result, {"a": 1, "b": 2, "c": 3})
+
+    def test_stops_at_shorter_length_when_keys_is_longer(self):
+        result = zip_to_map(["a", "b", "c"], [1, 2])
+        self.assertEqual(result, {"a": 1, "b": 2})
+
+    def test_stops_at_shorter_length_when_values_is_longer(self):
+        result = zip_to_map(["a", "b"], [1, 2, 3])
+        self.assertEqual(result, {"a": 1, "b": 2})
+
+    def test_keeps_latest_value_for_duplicate_keys(self):
+        result = zip_to_map(["a", "b", "a"], [1, 2, 3])
+        self.assertEqual(result["a"], 3)
+        self.assertEqual(result["b"], 2)
+        self.assertEqual(len(result), 2)
+
+    def test_accepts_tuple_keys(self):
+        k1 = (1, "x")
+        k2 = (2, "y")
+        result = zip_to_map([k1, k2], ["x", "y"])
+        self.assertEqual(result[k1], "x")
+        self.assertEqual(result[k2], "y")
+
+    def test_returns_empty_dict_when_either_input_is_empty(self):
+        self.assertEqual(zip_to_map([], [1, 2]), {})
+        self.assertEqual(zip_to_map(["a"], []), {})
+
+    def test_preserves_insertion_order_of_keys(self):
+        result = zip_to_map(["c", "a", "b"], [1, 2, 3])
+        self.assertEqual(list(result.keys()), ["c", "a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Port the TypeScript `Map` module utilities to Python, adding `group_by_to_map` and `zip_to_map` functions that leverage Python's dict insertion order preservation (3.7+) to mirror TypeScript `Map` semantics.

## Key Changes
- **New `group_by_to_map` function**: Groups array elements into a dict based on an iteratee function that determines the grouping key. Supports any hashable key type (not just strings/ints) and preserves insertion order of first occurrence.
- **New `zip_to_map` function**: Creates a dict by pairing elements from two arrays at corresponding indices. Stops at the shorter length and keeps the latest value for duplicate keys.
- **New `map` module**: Created `src/map/` package with dedicated implementations and comprehensive unit tests for both functions.
- **Updated exports**: Added both functions to the main `src/__init__.py` exports and `__all__` list.
- **Documentation**: Added sync notes explaining the design decision to use Python's dict (which preserves insertion order since 3.7) instead of relying on external dependencies.

## Implementation Details
- Both functions use Python's built-in `dict` which preserves insertion order, providing equivalent semantics to TypeScript's `Map` object.
- `group_by_to_map` accepts a callback iteratee that receives the value, index, and source array (matching the TS API).
- Type hints use `TypeVar` with `Hashable` bound for keys to ensure type safety while supporting any hashable type (tuples, frozensets, etc.).
- Comprehensive test coverage includes edge cases: empty arrays, duplicate keys, tuple keys, and parameter passing verification.

https://claude.ai/code/session_01RoLcbPkZEMArAHUSNooJnh