### PR TITLE
Fix timeout test assertion timing with fake timers

### DIFF
--- a/package/main/src/tests/unit/Async/timeout.test.ts
+++ b/package/main/src/tests/unit/Async/timeout.test.ts
@@ -1,18 +1,27 @@
 import { timeout } from "@/Async/timeout";
 
 describe("timeout", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
   it("resolves when promise completes before timeout", async () => {
     const promise = new Promise<string>((resolve) => {
       setTimeout(() => {
         resolve("done");
       }, 10);
     });
-    const result = await timeout(promise, 1000);
-    expect(result).toBe("done");
+    const result = timeout(promise, 1000);
+    await jest.advanceTimersByTimeAsync(10);
+    await expect(result).resolves.toBe("done");
   });
 
   it("rejects with timeout error when promise exceeds time", async () => {
-    jest.useFakeTimers();
     const promise = new Promise<string>((resolve) => {
       setTimeout(() => {
         resolve("done");
@@ -20,9 +29,8 @@ describe("timeout", () => {
     });
     const result = timeout(promise, 50);
     const assertion = expect(result).rejects.toThrow("Timed out after 50ms");
-    jest.advanceTimersByTime(50);
+    await jest.advanceTimersByTimeAsync(50);
     await assertion;
-    jest.useRealTimers();
   });
 
   it("rejects with original error when promise fails", async () => {
@@ -31,7 +39,10 @@ describe("timeout", () => {
         reject(new Error("original error"));
       }, 10);
     });
-    await expect(timeout(promise, 1000)).rejects.toThrow("original error");
+    const result = timeout(promise, 1000);
+    const assertion = expect(result).rejects.toThrow("original error");
+    await jest.advanceTimersByTimeAsync(10);
+    await assertion;
   });
 
   it("clears timeout after resolution", async () => {

--- a/package/main/src/tests/unit/Async/timeout.test.ts
+++ b/package/main/src/tests/unit/Async/timeout.test.ts
@@ -19,8 +19,9 @@ describe("timeout", () => {
       }, 10_000);
     });
     const result = timeout(promise, 50);
+    const assertion = expect(result).rejects.toThrow("Timed out after 50ms");
     jest.advanceTimersByTime(50);
-    await expect(result).rejects.toThrow("Timed out after 50ms");
+    await assertion;
     jest.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary
Refactored the timeout test to properly handle assertion execution with Jest's fake timers by separating the assertion setup from its execution.

## Key Changes
- Moved the `expect()` call outside of the `await` statement to set up the assertion before advancing timers
- The assertion is now created before `jest.advanceTimersByTime(50)` is called, ensuring the promise rejection is properly captured
- The `await` statement now only waits for the assertion to complete, rather than setting up and awaiting in a single expression

## Implementation Details
This change fixes a potential race condition where the assertion was being set up after the timers were advanced. By separating the assertion creation from its execution, we ensure that:
1. The promise rejection handler is registered before time advances
2. The fake timer advancement triggers the timeout
3. The assertion then validates the rejection occurred with the correct message

https://claude.ai/code/session_01DjX3pugcYXnYwjtPBzGB14