### PR TITLE
chore: release umt_rust v0.6.0

### DIFF
--- a/package/umt_rust/Cargo.lock
+++ b/package/umt_rust/Cargo.lock
@@ -737,7 +737,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "umt_rust"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",

--- a/package/umt_rust/Cargo.toml
+++ b/package/umt_rust/Cargo.toml
@@ -6,7 +6,7 @@ exclude = [".github", ".gitignore", "tests"]
 license = "MIT"
 name = "umt_rust"
 repository = "https://github.com/riya-amemiya/UMT"
-version = "0.5.0"
+version = "0.6.0"
 
 [lib]
 crate-type = ["lib"]

--- a/package/umt_rust/src/string/remove_prefix.rs
+++ b/package/umt_rust/src/string/remove_prefix.rs
@@ -18,10 +18,10 @@
 /// ```
 #[inline]
 pub fn umt_remove_prefix(s: &str, prefix: &str) -> String {
-    if !prefix.is_empty() {
-        if let Some(rest) = s.strip_prefix(prefix) {
-            return rest.to_string();
-        }
+    if !prefix.is_empty()
+        && let Some(rest) = s.strip_prefix(prefix)
+    {
+        return rest.to_string();
     }
     s.to_string()
 }

--- a/package/umt_rust/src/string/remove_suffix.rs
+++ b/package/umt_rust/src/string/remove_suffix.rs
@@ -18,10 +18,10 @@
 /// ```
 #[inline]
 pub fn umt_remove_suffix(s: &str, suffix: &str) -> String {
-    if !suffix.is_empty() {
-        if let Some(rest) = s.strip_suffix(suffix) {
-            return rest.to_string();
-        }
+    if !suffix.is_empty()
+        && let Some(rest) = s.strip_suffix(suffix)
+    {
+        return rest.to_string();
     }
     s.to_string()
 }


### PR DESCRIPTION
# Release v0.6.0

This release ports a large set of `package/main` utilities to the Rust crate, adding async control-flow, date, map, random, and object helpers alongside a substantially expanded validation suite. All functions are exported with the `umt_` prefix per crate convention, and no public functions were removed.

## ✨ New Features

### 🧩 New Modules

* **async_util** (`debounce_async`, `defer`, `p_settled`, `parallel`, `retry`, `sleep`, `throttle_async`, `timeout`, `wait_for`): Asynchronous control-flow helpers.
* **map** (`group_by_to_map`, `zip_to_map`): Map-returning collection utilities.
* **random** (`random_boolean`, `random_choice`, `random_float`, `random_int`, `random_uuid`, `seeded_random`, `weighted_choice`): Random value generation utilities.

### 🔧 New Functions in Existing Modules

* **date**: `add_duration`, `diff`, `end_of`, `format_relative`, `is_business_day`, `is_same_day`, `is_weekend`, `ms_by_unit`, `start_of`, `sub_duration`.
* **error**: `error_function`, `success_function`.
* **function**: `debounce`, `throttle`.
* **object**: `flatten_object`, `get`, `invert`, `omit_by`, `path_segments`, `pick_by`, `remove_prototype`, `remove_prototype_deep`, `remove_prototype_map`, `remove_prototype_map_deep`, `set`, `unflatten_object`.
* **string**: 24 helpers — `capitalize`, `capitalize_word`, `constant_case`, `count_occurrences`, `deburr`, `dedent`, `ensure_prefix`, `ensure_suffix`, `mask`, `normalize_whitespace`, `pascal_case`, `remove_prefix`, `remove_suffix`, `sanitize_string`, `snake_case`, `split_by_length`, `strip_ansi`, `strip_tags`, `swap_case`, `title_case`, `to_full_width`, `uncapitalize`, `word_count`, `words`.
* **validate**: New validators for `any`, `array_of`, `bigint`, `date`, `file`, `function`, `instance_of`, `map`, `never`, `set`, `template_literal`, `unknown`; environment checks `is_browser`, `is_bun`, `is_node`, `is_node_webkit`; object validators `intersection`, `nullable`, `omit_keys`, `partial`, `pick_keys`, `required`, `union`; and string validators `exact_length`, `one_of`. Added `number_validator` and `string_validator` factory functions.

## 🔄 Refactoring & Maintenance

* Consolidated the per-function files under `validate/number` and `validate/string` into their module `mod.rs`, preserving all public function paths (#870).
* Bumped Cargo dependencies (#855).

## 🧪 Testing

* Added comprehensive unit and integration tests covering every new module and function.
