### PR TITLE
test(benchmark): rewrite micro-benchmarks to run for a stable duration

### DIFF
--- a/package/main/src/tests/benchmark/calculator-currency.benchmark.ts
+++ b/package/main/src/tests/benchmark/calculator-currency.benchmark.ts
@@ -1,4 +1,4 @@
-import { bench, run, summary } from "mitata";
+import { bench, run, summary, do_not_optimize } from "mitata";
 import { calculatorCore } from "@/Math/calculator/core";
 
 // Use many currency symbols
@@ -45,9 +45,16 @@ for (let i = 1; i <= 5; i++) {
 }
 const expression = parts.join(" + ");
 
+// A single evaluation takes around twenty microseconds, so repeating it this
+// many times makes one measured sample take roughly ~500ms, keeping fixed
+// measurement overhead negligible.
+const ITERATIONS = 27_000;
+
 summary(() => {
   bench("calculatorCore multi-currency", () => {
-    calculatorCore(expression, rates);
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(calculatorCore(expression, rates));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/function.debounce.benchmark.ts
+++ b/package/main/src/tests/benchmark/function.debounce.benchmark.ts
@@ -7,41 +7,62 @@ const noop = () => {
   /* intentionally empty */
 };
 
+// Creation costs nanoseconds while a 100-call invocation burst costs a few
+// microseconds, so each group uses its own repetition count to bring one
+// measured sample to roughly ~500ms. This keeps fixed measurement overhead
+// negligible, and the count is shared across variants within a group.
+const CREATION_ITERATIONS = 8_000_000;
+const INVOCATION_ITERATIONS = 17_500;
+
 summary(() => {
   bench("customDebounce creation", () => {
-    do_not_optimize(customDebounce(noop, 100));
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      do_not_optimize(customDebounce(noop, 100));
+    }
   });
 
   bench("lodashDebounce creation", () => {
-    do_not_optimize(lodashDebounce(noop, 100));
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      do_not_optimize(lodashDebounce(noop, 100));
+    }
   });
 
   bench("esToolkitDebounce creation", () => {
-    do_not_optimize(esToolkitDebounce(noop, 100));
-  });
-
-  bench("customDebounce invocation", () => {
-    const debounced = customDebounce(noop, 100);
-    for (let i = 0; i < 100; i++) {
-      debounced();
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      do_not_optimize(esToolkitDebounce(noop, 100));
     }
-    debounced.cancel();
+  });
+});
+
+summary(() => {
+  bench("customDebounce invocation", () => {
+    for (let i = 0; i < INVOCATION_ITERATIONS; i++) {
+      const debounced = customDebounce(noop, 100);
+      for (let j = 0; j < 100; j++) {
+        debounced();
+      }
+      debounced.cancel();
+    }
   });
 
   bench("lodashDebounce invocation", () => {
-    const debounced = lodashDebounce(noop, 100);
-    for (let i = 0; i < 100; i++) {
-      debounced();
+    for (let i = 0; i < INVOCATION_ITERATIONS; i++) {
+      const debounced = lodashDebounce(noop, 100);
+      for (let j = 0; j < 100; j++) {
+        debounced();
+      }
+      debounced.cancel();
     }
-    debounced.cancel();
   });
 
   bench("esToolkitDebounce invocation", () => {
-    const debounced = esToolkitDebounce(noop, 100);
-    for (let i = 0; i < 100; i++) {
-      debounced();
+    for (let i = 0; i < INVOCATION_ITERATIONS; i++) {
+      const debounced = esToolkitDebounce(noop, 100);
+      for (let j = 0; j < 100; j++) {
+        debounced();
+      }
+      debounced.cancel();
     }
-    debounced.cancel();
   });
 });
 

--- a/package/main/src/tests/benchmark/function.memoize.benchmark.ts
+++ b/package/main/src/tests/benchmark/function.memoize.benchmark.ts
@@ -11,49 +11,70 @@ const expensive = (n: number) => {
   return result;
 };
 
+// The cache-hit and cache-miss paths differ by an order of magnitude in cost,
+// so each group repeats its work enough to bring one measured sample to
+// roughly ~500ms. This keeps fixed measurement overhead negligible, and the
+// count is shared across variants within a group to keep the comparison fair.
+const CACHE_HIT_ITERATIONS = 56_000;
+const CACHE_MISS_ITERATIONS = 22_000;
+
 summary(() => {
   bench("customMemoize (cache hit)", () => {
-    const memoized = customMemoize(expensive);
-    memoized(42);
-    for (let i = 0; i < 1000; i++) {
-      do_not_optimize(memoized(42));
+    for (let r = 0; r < CACHE_HIT_ITERATIONS; r++) {
+      const memoized = customMemoize(expensive);
+      memoized(42);
+      for (let i = 0; i < 1000; i++) {
+        do_not_optimize(memoized(42));
+      }
     }
   });
 
   bench("lodashMemoize (cache hit)", () => {
-    const memoized = lodashMemoize(expensive);
-    memoized(42);
-    for (let i = 0; i < 1000; i++) {
-      do_not_optimize(memoized(42));
+    for (let r = 0; r < CACHE_HIT_ITERATIONS; r++) {
+      const memoized = lodashMemoize(expensive);
+      memoized(42);
+      for (let i = 0; i < 1000; i++) {
+        do_not_optimize(memoized(42));
+      }
     }
   });
 
   bench("esToolkitMemoize (cache hit)", () => {
-    const memoized = esToolkitMemoize(expensive);
-    memoized(42);
-    for (let i = 0; i < 1000; i++) {
-      do_not_optimize(memoized(42));
+    for (let r = 0; r < CACHE_HIT_ITERATIONS; r++) {
+      const memoized = esToolkitMemoize(expensive);
+      memoized(42);
+      for (let i = 0; i < 1000; i++) {
+        do_not_optimize(memoized(42));
+      }
     }
   });
+});
 
+summary(() => {
   bench("customMemoize (cache miss)", () => {
-    const memoized = customMemoize(expensive);
-    for (let i = 0; i < 100; i++) {
-      do_not_optimize(memoized(i));
+    for (let r = 0; r < CACHE_MISS_ITERATIONS; r++) {
+      const memoized = customMemoize(expensive);
+      for (let i = 0; i < 100; i++) {
+        do_not_optimize(memoized(i));
+      }
     }
   });
 
   bench("lodashMemoize (cache miss)", () => {
-    const memoized = lodashMemoize(expensive);
-    for (let i = 0; i < 100; i++) {
-      do_not_optimize(memoized(i));
+    for (let r = 0; r < CACHE_MISS_ITERATIONS; r++) {
+      const memoized = lodashMemoize(expensive);
+      for (let i = 0; i < 100; i++) {
+        do_not_optimize(memoized(i));
+      }
     }
   });
 
   bench("esToolkitMemoize (cache miss)", () => {
-    const memoized = esToolkitMemoize(expensive);
-    for (let i = 0; i < 100; i++) {
-      do_not_optimize(memoized(i));
+    for (let r = 0; r < CACHE_MISS_ITERATIONS; r++) {
+      const memoized = esToolkitMemoize(expensive);
+      for (let i = 0; i < 100; i++) {
+        do_not_optimize(memoized(i));
+      }
     }
   });
 });

--- a/package/main/src/tests/benchmark/function.once.benchmark.ts
+++ b/package/main/src/tests/benchmark/function.once.benchmark.ts
@@ -5,40 +5,63 @@ import { once as esToolkitOnce } from "es-toolkit";
 
 const factory = () => 42;
 
+// Creating and invoking a wrapper costs only nanoseconds, so the raw figure is
+// noise-dominated. Each group repeats its operation enough times for one
+// measured sample to take roughly ~500ms, keeping the timer resolution and
+// scheduling jitter negligible. Counts differ per group because the per-call
+// cost differs by two orders of magnitude, and are shared across variants
+// within a group so the comparison stays fair.
+const CREATION_ITERATIONS = 27_000_000;
+const REPEATED_ITERATIONS = 260_000;
+
 summary(() => {
   bench("customOnce creation + invocation", () => {
-    const fn = customOnce(factory);
-    do_not_optimize(fn());
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      const fn = customOnce(factory);
+      do_not_optimize(fn());
+    }
   });
 
   bench("lodashOnce creation + invocation", () => {
-    const fn = lodashOnce(factory);
-    do_not_optimize(fn());
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      const fn = lodashOnce(factory);
+      do_not_optimize(fn());
+    }
   });
 
   bench("esToolkitOnce creation + invocation", () => {
-    const fn = esToolkitOnce(factory);
-    do_not_optimize(fn());
-  });
-
-  bench("customOnce repeated invocation", () => {
-    const fn = customOnce(factory);
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      const fn = esToolkitOnce(factory);
       do_not_optimize(fn());
+    }
+  });
+});
+
+summary(() => {
+  bench("customOnce repeated invocation", () => {
+    for (let i = 0; i < REPEATED_ITERATIONS; i++) {
+      const fn = customOnce(factory);
+      for (let j = 0; j < 1000; j++) {
+        do_not_optimize(fn());
+      }
     }
   });
 
   bench("lodashOnce repeated invocation", () => {
-    const fn = lodashOnce(factory);
-    for (let i = 0; i < 1000; i++) {
-      do_not_optimize(fn());
+    for (let i = 0; i < REPEATED_ITERATIONS; i++) {
+      const fn = lodashOnce(factory);
+      for (let j = 0; j < 1000; j++) {
+        do_not_optimize(fn());
+      }
     }
   });
 
   bench("esToolkitOnce repeated invocation", () => {
-    const fn = esToolkitOnce(factory);
-    for (let i = 0; i < 1000; i++) {
-      do_not_optimize(fn());
+    for (let i = 0; i < REPEATED_ITERATIONS; i++) {
+      const fn = esToolkitOnce(factory);
+      for (let j = 0; j < 1000; j++) {
+        do_not_optimize(fn());
+      }
     }
   });
 });

--- a/package/main/src/tests/benchmark/function.throttle.benchmark.ts
+++ b/package/main/src/tests/benchmark/function.throttle.benchmark.ts
@@ -7,41 +7,62 @@ const noop = () => {
   /* intentionally empty */
 };
 
+// Creation costs nanoseconds while a 100-call invocation burst costs a few
+// microseconds, so each group uses its own repetition count to bring one
+// measured sample to roughly ~500ms. This keeps fixed measurement overhead
+// negligible, and the count is shared across variants within a group.
+const CREATION_ITERATIONS = 5_000_000;
+const INVOCATION_ITERATIONS = 14_500;
+
 summary(() => {
   bench("customThrottle creation", () => {
-    do_not_optimize(customThrottle(noop, 100));
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      do_not_optimize(customThrottle(noop, 100));
+    }
   });
 
   bench("lodashThrottle creation", () => {
-    do_not_optimize(lodashThrottle(noop, 100));
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      do_not_optimize(lodashThrottle(noop, 100));
+    }
   });
 
   bench("esToolkitThrottle creation", () => {
-    do_not_optimize(esToolkitThrottle(noop, 100));
-  });
-
-  bench("customThrottle invocation", () => {
-    const throttled = customThrottle(noop, 100);
-    for (let i = 0; i < 100; i++) {
-      throttled();
+    for (let i = 0; i < CREATION_ITERATIONS; i++) {
+      do_not_optimize(esToolkitThrottle(noop, 100));
     }
-    throttled.cancel();
+  });
+});
+
+summary(() => {
+  bench("customThrottle invocation", () => {
+    for (let i = 0; i < INVOCATION_ITERATIONS; i++) {
+      const throttled = customThrottle(noop, 100);
+      for (let j = 0; j < 100; j++) {
+        throttled();
+      }
+      throttled.cancel();
+    }
   });
 
   bench("lodashThrottle invocation", () => {
-    const throttled = lodashThrottle(noop, 100);
-    for (let i = 0; i < 100; i++) {
-      throttled();
+    for (let i = 0; i < INVOCATION_ITERATIONS; i++) {
+      const throttled = lodashThrottle(noop, 100);
+      for (let j = 0; j < 100; j++) {
+        throttled();
+      }
+      throttled.cancel();
     }
-    throttled.cancel();
   });
 
   bench("esToolkitThrottle invocation", () => {
-    const throttled = esToolkitThrottle(noop, 100);
-    for (let i = 0; i < 100; i++) {
-      throttled();
+    for (let i = 0; i < INVOCATION_ITERATIONS; i++) {
+      const throttled = esToolkitThrottle(noop, 100);
+      for (let j = 0; j < 100; j++) {
+        throttled();
+      }
+      throttled.cancel();
     }
-    throttled.cancel();
   });
 });
 

--- a/package/main/src/tests/benchmark/generateNumberArray.benchmark.ts
+++ b/package/main/src/tests/benchmark/generateNumberArray.benchmark.ts
@@ -1,31 +1,49 @@
 import { bench, run, summary, do_not_optimize } from "mitata";
 import { generateNumberArray } from "@/Array/generateNumberArray";
 
+// Generating these arrays ranges from hundreds of nanoseconds to tens of
+// microseconds, which is noise-dominated. A single repetition count is shared
+// across all sizes so their relative cost stays comparable; it is sized so the
+// most expensive case takes roughly ~500ms, keeping fixed overhead negligible.
+const ITERATIONS = 6700;
+
 summary(() => {
   // Linear generation
   bench("generateNumberArray (100 elements)", () => {
-    do_not_optimize(generateNumberArray(100));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(generateNumberArray(100));
+    }
   });
 
   bench("generateNumberArray (1000 elements)", () => {
-    do_not_optimize(generateNumberArray(1000));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(generateNumberArray(1000));
+    }
   });
 
   bench("generateNumberArray (10,000 elements)", () => {
-    do_not_optimize(generateNumberArray(10_000));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(generateNumberArray(10_000));
+    }
   });
 
   // Random generation
   bench("generateNumberArray random (100 elements)", () => {
-    do_not_optimize(generateNumberArray(100, 0, 100, true));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(generateNumberArray(100, 0, 100, true));
+    }
   });
 
   bench("generateNumberArray random (1000 elements)", () => {
-    do_not_optimize(generateNumberArray(1000, 0, 1000, true));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(generateNumberArray(1000, 0, 1000, true));
+    }
   });
 
   bench("generateNumberArray random (10,000 elements)", () => {
-    do_not_optimize(generateNumberArray(10_000, 0, 10_000, true));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(generateNumberArray(10_000, 0, 10_000, true));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/levenshteinBenchmark.ts
+++ b/package/main/src/tests/benchmark/levenshteinBenchmark.ts
@@ -9,16 +9,30 @@ group("Levenshtein Distance", () => {
   const midStr1 = "Hello World This Is A Test String";
   const midStr2 = "Hello World This Is A Best String";
 
+  // Each input size has a very different cost (short is hundreds of
+  // nanoseconds, long is a few milliseconds), so a per-case repetition count is
+  // used to bring every measured sample to roughly ~500ms, keeping timer
+  // resolution and scheduling jitter negligible.
+  const SHORT_ITERATIONS = 2_700_000;
+  const MEDIUM_ITERATIONS = 164_000;
+  const LONG_ITERATIONS = 180;
+
   bench("Short strings", () => {
-    levenshteinDistance(str1, str2);
+    for (let i = 0; i < SHORT_ITERATIONS; i++) {
+      levenshteinDistance(str1, str2);
+    }
   });
 
   bench("Medium strings", () => {
-    levenshteinDistance(midStr1, midStr2);
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      levenshteinDistance(midStr1, midStr2);
+    }
   });
 
   bench("Long strings (1000 chars)", () => {
-    levenshteinDistance(longStr1, longStr2);
+    for (let i = 0; i < LONG_ITERATIONS; i++) {
+      levenshteinDistance(longStr1, longStr2);
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/math.addition.benchmark.ts
+++ b/package/main/src/tests/benchmark/math.addition.benchmark.ts
@@ -5,21 +5,38 @@ const integers = Array.from({ length: 100 }, (_, i) => i);
 const floats = Array.from({ length: 100 }, (_, i) => i * 0.1);
 const mixed = [...integers, ...floats];
 
+// Each case has a very different cost (the two-float case is in the hundreds of
+// nanoseconds while the larger inputs are tens of microseconds), so a per-case
+// repetition count is used to bring every measured sample to roughly ~500ms.
+// This keeps fixed measurement overhead negligible for every input shape.
+const INTEGERS_ITERATIONS = 105_000;
+const FLOATS_ITERATIONS = 31_000;
+const MIXED_ITERATIONS = 21_000;
+const TWO_FLOATS_ITERATIONS = 1_300_000;
+
 summary(() => {
   bench("addition (100 integers)", () => {
-    do_not_optimize(addition(...integers));
+    for (let i = 0; i < INTEGERS_ITERATIONS; i++) {
+      do_not_optimize(addition(...integers));
+    }
   });
 
   bench("addition (100 floats)", () => {
-    do_not_optimize(addition(...floats));
+    for (let i = 0; i < FLOATS_ITERATIONS; i++) {
+      do_not_optimize(addition(...floats));
+    }
   });
 
   bench("addition (200 mixed)", () => {
-    do_not_optimize(addition(...mixed));
+    for (let i = 0; i < MIXED_ITERATIONS; i++) {
+      do_not_optimize(addition(...mixed));
+    }
   });
 
   bench("addition (2 floats: 0.1 + 0.2)", () => {
-    do_not_optimize(addition(0.1, 0.2));
+    for (let i = 0; i < TWO_FLOATS_ITERATIONS; i++) {
+      do_not_optimize(addition(0.1, 0.2));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/math.clamp.benchmark.ts
+++ b/package/main/src/tests/benchmark/math.clamp.benchmark.ts
@@ -5,22 +5,35 @@ import { clamp as esToolkitClamp } from "es-toolkit";
 
 const testValues = [-100, -10, 0, 5, 50, 100, 1000];
 
+// A single clamp call costs only a few nanoseconds, which is far below the
+// timer resolution and dominated by scheduling jitter. Repeating the operation
+// this many times makes one measured sample take roughly ~500ms so that fixed
+// measurement overhead becomes negligible. The same count is shared across all
+// variants to keep the relative comparison fair.
+const ITERATIONS = 34_000_000;
+
 summary(() => {
   bench("customClamp", () => {
-    for (const value of testValues) {
-      do_not_optimize(customClamp(value, 0, 10));
+    for (let i = 0; i < ITERATIONS; i++) {
+      for (const value of testValues) {
+        do_not_optimize(customClamp(value, 0, 10));
+      }
     }
   });
 
   bench("lodashClamp", () => {
-    for (const value of testValues) {
-      do_not_optimize(lodashClamp(value, 0, 10));
+    for (let i = 0; i < ITERATIONS; i++) {
+      for (const value of testValues) {
+        do_not_optimize(lodashClamp(value, 0, 10));
+      }
     }
   });
 
   bench("esToolkitClamp", () => {
-    for (const value of testValues) {
-      do_not_optimize(esToolkitClamp(value, 0, 10));
+    for (let i = 0; i < ITERATIONS; i++) {
+      for (const value of testValues) {
+        do_not_optimize(esToolkitClamp(value, 0, 10));
+      }
     }
   });
 });

--- a/package/main/src/tests/benchmark/math.inRange.benchmark.ts
+++ b/package/main/src/tests/benchmark/math.inRange.benchmark.ts
@@ -5,22 +5,34 @@ import { inRange as esToolkitInRange } from "es-toolkit";
 
 const testValues = [-10, 0, 3, 5, 10, 50];
 
+// A single inRange call runs in a handful of nanoseconds, which is buried in
+// timer resolution and CPU jitter. Repeating it this many times makes one
+// measured sample take roughly ~500ms so that fixed overhead is negligible.
+// The same count is shared across all variants to keep the comparison fair.
+const ITERATIONS = 40_000_000;
+
 summary(() => {
   bench("customInRange", () => {
-    for (const value of testValues) {
-      do_not_optimize(customInRange(value, 0, 10));
+    for (let i = 0; i < ITERATIONS; i++) {
+      for (const value of testValues) {
+        do_not_optimize(customInRange(value, 0, 10));
+      }
     }
   });
 
   bench("lodashInRange", () => {
-    for (const value of testValues) {
-      do_not_optimize(lodashInRange(value, 0, 10));
+    for (let i = 0; i < ITERATIONS; i++) {
+      for (const value of testValues) {
+        do_not_optimize(lodashInRange(value, 0, 10));
+      }
     }
   });
 
   bench("esToolkitInRange", () => {
-    for (const value of testValues) {
-      do_not_optimize(esToolkitInRange(value, 0, 10));
+    for (let i = 0; i < ITERATIONS; i++) {
+      for (const value of testValues) {
+        do_not_optimize(esToolkitInRange(value, 0, 10));
+      }
     }
   });
 });

--- a/package/main/src/tests/benchmark/object.deepClone.benchmark.ts
+++ b/package/main/src/tests/benchmark/object.deepClone.benchmark.ts
@@ -12,29 +12,50 @@ const deepObj = {
   h: new Date(),
 };
 
+// Cloning these small objects costs from under a microsecond (shallow) to a few
+// microseconds (deep), which is noise-dominated. Each group repeats the clone
+// enough times to bring one measured sample to roughly ~500ms so that fixed
+// overhead is negligible. The count is shared across variants within a group.
+const SHALLOW_ITERATIONS = 1_100_000;
+const DEEP_ITERATIONS = 120_000;
+
 summary(() => {
   bench("customDeepClone (shallow)", () => {
-    do_not_optimize(customDeepClone(shallowObj));
+    for (let i = 0; i < SHALLOW_ITERATIONS; i++) {
+      do_not_optimize(customDeepClone(shallowObj));
+    }
   });
 
   bench("lodashCloneDeep (shallow)", () => {
-    do_not_optimize(lodashCloneDeep(shallowObj));
+    for (let i = 0; i < SHALLOW_ITERATIONS; i++) {
+      do_not_optimize(lodashCloneDeep(shallowObj));
+    }
   });
 
   bench("esToolkitCloneDeep (shallow)", () => {
-    do_not_optimize(esToolkitCloneDeep(shallowObj));
+    for (let i = 0; i < SHALLOW_ITERATIONS; i++) {
+      do_not_optimize(esToolkitCloneDeep(shallowObj));
+    }
   });
+});
 
+summary(() => {
   bench("customDeepClone (deep)", () => {
-    do_not_optimize(customDeepClone(deepObj));
+    for (let i = 0; i < DEEP_ITERATIONS; i++) {
+      do_not_optimize(customDeepClone(deepObj));
+    }
   });
 
   bench("lodashCloneDeep (deep)", () => {
-    do_not_optimize(lodashCloneDeep(deepObj));
+    for (let i = 0; i < DEEP_ITERATIONS; i++) {
+      do_not_optimize(lodashCloneDeep(deepObj));
+    }
   });
 
   bench("esToolkitCloneDeep (deep)", () => {
-    do_not_optimize(esToolkitCloneDeep(deepObj));
+    for (let i = 0; i < DEEP_ITERATIONS; i++) {
+      do_not_optimize(esToolkitCloneDeep(deepObj));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/object.mapKeys.benchmark.ts
+++ b/package/main/src/tests/benchmark/object.mapKeys.benchmark.ts
@@ -20,41 +20,71 @@ for (let i = 0; i < 1000; i++) {
 
 const transform = (_v: unknown, k: string) => k.toUpperCase();
 
+// Each key-count tier is benchmarked in its own group so the three libraries
+// are compared on the same input. The repetition count per tier is chosen so
+// that one measured sample takes roughly ~500ms, keeping timer resolution and
+// scheduling jitter negligible. The count is shared across variants in a tier.
+const SMALL_ITERATIONS = 430_000;
+const MEDIUM_ITERATIONS = 28_000;
+const LARGE_ITERATIONS = 2250;
+
 summary(() => {
   bench("customMapKeys (10 keys)", () => {
-    do_not_optimize(customMapKeys(smallObj, transform));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(customMapKeys(smallObj, transform));
+    }
   });
 
   bench("lodashMapKeys (10 keys)", () => {
-    do_not_optimize(lodashMapKeys(smallObj, transform));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(lodashMapKeys(smallObj, transform));
+    }
   });
 
   bench("esToolkitMapKeys (10 keys)", () => {
-    do_not_optimize(esToolkitMapKeys(smallObj, transform));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(esToolkitMapKeys(smallObj, transform));
+    }
   });
+});
 
+summary(() => {
   bench("customMapKeys (100 keys)", () => {
-    do_not_optimize(customMapKeys(mediumObj, transform));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(customMapKeys(mediumObj, transform));
+    }
   });
 
   bench("lodashMapKeys (100 keys)", () => {
-    do_not_optimize(lodashMapKeys(mediumObj, transform));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(lodashMapKeys(mediumObj, transform));
+    }
   });
 
   bench("esToolkitMapKeys (100 keys)", () => {
-    do_not_optimize(esToolkitMapKeys(mediumObj, transform));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(esToolkitMapKeys(mediumObj, transform));
+    }
   });
+});
 
+summary(() => {
   bench("customMapKeys (1000 keys)", () => {
-    do_not_optimize(customMapKeys(largeObj, transform));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(customMapKeys(largeObj, transform));
+    }
   });
 
   bench("lodashMapKeys (1000 keys)", () => {
-    do_not_optimize(lodashMapKeys(largeObj, transform));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(lodashMapKeys(largeObj, transform));
+    }
   });
 
   bench("esToolkitMapKeys (1000 keys)", () => {
-    do_not_optimize(esToolkitMapKeys(largeObj, transform));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(esToolkitMapKeys(largeObj, transform));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/object.mapValues.benchmark.ts
+++ b/package/main/src/tests/benchmark/object.mapValues.benchmark.ts
@@ -20,41 +20,71 @@ for (let i = 0; i < 1000; i++) {
 
 const transform = (v: unknown) => (v as number) * 2;
 
+// Each key-count tier is benchmarked in its own group so the three libraries
+// are compared on the same input. The repetition count per tier is chosen so
+// that one measured sample takes roughly ~500ms, keeping timer resolution and
+// scheduling jitter negligible. The count is shared across variants in a tier.
+const SMALL_ITERATIONS = 2_500_000;
+const MEDIUM_ITERATIONS = 61_000;
+const LARGE_ITERATIONS = 3800;
+
 summary(() => {
   bench("customMapValues (10 keys)", () => {
-    do_not_optimize(customMapValues(smallObj, transform));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(customMapValues(smallObj, transform));
+    }
   });
 
   bench("lodashMapValues (10 keys)", () => {
-    do_not_optimize(lodashMapValues(smallObj, transform));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(lodashMapValues(smallObj, transform));
+    }
   });
 
   bench("esToolkitMapValues (10 keys)", () => {
-    do_not_optimize(esToolkitMapValues(smallObj, transform));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(esToolkitMapValues(smallObj, transform));
+    }
   });
+});
 
+summary(() => {
   bench("customMapValues (100 keys)", () => {
-    do_not_optimize(customMapValues(mediumObj, transform));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(customMapValues(mediumObj, transform));
+    }
   });
 
   bench("lodashMapValues (100 keys)", () => {
-    do_not_optimize(lodashMapValues(mediumObj, transform));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(lodashMapValues(mediumObj, transform));
+    }
   });
 
   bench("esToolkitMapValues (100 keys)", () => {
-    do_not_optimize(esToolkitMapValues(mediumObj, transform));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(esToolkitMapValues(mediumObj, transform));
+    }
   });
+});
 
+summary(() => {
   bench("customMapValues (1000 keys)", () => {
-    do_not_optimize(customMapValues(largeObj, transform));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(customMapValues(largeObj, transform));
+    }
   });
 
   bench("lodashMapValues (1000 keys)", () => {
-    do_not_optimize(lodashMapValues(largeObj, transform));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(lodashMapValues(largeObj, transform));
+    }
   });
 
   bench("esToolkitMapValues (1000 keys)", () => {
-    do_not_optimize(esToolkitMapValues(largeObj, transform));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(esToolkitMapValues(largeObj, transform));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/object.pickDeep.benchmark.ts
+++ b/package/main/src/tests/benchmark/object.pickDeep.benchmark.ts
@@ -14,12 +14,19 @@ for (let i = 0; i < 100; i++) {
 }
 keys.push("nested.a.b.c");
 
+// A single pickDeep call takes tens of microseconds, so repeating it this many
+// times makes one measured sample take roughly ~500ms, keeping fixed
+// measurement overhead negligible.
+const ITERATIONS = 30_000;
+
 summary(() => {
   bench("pickDeep", () => {
     // biome-ignore lint/suspicious/noExplicitAny: benchmark keys
     const k = keys as any;
-    // biome-ignore lint/suspicious/noExplicitAny: benchmark call
-    do_not_optimize((pickDeep as any)(largeObj, ...k));
+    for (let i = 0; i < ITERATIONS; i++) {
+      // biome-ignore lint/suspicious/noExplicitAny: benchmark call
+      do_not_optimize((pickDeep as any)(largeObj, ...k));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/predicate.benchmark.ts
+++ b/package/main/src/tests/benchmark/predicate.benchmark.ts
@@ -17,44 +17,64 @@ const inlineNot = (n: number) => !(n > 0);
 
 const testValues = Array.from({ length: 10_000 }, (_, i) => i - 5000);
 
+// One pass over the 10k values already runs in tens to a hundred microseconds,
+// but that is still noise-dominated. Each group repeats the pass enough times
+// for one measured sample to take roughly ~500ms, keeping fixed overhead
+// negligible. The count is shared between the composed and inline variants.
+const EVERY_ITERATIONS = 4500;
+const SOME_ITERATIONS = 4500;
+const NOT_ITERATIONS = 38_000;
+
 summary(() => {
   bench("UMT every composition", () => {
-    for (const v of testValues) {
-      do_not_optimize(umtEvery(v));
+    for (let i = 0; i < EVERY_ITERATIONS; i++) {
+      for (const v of testValues) {
+        do_not_optimize(umtEvery(v));
+      }
     }
   });
 
   bench("Inline arrow every", () => {
-    for (const v of testValues) {
-      do_not_optimize(inlineEvery(v));
+    for (let i = 0; i < EVERY_ITERATIONS; i++) {
+      for (const v of testValues) {
+        do_not_optimize(inlineEvery(v));
+      }
     }
   });
 });
 
 summary(() => {
   bench("UMT some composition", () => {
-    for (const v of testValues) {
-      do_not_optimize(umtSome(v));
+    for (let i = 0; i < SOME_ITERATIONS; i++) {
+      for (const v of testValues) {
+        do_not_optimize(umtSome(v));
+      }
     }
   });
 
   bench("Inline arrow some", () => {
-    for (const v of testValues) {
-      do_not_optimize(inlineSome(v));
+    for (let i = 0; i < SOME_ITERATIONS; i++) {
+      for (const v of testValues) {
+        do_not_optimize(inlineSome(v));
+      }
     }
   });
 });
 
 summary(() => {
   bench("UMT not composition", () => {
-    for (const v of testValues) {
-      do_not_optimize(umtNot(v));
+    for (let i = 0; i < NOT_ITERATIONS; i++) {
+      for (const v of testValues) {
+        do_not_optimize(umtNot(v));
+      }
     }
   });
 
   bench("Inline arrow not", () => {
-    for (const v of testValues) {
-      do_not_optimize(inlineNot(v));
+    for (let i = 0; i < NOT_ITERATIONS; i++) {
+      for (const v of testValues) {
+        do_not_optimize(inlineNot(v));
+      }
     }
   });
 });

--- a/package/main/src/tests/benchmark/string.formatString.benchmark.ts
+++ b/package/main/src/tests/benchmark/string.formatString.benchmark.ts
@@ -21,25 +21,43 @@ const customFormatters = {
   },
 };
 
+// A single format call ranges from one to forty microseconds depending on the
+// spec, which is noise-dominated. A single repetition count is shared across
+// all cases so their relative cost stays comparable; it is sized so the most
+// expensive case takes roughly ~500ms, keeping fixed overhead negligible.
+const ITERATIONS = 14_000;
+
 summary(() => {
   bench("formatString - currency(locale,code)", () => {
-    do_not_optimize(formatString(simpleTemplate, simpleData));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(formatString(simpleTemplate, simpleData));
+    }
   });
 
   bench("formatString - number(locale,min,max)", () => {
-    do_not_optimize(formatString(multiArgTemplate, multiArgData));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(formatString(multiArgTemplate, multiArgData));
+    }
   });
 
   bench("formatString - pad(width,char)", () => {
-    do_not_optimize(formatString(padTemplate, padData));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(formatString(padTemplate, padData));
+    }
   });
 
   bench("formatString - plural(singular,plural)", () => {
-    do_not_optimize(formatString(pluralTemplate, pluralData));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(formatString(pluralTemplate, pluralData));
+    }
   });
 
   bench("formatString - custom wrap('quoted','args')", () => {
-    do_not_optimize(formatString(quotedTemplate, quotedData, customFormatters));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(
+        formatString(quotedTemplate, quotedData, customFormatters),
+      );
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/string.fuzzySearch.benchmark.ts
+++ b/package/main/src/tests/benchmark/string.fuzzySearch.benchmark.ts
@@ -49,21 +49,38 @@ const itemsLarge = Array.from({ length: 1000 }, (_, index) => {
   return `randomstring${index}`; // diff length
 });
 
+// The small input runs in well under two microseconds and the large input in a
+// few hundred microseconds, both noise-dominated. Each group repeats its search
+// enough times for one measured sample to take roughly ~500ms, keeping fixed
+// overhead negligible. The count is shared across variants within a group.
+const SMALL_ITERATIONS = 560_000;
+const LARGE_ITERATIONS = 2200;
+
 summary(() => {
   bench("legacyFuzzySearch (small)", () => {
-    do_not_optimize(legacyFuzzySearch(query, itemsSmall));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(legacyFuzzySearch(query, itemsSmall));
+    }
   });
 
   bench("fuzzySearch (small)", () => {
-    do_not_optimize(fuzzySearch(query, itemsSmall));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(fuzzySearch(query, itemsSmall));
+    }
   });
+});
 
+summary(() => {
   bench("legacyFuzzySearch (large)", () => {
-    do_not_optimize(legacyFuzzySearch(query, itemsLarge));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(legacyFuzzySearch(query, itemsLarge));
+    }
   });
 
   bench("fuzzySearch (large)", () => {
-    do_not_optimize(fuzzySearch(query, itemsLarge));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(fuzzySearch(query, itemsLarge));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/uuid.benchmark.ts
+++ b/package/main/src/tests/benchmark/uuid.benchmark.ts
@@ -7,17 +7,28 @@ const invalidUUID = "123e4567-e89b-42d3-a456-42661417400Z";
 const validatorV4 = uuid([4]);
 const validatorAll = uuid([1, 2, 3, 4, 5]);
 
+// A single validate call takes well under a microsecond, so the raw number is
+// noise-dominated. Repeating it this many times makes one measured sample take
+// roughly ~500ms, rendering timer resolution and scheduling jitter negligible.
+const ITERATIONS = 3_000_000;
+
 summary(() => {
   bench("validate UUID v4 (single version)", () => {
-    do_not_optimize(validatorV4.validate(uuidV4));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(validatorV4.validate(uuidV4));
+    }
   });
 
   bench("validate UUID invalid (single version)", () => {
-    do_not_optimize(validatorV4.validate(invalidUUID));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(validatorV4.validate(invalidUUID));
+    }
   });
 
   bench("validate UUID v4 (all versions)", () => {
-    do_not_optimize(validatorAll.validate(uuidV4));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(validatorAll.validate(uuidV4));
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/uuidv7-generator.benchmark.ts
+++ b/package/main/src/tests/benchmark/uuidv7-generator.benchmark.ts
@@ -1,9 +1,16 @@
 import { bench, run, summary, do_not_optimize } from "mitata";
 import { uuidv7 } from "@/Math/uuidv7";
 
+// Generating a single uuid takes only a few hundred nanoseconds. Repeating the
+// generation this many times makes one measured sample take roughly ~500ms so
+// that timer resolution and CPU scheduling jitter become negligible.
+const ITERATIONS = 2_400_000;
+
 summary(() => {
   bench("uuidv7 generator", () => {
-    do_not_optimize(uuidv7());
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(uuidv7());
+    }
   });
 });
 


### PR DESCRIPTION
The standalone micro-benchmarks measured operations that complete in the
nanosecond to low-microsecond range, where timer resolution and CPU
scheduling jitter dominate and make the reported numbers unreliable.

Each affected benchmark now repeats its operation a calibrated number of
times so that a single measured sample runs for roughly ~500ms, which makes
fixed measurement overhead negligible. Within every comparison group the
repetition count is shared across variants so the relative comparison stays
fair, and groups whose per-operation cost spans orders of magnitude (such as
debounce creation vs invocation) are split so each is measured on a
comparable scale. The large-array scaling benchmarks (sort, chunk, groupBy,
zipLongest, etc.) already exercise substantial inputs and are left intact.

https://claude.ai/code/session_01ThFMoE7f9H7BiKVL7rL58L