### PR TITLE
Improve benchmark stability by repeating small operations

### DIFF
--- a/package/main/src/tests/benchmark/array.chunk.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.chunk.benchmark.ts
@@ -21,6 +21,22 @@ for (const size of arraySizes) {
   );
 }
 
+// Small/medium inputs run in microseconds, which is buried in CI-runner jitter
+// and produces meaningless base/head diffs. Repeating the operation a fixed
+// number of times lifts one measured sample to a few milliseconds so it stays
+// well above that jitter. The count is fixed (not derived from measured speed)
+// so the comparison still reflects real per-operation differences. From 100k
+// upward a single call already takes long enough and runs once.
+const repsForSize = (size: number): number => {
+  if (size <= 1000) {
+    return 300;
+  }
+  if (size <= 10_000) {
+    return 30;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -34,13 +50,11 @@ summary(() => {
           throw new Error(`No shared array found for size: ${size}`);
         }
 
-        yield {
-          0() {
-            return [...original_array];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(customChunk(arr, currentChunkSize));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(customChunk(original_array, currentChunkSize));
+          }
         };
       },
     )
@@ -58,13 +72,11 @@ summary(() => {
           throw new Error(`No shared array found for size: ${size}`);
         }
 
-        yield {
-          0() {
-            return [...original_array];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(lodashChunk(arr, currentChunkSize));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(lodashChunk(original_array, currentChunkSize));
+          }
         };
       },
     )
@@ -82,13 +94,11 @@ summary(() => {
           throw new Error(`No shared array found for size: ${size}`);
         }
 
-        yield {
-          0() {
-            return [...original_array];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(esToolkitChunk(arr, currentChunkSize));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(esToolkitChunk(original_array, currentChunkSize));
+          }
         };
       },
     )

--- a/package/main/src/tests/benchmark/array.getArraysCommon.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.getArraysCommon.benchmark.ts
@@ -37,6 +37,21 @@ for (const size of arraySizes) {
   sharedRandomArrays.set(size, [baseArray, ...arrays]);
 }
 
+// Small inputs run in microseconds, which is buried in CI-runner jitter and
+// produces meaningless base/head diffs. Repeating the operation a fixed number
+// of times lifts one measured sample to a few milliseconds so it stays well
+// above that jitter. The count is fixed (not derived from measured speed) so
+// the comparison still reflects real per-operation differences.
+const repsForSize = (size: number): number => {
+  if (size <= 100) {
+    return 1500;
+  }
+  if (size <= 1000) {
+    return 150;
+  }
+  return 15;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -54,13 +69,11 @@ summary(() => {
         const inputArrays = allArrays.slice(0, count);
         const [first, ...rest] = inputArrays;
 
-        yield {
-          0() {
-            return inputArrays;
-          },
-          bench() {
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
             do_not_optimize(getArraysCommon(first, ...rest));
-          },
+          }
         };
       },
     )

--- a/package/main/src/tests/benchmark/array.getArraysDiff.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.getArraysDiff.benchmark.ts
@@ -11,6 +11,21 @@ import { getArraysDiff } from "../../Array/getArraysDiff";
 const arraySizes = [100, 1000, 10_000];
 const numberOfArrays = [2, 5];
 
+// Small inputs run in microseconds, which is buried in CI-runner jitter and
+// produces meaningless base/head diffs. Repeating the operation a fixed number
+// of times lifts one measured sample to a few milliseconds so it stays well
+// above that jitter. The count is fixed (not derived from measured speed) so
+// the comparison still reflects real per-operation differences.
+const repsForSize = (size: number): number => {
+  if (size <= 100) {
+    return 1500;
+  }
+  if (size <= 1000) {
+    return 150;
+  }
+  return 15;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -29,13 +44,11 @@ summary(() => {
           arrays.push(arr);
         }
 
-        yield {
-          0() {
-            return arrays;
-          },
-          bench() {
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
             do_not_optimize(getArraysDiff(arrays[0], ...arrays.slice(1)));
-          },
+          }
         };
       },
     ).args({ size: arraySizes, count: numberOfArrays });

--- a/package/main/src/tests/benchmark/array.groupBy-first-char.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-first-char.benchmark.ts
@@ -29,6 +29,22 @@ for (const size of arraySizes) {
 
 const byFirstChar = (item: string): string => item[0];
 
+// Small/medium inputs run in microseconds, which is buried in CI-runner jitter
+// and produces meaningless base/head diffs. Repeating the operation a fixed
+// number of times lifts one measured sample to a few milliseconds so it stays
+// well above that jitter. The count is fixed (not derived from measured speed)
+// so the comparison still reflects real per-operation differences. From 100k
+// upward a single call already takes long enough and runs once.
+const repsForSize = (size: number): number => {
+  if (size <= 1000) {
+    return 100;
+  }
+  if (size <= 10_000) {
+    return 10;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -39,13 +55,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(customGroupBy(arr, byFirstChar));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(customGroupBy(originalArray, byFirstChar));
+          }
         };
       },
     )
@@ -60,13 +74,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(lodashGroupBy(arr, byFirstChar));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(lodashGroupBy(originalArray, byFirstChar));
+          }
         };
       },
     )
@@ -81,13 +93,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(esToolkitGroupBy(arr, byFirstChar));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(esToolkitGroupBy(originalArray, byFirstChar));
+          }
         };
       },
     )
@@ -102,13 +112,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(Object.groupBy(arr, byFirstChar));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(Object.groupBy(originalArray, byFirstChar));
+          }
         };
       },
     )

--- a/package/main/src/tests/benchmark/array.groupBy-length.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-length.benchmark.ts
@@ -26,6 +26,22 @@ for (const size of arraySizes) {
 
 const byLength = (item: string): number => item.length;
 
+// Small/medium inputs run in microseconds, which is buried in CI-runner jitter
+// and produces meaningless base/head diffs. Repeating the operation a fixed
+// number of times lifts one measured sample to a few milliseconds so it stays
+// well above that jitter. The count is fixed (not derived from measured speed)
+// so the comparison still reflects real per-operation differences. From 100k
+// upward a single call already takes long enough and runs once.
+const repsForSize = (size: number): number => {
+  if (size <= 1000) {
+    return 100;
+  }
+  if (size <= 10_000) {
+    return 10;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -36,13 +52,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(customGroupBy(arr, byLength));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(customGroupBy(originalArray, byLength));
+          }
         };
       },
     )
@@ -57,13 +71,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(lodashGroupBy(arr, byLength));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(lodashGroupBy(originalArray, byLength));
+          }
         };
       },
     )
@@ -78,13 +90,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(esToolkitGroupBy(arr, byLength));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(esToolkitGroupBy(originalArray, byLength));
+          }
         };
       },
     )
@@ -99,13 +109,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: string[]) {
-            do_not_optimize(Object.groupBy(arr, byLength));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(Object.groupBy(originalArray, byLength));
+          }
         };
       },
     )

--- a/package/main/src/tests/benchmark/array.groupBy-math-floor.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.groupBy-math-floor.benchmark.ts
@@ -23,6 +23,22 @@ for (const size of arraySizes) {
 
 const byMathFloor = (item: number): number => Math.floor(item);
 
+// Small/medium inputs run in microseconds, which is buried in CI-runner jitter
+// and produces meaningless base/head diffs. Repeating the operation a fixed
+// number of times lifts one measured sample to a few milliseconds so it stays
+// well above that jitter. The count is fixed (not derived from measured speed)
+// so the comparison still reflects real per-operation differences. From 100k
+// upward a single call already takes long enough and runs once.
+const repsForSize = (size: number): number => {
+  if (size <= 1000) {
+    return 100;
+  }
+  if (size <= 10_000) {
+    return 10;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -33,13 +49,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(customGroupBy(arr, byMathFloor));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(customGroupBy(originalArray, byMathFloor));
+          }
         };
       },
     )
@@ -54,13 +68,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(lodashGroupBy(arr, byMathFloor));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(lodashGroupBy(originalArray, byMathFloor));
+          }
         };
       },
     )
@@ -75,13 +87,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(esToolkitGroupBy(arr, byMathFloor));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(esToolkitGroupBy(originalArray, byMathFloor));
+          }
         };
       },
     )
@@ -96,13 +106,11 @@ summary(() => {
         if (!originalArray) {
           throw new Error(`No shared array found for size: ${size}`);
         }
-        yield {
-          0() {
-            return [...originalArray];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(Object.groupBy(arr, byMathFloor));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(Object.groupBy(originalArray, byMathFloor));
+          }
         };
       },
     )

--- a/package/main/src/tests/benchmark/array.randomSelect.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.randomSelect.benchmark.ts
@@ -5,35 +5,53 @@ import { shuffle } from "@/Array/shuffle";
 const size = 10_000;
 const array = Array.from({ length: size }, (_, i) => i);
 
+// A single selection runs in tens to hundreds of microseconds, which is buried
+// in CI-runner jitter. Repeating the operation a fixed number of times lifts
+// one measured sample to a few milliseconds so it stays above that jitter. The
+// same count is shared across all cases so the comparison stays fair.
+const ITERATIONS = 30;
+
 summary(() => {
   bench(`randomSelect(size=${size}, count=${size * 0.1})`, () => {
-    do_not_optimize(randomSelect(array, size * 0.1));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(randomSelect(array, size * 0.1));
+    }
   });
 
   bench(`randomSelect(size=${size}, count=${size * 0.5})`, () => {
-    do_not_optimize(randomSelect(array, size * 0.5));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(randomSelect(array, size * 0.5));
+    }
   });
 
   bench(
     `randomSelect(size=${size}, count=${size * 0.8}) (optimization threshold)`,
     () => {
-      do_not_optimize(randomSelect(array, size * 0.8));
+      for (let i = 0; i < ITERATIONS; i++) {
+        do_not_optimize(randomSelect(array, size * 0.8));
+      }
     },
   );
 
   bench(`randomSelect(size=${size}, count=${size * 0.9})`, () => {
-    do_not_optimize(randomSelect(array, size * 0.9));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(randomSelect(array, size * 0.9));
+    }
   });
 
   bench(`randomSelect(size=${size}, count=${size * 0.99})`, () => {
-    do_not_optimize(randomSelect(array, size * 0.99));
+    for (let i = 0; i < ITERATIONS; i++) {
+      do_not_optimize(randomSelect(array, size * 0.99));
+    }
   });
 
   // Reference baseline: Full shuffle + truncate
   bench(`shuffle(size=${size}) + truncate to ${size * 0.9}`, () => {
-    const res = shuffle(array);
-    res.length = size * 0.9;
-    do_not_optimize(res);
+    for (let i = 0; i < ITERATIONS; i++) {
+      const res = shuffle(array);
+      res.length = size * 0.9;
+      do_not_optimize(res);
+    }
   });
 });
 

--- a/package/main/src/tests/benchmark/array.sort-edge-almost-sorted.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-edge-almost-sorted.benchmark.ts
@@ -33,6 +33,27 @@ for (const size of arraySizes) {
   almostSortedArrays.set(size, almostSorted);
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("ultraNumberSort($size)", function* (state: k_state) {
@@ -43,13 +64,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(ultraNumberSort(arr));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -63,13 +83,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -83,13 +102,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -103,13 +121,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -123,13 +140,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -143,13 +159,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-edge-nan.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-edge-nan.benchmark.ts
@@ -31,6 +31,27 @@ for (const size of arraySizes) {
   nanArrays.set(size, nanArray);
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("ultraNumberSort($size)", function* (state: k_state) {
@@ -41,13 +62,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(ultraNumberSort(arr));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -61,13 +81,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -81,13 +100,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -101,13 +119,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -121,13 +138,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -141,13 +157,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-edge-same-values.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-edge-same-values.benchmark.ts
@@ -23,6 +23,27 @@ for (const size of arraySizes) {
   sameValueArrays.set(size, new Array(size).fill(42));
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("ultraNumberSort($size)", function* (state: k_state) {
@@ -33,13 +54,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(ultraNumberSort(arr));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -53,13 +73,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -73,13 +92,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -93,13 +111,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -113,13 +130,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -133,13 +149,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-edge-sawtooth.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-edge-sawtooth.benchmark.ts
@@ -27,6 +27,27 @@ for (const size of arraySizes) {
   sawtoothArrays.set(size, sawtooth);
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("ultraNumberSort($size)", function* (state: k_state) {
@@ -37,13 +58,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(ultraNumberSort(arr));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -57,13 +77,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -77,13 +96,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -97,13 +115,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -117,13 +134,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -137,13 +153,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: number[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-number.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-number.benchmark.ts
@@ -25,6 +25,27 @@ for (const size of arraySizes) {
   );
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench(
@@ -37,13 +58,11 @@ summary(() => {
           throw new Error(`No shared array found for size: ${size}`);
         }
 
-        yield {
-          0() {
-            return [...original_array];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(arr.sort(compareFunction));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize([...original_array].sort(compareFunction));
+          }
         };
       },
     )
@@ -58,13 +77,11 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
-          do_not_optimize(sort(arr).asc());
-        },
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          do_not_optimize(sort([...original_array]).asc());
+        }
       };
     })
       .args("size", arraySizes)
@@ -78,13 +95,11 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
-          do_not_optimize(quickSort(arr, compareFunction));
-        },
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          do_not_optimize(quickSort([...original_array], compareFunction));
+        }
       };
     })
       .args("size", arraySizes)
@@ -100,13 +115,13 @@ summary(() => {
           throw new Error(`No shared array found for size: ${size}`);
         }
 
-        yield {
-          0() {
-            return [...original_array];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(
+              dualPivotQuickSort([...original_array], compareFunction),
+            );
+          }
         };
       },
     )
@@ -121,13 +136,11 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
-          do_not_optimize(timSort(arr, compareFunction));
-        },
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          do_not_optimize(timSort([...original_array], compareFunction));
+        }
       };
     })
       .args("size", arraySizes)
@@ -141,13 +154,11 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: number[]) {
-          do_not_optimize(mergeSort(arr, compareFunction));
-        },
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          do_not_optimize(mergeSort([...original_array], compareFunction));
+        }
       };
     })
       .args("size", arraySizes)
@@ -163,13 +174,11 @@ summary(() => {
           throw new Error(`No shared array found for size: ${size}`);
         }
 
-        yield {
-          0() {
-            return [...original_array];
-          },
-          bench(arr: number[]) {
-            do_not_optimize(ultraNumberSort(arr, true));
-          },
+        const reps = repsForSize(size);
+        yield () => {
+          for (let r = 0; r < reps; r++) {
+            do_not_optimize(ultraNumberSort([...original_array], true));
+          }
         };
       },
     )

--- a/package/main/src/tests/benchmark/array.sort-object-complex.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-object-complex.benchmark.ts
@@ -54,6 +54,27 @@ for (const size of arraySizes) {
   );
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -64,13 +85,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Product[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Product[] = [...original_array];
           do_not_optimize(quickSort(arr, compareProductComplex));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -84,13 +104,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Product[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Product[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareProductComplex));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -104,13 +123,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Product[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Product[] = [...original_array];
           do_not_optimize(timSort(arr, compareProductComplex));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -124,13 +142,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Product[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Product[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareProductComplex));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -144,13 +161,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Product[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Product[] = [...original_array];
           do_not_optimize(arr.sort(compareProductComplex));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-object-duplicates.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-object-duplicates.benchmark.ts
@@ -41,6 +41,27 @@ for (const size of arraySizes) {
   duplicatePersonArrays.set(size, duplicateArray);
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -51,13 +72,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(quickSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -71,13 +91,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -91,13 +110,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(timSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -111,13 +129,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -131,13 +148,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(arr.sort(compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-object-numeric.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-object-numeric.benchmark.ts
@@ -39,6 +39,27 @@ for (const size of arraySizes) {
   );
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -49,13 +70,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(quickSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -69,13 +89,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -89,13 +108,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(timSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -109,13 +127,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -129,13 +146,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(arr.sort(compareById));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-object-string.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-object-string.benchmark.ts
@@ -40,6 +40,27 @@ for (const size of arraySizes) {
   );
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -50,13 +71,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(quickSort(arr, compareByName));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -70,13 +90,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareByName));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -90,13 +109,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(timSort(arr, compareByName));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -110,13 +128,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareByName));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -130,13 +147,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: Person[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: Person[] = [...original_array];
           do_not_optimize(arr.sort(compareByName));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-string-long.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-string-long.benchmark.ts
@@ -38,6 +38,27 @@ for (const size of arraySizes) {
   );
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -48,13 +69,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -68,13 +88,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -88,13 +107,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -108,13 +126,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -128,13 +145,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-string-reverse.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-string-reverse.benchmark.ts
@@ -36,6 +36,27 @@ for (const size of arraySizes) {
   reverseSortedArrays.set(size, sorted.reverse());
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -46,13 +67,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -66,13 +86,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -86,13 +105,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -106,13 +124,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -126,13 +143,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-string-short.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-string-short.benchmark.ts
@@ -39,6 +39,27 @@ for (const size of arraySizes) {
   );
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -49,13 +70,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -69,13 +89,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -89,13 +108,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -109,13 +127,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -129,13 +146,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(insertionSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes.slice(0, 3)) // Only small sizes for insertion sort
@@ -149,13 +165,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.sort-string-sorted.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.sort-string-sorted.benchmark.ts
@@ -36,6 +36,27 @@ for (const size of arraySizes) {
   sortedArrays.set(size, sorted);
 }
 
+// Small arrays sort in nanoseconds to a few microseconds, which is buried in
+// CI-runner jitter and produces meaningless base/head diffs. Repeating the sort
+// a fixed number of times lifts one measured sample to a few milliseconds so it
+// stays well above that jitter. The count is fixed (not derived from measured
+// speed) so the comparison still reflects real per-operation differences. Only
+// the small sizes are repeated: from 10k upward a single sort already takes
+// long enough, and some algorithms become pathologically slow on adversarial
+// inputs, so repeating them there would explode the run time.
+const repsForSize = (size: number): number => {
+  if (size <= 10) {
+    return 20_000;
+  }
+  if (size <= 100) {
+    return 2000;
+  }
+  if (size <= 1000) {
+    return 200;
+  }
+  return 1;
+};
+
 summary(() => {
   lineplot(() => {
     bench("quickSort($size)", function* (state: k_state) {
@@ -46,13 +67,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(quickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -66,13 +86,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(dualPivotQuickSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -86,13 +105,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(timSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -106,13 +124,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(mergeSort(arr, compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)
@@ -126,13 +143,12 @@ summary(() => {
         throw new Error(`No shared array found for size: ${size}`);
       }
 
-      yield {
-        0() {
-          return [...original_array];
-        },
-        bench(arr: string[]) {
+      const reps = repsForSize(size);
+      yield () => {
+        for (let r = 0; r < reps; r++) {
+          const arr: string[] = [...original_array];
           do_not_optimize(arr.sort(compareFunction));
-        },
+        }
       };
     })
       .args("size", arraySizes)

--- a/package/main/src/tests/benchmark/array.zipLongest.benchmark.ts
+++ b/package/main/src/tests/benchmark/array.zipLongest.benchmark.ts
@@ -62,6 +62,22 @@ for (const count of arrayCounts) {
   }
 }
 
+// The smaller inputs zip in microseconds, which is buried in CI-runner jitter
+// and produces meaningless base/head diffs. Repeating the operation a fixed
+// number of times lifts one measured sample to a few milliseconds so it stays
+// well above that jitter. The count is fixed (not derived from measured speed)
+// so the comparison still reflects real per-operation differences and is keyed
+// off the array length, which dominates the cost.
+const repsForLength = (length: number): number => {
+  if (length <= 100) {
+    return 1000;
+  }
+  if (length <= 1000) {
+    return 100;
+  }
+  return 10;
+};
+
 summary(() => {
   bench(
     "zipLongest-prealloc(arrays: $count, length: $length)",
@@ -69,8 +85,11 @@ summary(() => {
       const count = state.get("count") as number;
       const length = state.get("length") as number;
       const arrays = testData.get(`${count}-${length}`) as unknown[][];
+      const reps = repsForLength(length);
       yield () => {
-        do_not_optimize(zipLongestOptimized(...arrays));
+        for (let r = 0; r < reps; r++) {
+          do_not_optimize(zipLongestOptimized(...arrays));
+        }
       };
     },
   )
@@ -83,8 +102,11 @@ summary(() => {
       const count = state.get("count") as number;
       const length = state.get("length") as number;
       const arrays = testData.get(`${count}-${length}`) as unknown[][];
+      const reps = repsForLength(length);
       yield () => {
-        do_not_optimize(zipLongestPush(...arrays));
+        for (let r = 0; r < reps; r++) {
+          do_not_optimize(zipLongestPush(...arrays));
+        }
       };
     },
   )

--- a/package/main/src/tests/benchmark/dataStructure.lruCache.benchmark.ts
+++ b/package/main/src/tests/benchmark/dataStructure.lruCache.benchmark.ts
@@ -3,28 +3,60 @@ import { LRUCache } from "@/DataStructure/lruCache";
 
 const CACHE_SIZES = [100, 1000, 10_000];
 
+// The smaller caches operate in microseconds, which is buried in CI-runner
+// jitter. Each operation is repeated a fixed number of times so one measured
+// sample reaches a few milliseconds and stays above that jitter. The set/get
+// passes scale with the capacity, while the mixed pass already does twice the
+// work, so it uses a smaller count to avoid overshooting on the largest cache.
+// The counts are fixed so the base/head comparison stays meaningful.
+const repsSetGet = (size: number): number => {
+  if (size <= 100) {
+    return 200;
+  }
+  if (size <= 1000) {
+    return 20;
+  }
+  return 13;
+};
+const repsMixed = (size: number): number => {
+  if (size <= 100) {
+    return 200;
+  }
+  if (size <= 1000) {
+    return 12;
+  }
+  return 1;
+};
+
 for (const size of CACHE_SIZES) {
+  const setGetReps = repsSetGet(size);
+  const mixedReps = repsMixed(size);
+
   summary(() => {
     bench(`LRUCache set (capacity=${size})`, () => {
-      const cache = new LRUCache<number, number>(size);
-      for (let i = 0; i < size; i++) {
-        cache.set(i, i);
+      for (let r = 0; r < setGetReps; r++) {
+        const cache = new LRUCache<number, number>(size);
+        for (let i = 0; i < size; i++) {
+          cache.set(i, i);
+        }
+        do_not_optimize(cache);
       }
-      do_not_optimize(cache);
     });
 
     bench(`plain Map set (limit=${size})`, () => {
-      const map = new Map<number, number>();
-      for (let i = 0; i < size; i++) {
-        if (map.size >= size) {
-          const firstKey = map.keys().next().value;
-          if (firstKey !== undefined) {
-            map.delete(firstKey);
+      for (let r = 0; r < setGetReps; r++) {
+        const map = new Map<number, number>();
+        for (let i = 0; i < size; i++) {
+          if (map.size >= size) {
+            const firstKey = map.keys().next().value;
+            if (firstKey !== undefined) {
+              map.delete(firstKey);
+            }
           }
+          map.set(i, i);
         }
-        map.set(i, i);
+        do_not_optimize(map);
       }
-      do_not_optimize(map);
     });
   });
 
@@ -37,41 +69,49 @@ for (const size of CACHE_SIZES) {
     }
 
     bench(`LRUCache get (capacity=${size})`, () => {
-      for (let i = 0; i < size; i++) {
-        do_not_optimize(lruCache.get(i));
+      for (let r = 0; r < setGetReps; r++) {
+        for (let i = 0; i < size; i++) {
+          do_not_optimize(lruCache.get(i));
+        }
       }
     });
 
     bench(`plain Map get (limit=${size})`, () => {
-      for (let i = 0; i < size; i++) {
-        do_not_optimize(plainMap.get(i));
+      for (let r = 0; r < setGetReps; r++) {
+        for (let i = 0; i < size; i++) {
+          do_not_optimize(plainMap.get(i));
+        }
       }
     });
   });
 
   summary(() => {
     bench(`LRUCache set+get mixed (capacity=${size})`, () => {
-      const cache = new LRUCache<number, number>(size);
-      for (let i = 0; i < size * 2; i++) {
-        cache.set(i, i);
-        if (i > 0) {
-          do_not_optimize(cache.get(i - 1));
+      for (let r = 0; r < mixedReps; r++) {
+        const cache = new LRUCache<number, number>(size);
+        for (let i = 0; i < size * 2; i++) {
+          cache.set(i, i);
+          if (i > 0) {
+            do_not_optimize(cache.get(i - 1));
+          }
         }
       }
     });
 
     bench(`plain Map set+get mixed (limit=${size})`, () => {
-      const map = new Map<number, number>();
-      for (let i = 0; i < size * 2; i++) {
-        if (map.size >= size) {
-          const firstKey = map.keys().next().value;
-          if (firstKey !== undefined) {
-            map.delete(firstKey);
+      for (let r = 0; r < mixedReps; r++) {
+        const map = new Map<number, number>();
+        for (let i = 0; i < size * 2; i++) {
+          if (map.size >= size) {
+            const firstKey = map.keys().next().value;
+            if (firstKey !== undefined) {
+              map.delete(firstKey);
+            }
           }
-        }
-        map.set(i, i);
-        if (i > 0) {
-          do_not_optimize(map.get(i - 1));
+          map.set(i, i);
+          if (i > 0) {
+            do_not_optimize(map.get(i - 1));
+          }
         }
       }
     });

--- a/package/main/src/tests/benchmark/iterator.lazy.benchmark.ts
+++ b/package/main/src/tests/benchmark/iterator.lazy.benchmark.ts
@@ -17,22 +17,44 @@ const double = (n: number) => n * 2;
 const isEven = (n: number) => n % 2 === 0;
 const takeCount = 100;
 
+// The lazy pipeline short-circuits after taking 100 elements, so its cost is a
+// few microseconds regardless of the source size; it therefore uses a fixed
+// repetition count. The eager native pipeline scans the whole array, so its
+// cost grows with the size and uses a size-based count. Both are sized so one
+// measured sample reaches a few milliseconds and stays above CI-runner jitter,
+// and the counts are fixed so the base/head comparison stays meaningful.
+const LAZY_ITERATIONS = 1000;
+const nativeIterations = (size: number): number => {
+  if (size <= 10_000) {
+    return 50;
+  }
+  if (size <= 100_000) {
+    return 7;
+  }
+  return 1;
+};
+
 summary(() => {
   for (const size of arraySizes) {
     const arr = sharedArrays.get(size);
     if (!arr) {
       throw new Error(`No shared array found for size: ${size}`);
     }
+    const nativeReps = nativeIterations(size);
 
     bench(`UMT lazy pipeline (size: ${size})`, () => {
-      const mapped = lazyMap(arr, double);
-      const filtered = lazyFilter(mapped, isEven);
-      const taken = lazyTake(filtered, takeCount);
-      do_not_optimize([...taken]);
+      for (let i = 0; i < LAZY_ITERATIONS; i++) {
+        const mapped = lazyMap(arr, double);
+        const filtered = lazyFilter(mapped, isEven);
+        const taken = lazyTake(filtered, takeCount);
+        do_not_optimize([...taken]);
+      }
     });
 
     bench(`Array native pipeline (size: ${size})`, () => {
-      do_not_optimize(arr.map(double).filter(isEven).slice(0, takeCount));
+      for (let i = 0; i < nativeReps; i++) {
+        do_not_optimize(arr.map(double).filter(isEven).slice(0, takeCount));
+      }
     });
   }
 });

--- a/package/main/src/tests/benchmark/math.sumPrecise.benchmark.ts
+++ b/package/main/src/tests/benchmark/math.sumPrecise.benchmark.ts
@@ -8,29 +8,50 @@ const largeArray = Array.from({ length: 1_000_000 }, () => Math.random());
 const reduceSum = (numbers: number[]): number =>
   numbers.reduce((acc, n) => acc + n, 0);
 
+// Summing the smaller arrays runs in well under a microsecond, which is buried
+// in CI-runner jitter. Each size repeats its work a fixed number of times so
+// that one measured sample reaches a few milliseconds and stays above that
+// jitter. The count is shared between sumPrecise and reduce within a size so
+// their comparison stays fair.
+const SMALL_ITERATIONS = 40_000;
+const MEDIUM_ITERATIONS = 400;
+const LARGE_ITERATIONS = 5;
+
 summary(() => {
   bench("sumPrecise (100 elements)", () => {
-    do_not_optimize(sumPrecise(smallArray));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(sumPrecise(smallArray));
+    }
   });
 
   bench("Array.reduce (100 elements)", () => {
-    do_not_optimize(reduceSum(smallArray));
+    for (let i = 0; i < SMALL_ITERATIONS; i++) {
+      do_not_optimize(reduceSum(smallArray));
+    }
   });
 
   bench("sumPrecise (10,000 elements)", () => {
-    do_not_optimize(sumPrecise(mediumArray));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(sumPrecise(mediumArray));
+    }
   });
 
   bench("Array.reduce (10,000 elements)", () => {
-    do_not_optimize(reduceSum(mediumArray));
+    for (let i = 0; i < MEDIUM_ITERATIONS; i++) {
+      do_not_optimize(reduceSum(mediumArray));
+    }
   });
 
   bench("sumPrecise (1,000,000 elements)", () => {
-    do_not_optimize(sumPrecise(largeArray));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(sumPrecise(largeArray));
+    }
   });
 
   bench("Array.reduce (1,000,000 elements)", () => {
-    do_not_optimize(reduceSum(largeArray));
+    for (let i = 0; i < LARGE_ITERATIONS; i++) {
+      do_not_optimize(reduceSum(largeArray));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
This PR improves the reliability of benchmark measurements by repeating small/fast operations a fixed number of times. Operations that complete in microseconds are buried in CI-runner jitter and produce meaningless performance diffs. By repeating them to reach a few milliseconds per sample, the measurements stay well above the noise floor while maintaining fair comparisons.

## Key Changes

- **Array sorting benchmarks**: Added `repsForSize()` function that repeats sorts based on array size:
  - Size ≤ 10: 20,000 repetitions
  - Size ≤ 100: 2,000 repetitions
  - Size ≤ 1,000: 200 repetitions
  - Size > 1,000: 1 repetition (single sort already takes long enough)
  
  Refactored benchmark structure from object-based (`{ 0() {...}, bench(arr) {...} }`) to function-based (`() => { for (let r = 0; r < reps; r++) {...} }`)

- **LRU Cache benchmarks**: Added separate repetition functions for set/get operations (`repsSetGet`) and mixed operations (`repsMixed`), with mixed operations using lower counts since they do twice the work

- **Array utility benchmarks** (groupBy, chunk, zipLongest, getArraysCommon, getArraysDiff): Added size-based repetition counts to lift microsecond-scale operations into the millisecond range

- **Single-operation benchmarks** (randomSelect, sumPrecise, iterator.lazy): Added fixed iteration counts (e.g., `ITERATIONS = 30`, `SMALL_ITERATIONS = 40_000`) to ensure consistent measurement scale

## Implementation Details

- Repetition counts are **fixed, not derived from measured speed**, so base/head comparisons still reflect real per-operation differences
- For size-based benchmarks, only small sizes are repeated; larger sizes that already take sufficient time run once to avoid pathological slowdowns on adversarial inputs
- The refactoring maintains the same test coverage while improving measurement signal-to-noise ratio

https://claude.ai/code/session_01ThFMoE7f9H7BiKVL7rL58L