### PR TITLE
Add comprehensive benchmarks and optimize validator performance

### DIFF
--- a/package/main/src/Validate/array/arrayOf.ts
+++ b/package/main/src/Validate/array/arrayOf.ts
@@ -50,13 +50,13 @@ export const arrayOf = <
         type: values,
       };
     }
-    for (const value of values) {
-      const result = (
-        validator as unknown as (v: Element) => {
-          validate: boolean;
-          message: string;
-        }
-      )(value);
+    const elementValidator = validator as unknown as (v: Element) => {
+      validate: boolean;
+      message: string;
+    };
+    const length = values.length;
+    for (let index = 0; index < length; index++) {
+      const result = elementValidator(values[index]);
       if (!result.validate) {
         return {
           validate: false,

--- a/package/main/src/Validate/boolean/core.ts
+++ b/package/main/src/Validate/boolean/core.ts
@@ -19,7 +19,11 @@ export const boolean = (
   message?: string,
 ): ((value: boolean) => ValidateCoreReturnType<boolean>) &
   StandardSchemaV1<boolean, boolean> => {
+  // Build the core validator once so each call avoids re-creating the curried
+  // closure and a fresh empty rules array.
+  const rules: [] = [];
+  const run = core<boolean>("boolean");
   const validator = (value: boolean): ValidateCoreReturnType<boolean> =>
-    core<boolean>("boolean")(value, [], message);
+    run(value, rules, message);
   return attachStandard<boolean, boolean, typeof validator>(validator);
 };

--- a/package/main/src/Validate/boolean/core.ts
+++ b/package/main/src/Validate/boolean/core.ts
@@ -19,8 +19,6 @@ export const boolean = (
   message?: string,
 ): ((value: boolean) => ValidateCoreReturnType<boolean>) &
   StandardSchemaV1<boolean, boolean> => {
-  // Build the core validator once so each call avoids re-creating the curried
-  // closure and a fresh empty rules array.
   const rules: [] = [];
   const run = core<boolean>("boolean");
   const validator = (value: boolean): ValidateCoreReturnType<boolean> =>

--- a/package/main/src/Validate/core/index.ts
+++ b/package/main/src/Validate/core/index.ts
@@ -30,11 +30,13 @@ export const core =
         type,
       };
     }
-    for (const validate of option) {
-      if (!validate.validate(value)) {
+    const length = option.length;
+    for (let index = 0; index < length; index++) {
+      const rule = option[index];
+      if (!rule.validate(value)) {
         return {
           validate: false,
-          message: validate.message ?? "",
+          message: rule.message ?? "",
           type,
         };
       }

--- a/package/main/src/Validate/core/index.ts
+++ b/package/main/src/Validate/core/index.ts
@@ -9,18 +9,23 @@ import type {
   ValidateReturnType,
 } from "@/Validate/type";
 
+const EMPTY_OPTION: ValidateReturnType<unknown>[] = [];
+
 /**
  * Creates a validator function that checks type and additional validation rules
  * @template T - The type of value to validate
  * @param {Types<T>} type - The expected type of the value
  * @returns {Function} - A validator function that accepts a value, options, and message
  */
-
-export const core =
-  <T>(type: Types<T>) =>
-  <O extends ValidateReturnType<T>[]>(
+export const core = <T>(type: Types<T>) => {
+  const success: ValidateCoreReturnType<T> = {
+    validate: true,
+    message: "",
+    type,
+  };
+  return <O extends ValidateReturnType<T>[]>(
     value: T,
-    option: O = [] as unknown as O,
+    option: O = EMPTY_OPTION as unknown as O,
     message?: string,
   ): ValidateCoreReturnType<T> => {
     if (typeof value !== type) {
@@ -41,9 +46,6 @@ export const core =
         };
       }
     }
-    return {
-      validate: true,
-      message: "",
-      type,
-    };
+    return success;
   };
+};

--- a/package/main/src/Validate/number/core.ts
+++ b/package/main/src/Validate/number/core.ts
@@ -25,8 +25,6 @@ export const number = <T extends ValidateReturnType<number>[]>(
   message?: string,
 ): ((value: number) => ValidateCoreReturnType<number>) &
   StandardSchemaV1<number, number> => {
-  // Build the core validator and resolve the rules array once so each call
-  // avoids re-creating the curried closure and a fresh default array.
   const rules = option ?? [];
   const run = core<number>("number");
   const validator = (value: number) => run(value, rules, message);

--- a/package/main/src/Validate/number/core.ts
+++ b/package/main/src/Validate/number/core.ts
@@ -25,7 +25,10 @@ export const number = <T extends ValidateReturnType<number>[]>(
   message?: string,
 ): ((value: number) => ValidateCoreReturnType<number>) &
   StandardSchemaV1<number, number> => {
-  const validator = (value: number) =>
-    core<number>("number")(value, option, message);
+  // Build the core validator and resolve the rules array once so each call
+  // avoids re-creating the curried closure and a fresh default array.
+  const rules = option ?? [];
+  const run = core<number>("number");
+  const validator = (value: number) => run(value, rules, message);
   return attachStandard<number, number, typeof validator>(validator);
 };

--- a/package/main/src/Validate/object/core.ts
+++ b/package/main/src/Validate/object/core.ts
@@ -73,9 +73,6 @@ export const object = <T extends ObjectShape>(
 ): ObjectValidator<T> & StandardSchemaV1<InferObject<T>, InferObject<T>> => {
   type Inferred = InferObject<T>;
 
-  // Resolve the property keys and their validators once at factory time so the
-  // hot path iterates a fixed-length array instead of walking the prototype
-  // chain with `for...in` on every call.
   const keys = Object.keys(option);
   const validators = keys.map((key) => option[key]);
   const length = keys.length;

--- a/package/main/src/Validate/object/core.ts
+++ b/package/main/src/Validate/object/core.ts
@@ -73,6 +73,13 @@ export const object = <T extends ObjectShape>(
 ): ObjectValidator<T> & StandardSchemaV1<InferObject<T>, InferObject<T>> => {
   type Inferred = InferObject<T>;
 
+  // Resolve the property keys and their validators once at factory time so the
+  // hot path iterates a fixed-length array instead of walking the prototype
+  // chain with `for...in` on every call.
+  const keys = Object.keys(option);
+  const validators = keys.map((key) => option[key]);
+  const length = keys.length;
+
   const validator = ((value: Inferred): ValidateCoreReturnType<Inferred> => {
     if (!isDictionaryObject(value)) {
       return {
@@ -81,13 +88,13 @@ export const object = <T extends ObjectShape>(
         type: value,
       };
     }
-    for (const validate in option) {
+    for (let index = 0; index < length; index++) {
       // biome-ignore lint/suspicious/noExplicitAny: Index access requires any cast
-      if (!option[validate]((value as any)[validate]).validate) {
+      const result = validators[index]((value as any)[keys[index]]);
+      if (!result.validate) {
         return {
           validate: false,
-          // biome-ignore lint/suspicious/noExplicitAny: Index access requires any cast
-          message: option[validate](value as any).message,
+          message: result.message,
           // biome-ignore lint/suspicious/noExplicitAny: Type assertion needed for return type compatibility
           type: value as any,
         };

--- a/package/main/src/Validate/string/core.ts
+++ b/package/main/src/Validate/string/core.ts
@@ -25,8 +25,6 @@ export const string = <T extends ValidateReturnType<string>[]>(
   message?: string,
 ): ((value: string) => ValidateCoreReturnType<string>) &
   StandardSchemaV1<string, string> => {
-  // Build the core validator and resolve the rules array once so each call
-  // avoids re-creating the curried closure and a fresh default array.
   const rules = option ?? [];
   const run = core<string>("string");
   const validator = (value: string) => run(value, rules, message);

--- a/package/main/src/Validate/string/core.ts
+++ b/package/main/src/Validate/string/core.ts
@@ -25,7 +25,10 @@ export const string = <T extends ValidateReturnType<string>[]>(
   message?: string,
 ): ((value: string) => ValidateCoreReturnType<string>) &
   StandardSchemaV1<string, string> => {
-  const validator = (value: string) =>
-    core<string>("string")(value, option, message);
+  // Build the core validator and resolve the rules array once so each call
+  // avoids re-creating the curried closure and a fresh default array.
+  const rules = option ?? [];
+  const run = core<string>("string");
+  const validator = (value: string) => run(value, rules, message);
   return attachStandard<string, string, typeof validator>(validator);
 };

--- a/package/main/src/tests/benchmark/validate.edgeCases.benchmark.ts
+++ b/package/main/src/tests/benchmark/validate.edgeCases.benchmark.ts
@@ -1,0 +1,185 @@
+import { bench, run, summary, do_not_optimize } from "mitata";
+import {
+  array as vbArray,
+  minValue as vbMinValue,
+  number as vbNumber,
+  object as vbObject,
+  optional as vbOptional,
+  picklist as vbPicklist,
+  pipe as vbPipe,
+  safeParse as vbSafeParse,
+  string as vbString,
+  union as vbUnion,
+} from "valibot";
+import { z } from "zod";
+import { arrayOf } from "@/Validate/array";
+import { number } from "@/Validate/number";
+import { minValue } from "@/Validate/number/minValue";
+import { object } from "@/Validate/object";
+import { optional } from "@/Validate/object/optional";
+import { union } from "@/Validate/object/union";
+import { string } from "@/Validate/string";
+import { oneOf } from "@/Validate/string/oneOf";
+
+// Exercises paths that a flat happy-path benchmark misses: fail-fast rejection,
+// union branch selection, optional members left out, literal-union membership,
+// and a large primitive array. Each group repeats its validation enough times
+// to bring one measured sample to a few hundred milliseconds so fixed overhead
+// stays negligible. The count is shared across the libraries within a group.
+const FAILURE_ITERATIONS = 1_000_000;
+const UNION_ITERATIONS = 1_000_000;
+const OPTIONAL_ITERATIONS = 500_000;
+const ENUM_ITERATIONS = 1_000_000;
+const LARGE_ARRAY_ITERATIONS = 2000;
+
+// ------------------------------------------- fail fast (first key is wrong)
+const umtFailure = object({ name: string(), age: number() });
+const zodFailure = z.object({ name: z.string(), age: z.number() });
+const valibotFailure = vbObject({ name: vbString(), age: vbNumber() });
+const failureValue = { name: 123, age: 30 };
+
+summary(() => {
+  bench("failure · UMT", () => {
+    for (let i = 0; i < FAILURE_ITERATIONS; i++) {
+      do_not_optimize(umtFailure(failureValue as never));
+    }
+  });
+
+  bench("failure · Zod", () => {
+    for (let i = 0; i < FAILURE_ITERATIONS; i++) {
+      do_not_optimize(zodFailure.safeParse(failureValue));
+    }
+  });
+
+  bench("failure · Valibot", () => {
+    for (let i = 0; i < FAILURE_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotFailure, failureValue));
+    }
+  });
+});
+
+// ------------------------------------------- union (matches second branch)
+const umtUnion = union(string(), number());
+const zodUnion = z.union([z.string(), z.number()]);
+const valibotUnion = vbUnion([vbString(), vbNumber()]);
+const unionValue = 42;
+
+summary(() => {
+  bench("union · UMT", () => {
+    for (let i = 0; i < UNION_ITERATIONS; i++) {
+      do_not_optimize(umtUnion(unionValue));
+    }
+  });
+
+  bench("union · Zod", () => {
+    for (let i = 0; i < UNION_ITERATIONS; i++) {
+      do_not_optimize(zodUnion.safeParse(unionValue));
+    }
+  });
+
+  bench("union · Valibot", () => {
+    for (let i = 0; i < UNION_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotUnion, unionValue));
+    }
+  });
+});
+
+// ------------------------------------------- optional members left out
+const umtOptional = object({
+  id: string(),
+  nick: optional(string()),
+  bio: optional(string()),
+});
+const zodOptional = z.object({
+  id: z.string(),
+  nick: z.string().optional(),
+  bio: z.string().optional(),
+});
+const valibotOptional = vbObject({
+  id: vbString(),
+  nick: vbOptional(vbString()),
+  bio: vbOptional(vbString()),
+});
+const optionalValue = { id: "u1" };
+
+summary(() => {
+  bench("optional · UMT", () => {
+    for (let i = 0; i < OPTIONAL_ITERATIONS; i++) {
+      do_not_optimize(umtOptional(optionalValue as never));
+    }
+  });
+
+  bench("optional · Zod", () => {
+    for (let i = 0; i < OPTIONAL_ITERATIONS; i++) {
+      do_not_optimize(zodOptional.safeParse(optionalValue));
+    }
+  });
+
+  bench("optional · Valibot", () => {
+    for (let i = 0; i < OPTIONAL_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotOptional, optionalValue));
+    }
+  });
+});
+
+// ------------------------------------------- literal union membership
+const enumValues = ["a", "b", "c", "d", "e", "f"] as const;
+const umtEnum = oneOf(enumValues);
+const zodEnum = z.enum(enumValues);
+const valibotEnum = vbPicklist(enumValues);
+const enumValue = "f";
+
+summary(() => {
+  bench("enum · UMT", () => {
+    for (let i = 0; i < ENUM_ITERATIONS; i++) {
+      do_not_optimize(umtEnum(enumValue));
+    }
+  });
+
+  bench("enum · Zod", () => {
+    for (let i = 0; i < ENUM_ITERATIONS; i++) {
+      do_not_optimize(zodEnum.safeParse(enumValue));
+    }
+  });
+
+  bench("enum · Valibot", () => {
+    for (let i = 0; i < ENUM_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotEnum, enumValue));
+    }
+  });
+});
+
+// ------------------------------------------- large primitive array
+const umtLargeArray = arrayOf(number([minValue(0)]));
+const zodLargeArray = z.array(z.number().min(0));
+const valibotLargeArray = vbArray(vbPipe(vbNumber(), vbMinValue(0)));
+const largeArrayValue = Array.from({ length: 1000 }, (_, i) => i);
+
+summary(() => {
+  bench("largeArray · UMT", () => {
+    for (let i = 0; i < LARGE_ARRAY_ITERATIONS; i++) {
+      do_not_optimize(umtLargeArray(largeArrayValue));
+    }
+  });
+
+  bench("largeArray · Zod", () => {
+    for (let i = 0; i < LARGE_ARRAY_ITERATIONS; i++) {
+      do_not_optimize(zodLargeArray.safeParse(largeArrayValue));
+    }
+  });
+
+  bench("largeArray · Valibot", () => {
+    for (let i = 0; i < LARGE_ARRAY_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotLargeArray, largeArrayValue));
+    }
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution:", e);
+  }
+})();

--- a/package/main/src/tests/benchmark/validate.libraries.benchmark.ts
+++ b/package/main/src/tests/benchmark/validate.libraries.benchmark.ts
@@ -1,0 +1,164 @@
+import { bench, run, summary, do_not_optimize } from "mitata";
+import {
+  array as vbArray,
+  boolean as vbBoolean,
+  maxLength as vbMaxLength,
+  maxValue as vbMaxValue,
+  minLength as vbMinLength,
+  minValue as vbMinValue,
+  number as vbNumber,
+  object as vbObject,
+  pipe as vbPipe,
+  safeParse as vbSafeParse,
+  string as vbString,
+} from "valibot";
+import { z } from "zod";
+import { arrayOf } from "@/Validate/array";
+import { boolean } from "@/Validate/boolean";
+import { number } from "@/Validate/number";
+import { maxValue } from "@/Validate/number/maxValue";
+import { minValue } from "@/Validate/number/minValue";
+import { object } from "@/Validate/object";
+import { string } from "@/Validate/string";
+import { maxLength } from "@/Validate/string/maxLength";
+import { minLength } from "@/Validate/string/minLength";
+
+// Compares UMT validators against Zod and Valibot on representative shapes.
+// UMT validators only report a pass/fail result, so the Zod and Valibot
+// schemas are run through their safe-parse entry points to keep the compared
+// work equivalent (validate without throwing). Each group repeats a single
+// validation enough times to bring one measured sample to a few hundred
+// milliseconds so fixed overhead stays negligible. The count is shared across
+// the libraries within a group.
+const STRING_ITERATIONS = 1_000_000;
+const NUMBER_ITERATIONS = 1_000_000;
+const OBJECT_ITERATIONS = 300_000;
+const ARRAY_ITERATIONS = 30_000;
+
+// ---------------------------------------------------------------- string
+const umtString = string([minLength(3), maxLength(20)]);
+const zodString = z.string().min(3).max(20);
+const valibotString = vbPipe(vbString(), vbMinLength(3), vbMaxLength(20));
+const stringValue = "hello world";
+
+summary(() => {
+  bench("string · UMT", () => {
+    for (let i = 0; i < STRING_ITERATIONS; i++) {
+      do_not_optimize(umtString(stringValue));
+    }
+  });
+
+  bench("string · Zod", () => {
+    for (let i = 0; i < STRING_ITERATIONS; i++) {
+      do_not_optimize(zodString.safeParse(stringValue));
+    }
+  });
+
+  bench("string · Valibot", () => {
+    for (let i = 0; i < STRING_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotString, stringValue));
+    }
+  });
+});
+
+// ---------------------------------------------------------------- number
+const umtNumber = number([minValue(0), maxValue(100)]);
+const zodNumber = z.number().min(0).max(100);
+const valibotNumber = vbPipe(vbNumber(), vbMinValue(0), vbMaxValue(100));
+const numberValue = 42;
+
+summary(() => {
+  bench("number · UMT", () => {
+    for (let i = 0; i < NUMBER_ITERATIONS; i++) {
+      do_not_optimize(umtNumber(numberValue));
+    }
+  });
+
+  bench("number · Zod", () => {
+    for (let i = 0; i < NUMBER_ITERATIONS; i++) {
+      do_not_optimize(zodNumber.safeParse(numberValue));
+    }
+  });
+
+  bench("number · Valibot", () => {
+    for (let i = 0; i < NUMBER_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotNumber, numberValue));
+    }
+  });
+});
+
+// ---------------------------------------------------------------- object
+const umtObject = object({
+  name: string([minLength(1)]),
+  age: number([minValue(0)]),
+  email: string([minLength(3)]),
+  active: boolean(),
+});
+const zodObject = z.object({
+  name: z.string().min(1),
+  age: z.number().min(0),
+  email: z.string().min(3),
+  active: z.boolean(),
+});
+const valibotObject = vbObject({
+  name: vbPipe(vbString(), vbMinLength(1)),
+  age: vbPipe(vbNumber(), vbMinValue(0)),
+  email: vbPipe(vbString(), vbMinLength(3)),
+  active: vbBoolean(),
+});
+const objectValue = { name: "John", age: 30, email: "j@x.io", active: true };
+
+summary(() => {
+  bench("object · UMT", () => {
+    for (let i = 0; i < OBJECT_ITERATIONS; i++) {
+      do_not_optimize(umtObject(objectValue));
+    }
+  });
+
+  bench("object · Zod", () => {
+    for (let i = 0; i < OBJECT_ITERATIONS; i++) {
+      do_not_optimize(zodObject.safeParse(objectValue));
+    }
+  });
+
+  bench("object · Valibot", () => {
+    for (let i = 0; i < OBJECT_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotObject, objectValue));
+    }
+  });
+});
+
+// ---------------------------------------------- array of objects
+const umtArray = arrayOf(umtObject);
+const zodArray = z.array(zodObject);
+const valibotArray = vbArray(valibotObject);
+const arrayValue = Array.from({ length: 20 }, () => objectValue);
+
+summary(() => {
+  bench("array · UMT", () => {
+    for (let i = 0; i < ARRAY_ITERATIONS; i++) {
+      do_not_optimize(umtArray(arrayValue as never));
+    }
+  });
+
+  bench("array · Zod", () => {
+    for (let i = 0; i < ARRAY_ITERATIONS; i++) {
+      do_not_optimize(zodArray.safeParse(arrayValue));
+    }
+  });
+
+  bench("array · Valibot", () => {
+    for (let i = 0; i < ARRAY_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotArray, arrayValue));
+    }
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution:", e);
+  }
+})();

--- a/package/main/src/tests/benchmark/validate.nested.benchmark.ts
+++ b/package/main/src/tests/benchmark/validate.nested.benchmark.ts
@@ -1,0 +1,92 @@
+import { bench, run, summary, do_not_optimize } from "mitata";
+import {
+  number as vbNumber,
+  object as vbObject,
+  safeParse as vbSafeParse,
+  string as vbString,
+} from "valibot";
+import { z } from "zod";
+import { number } from "@/Validate/number";
+import { object } from "@/Validate/object";
+import { string } from "@/Validate/string";
+
+// Validates a five-level-deep nested object so the comparison stresses
+// recursive descent rather than a single flat shape. Each library builds the
+// same tree of leaf and branch schemas. The loop repeats the validation enough
+// times to bring one measured sample to a few hundred milliseconds so fixed
+// overhead stays negligible. The count is shared across the libraries.
+const NESTED_ITERATIONS = 200_000;
+
+const umtLeaf = object({ a: string(), b: number() });
+const umtLevel4 = object({ a: string(), b: number(), child: umtLeaf });
+const umtLevel3 = object({ a: string(), b: number(), child: umtLevel4 });
+const umtLevel2 = object({ a: string(), b: number(), child: umtLevel3 });
+const umtNested = object({ a: string(), b: number(), child: umtLevel2 });
+
+const zodLeaf = z.object({ a: z.string(), b: z.number() });
+const zodLevel4 = z.object({ a: z.string(), b: z.number(), child: zodLeaf });
+const zodLevel3 = z.object({ a: z.string(), b: z.number(), child: zodLevel4 });
+const zodLevel2 = z.object({ a: z.string(), b: z.number(), child: zodLevel3 });
+const zodNested = z.object({ a: z.string(), b: z.number(), child: zodLevel2 });
+
+const valibotLeaf = vbObject({ a: vbString(), b: vbNumber() });
+const valibotLevel4 = vbObject({
+  a: vbString(),
+  b: vbNumber(),
+  child: valibotLeaf,
+});
+const valibotLevel3 = vbObject({
+  a: vbString(),
+  b: vbNumber(),
+  child: valibotLevel4,
+});
+const valibotLevel2 = vbObject({
+  a: vbString(),
+  b: vbNumber(),
+  child: valibotLevel3,
+});
+const valibotNested = vbObject({
+  a: vbString(),
+  b: vbNumber(),
+  child: valibotLevel2,
+});
+
+const leaf = { a: "leaf", b: 5 };
+const nestedValue = {
+  a: "l1",
+  b: 1,
+  child: {
+    a: "l2",
+    b: 2,
+    child: { a: "l3", b: 3, child: { a: "l4", b: 4, child: leaf } },
+  },
+};
+
+summary(() => {
+  bench("nested · UMT", () => {
+    for (let i = 0; i < NESTED_ITERATIONS; i++) {
+      do_not_optimize(umtNested(nestedValue));
+    }
+  });
+
+  bench("nested · Zod", () => {
+    for (let i = 0; i < NESTED_ITERATIONS; i++) {
+      do_not_optimize(zodNested.safeParse(nestedValue));
+    }
+  });
+
+  bench("nested · Valibot", () => {
+    for (let i = 0; i < NESTED_ITERATIONS; i++) {
+      do_not_optimize(vbSafeParse(valibotNested, nestedValue));
+    }
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution:", e);
+  }
+})();

--- a/package/main/src/tests/benchmark/validate.standardSchema.benchmark.ts
+++ b/package/main/src/tests/benchmark/validate.standardSchema.benchmark.ts
@@ -1,0 +1,103 @@
+import { sValidator } from "@hono/standard-validator";
+import { Hono } from "hono";
+import { bench, run, summary, do_not_optimize } from "mitata";
+import {
+  array as vbArray,
+  boolean as vbBoolean,
+  number as vbNumber,
+  object as vbObject,
+  string as vbString,
+} from "valibot";
+import { z } from "zod";
+import { arrayOf } from "@/Validate/array";
+import { boolean } from "@/Validate/boolean";
+import { number } from "@/Validate/number";
+import { object } from "@/Validate/object";
+import { string } from "@/Validate/string";
+
+// UMT, Zod, and Valibot all implement Standard Schema, so the same object can
+// be driven both through the raw `~standard.validate` entry point and through
+// Hono's `sValidator`, which consumes any Standard Schema. The direct group
+// repeats the call enough times to make one sample last a few hundred
+// milliseconds. The Hono group issues one real request per measured iteration
+// with a hundred-element array payload so validation is a meaningful share of
+// the request rather than being dwarfed by routing and JSON parsing.
+const DIRECT_ITERATIONS = 500_000;
+
+const umtSchema = object({ name: string(), age: number(), active: boolean() });
+const zodSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  active: z.boolean(),
+});
+const valibotSchema = vbObject({
+  name: vbString(),
+  age: vbNumber(),
+  active: vbBoolean(),
+});
+const inputValue = { name: "John", age: 30, active: true };
+
+// ------------------------------------------- raw Standard Schema interface
+summary(() => {
+  bench("standard · UMT", () => {
+    for (let i = 0; i < DIRECT_ITERATIONS; i++) {
+      do_not_optimize(umtSchema["~standard"].validate(inputValue));
+    }
+  });
+
+  bench("standard · Zod", () => {
+    for (let i = 0; i < DIRECT_ITERATIONS; i++) {
+      do_not_optimize(zodSchema["~standard"].validate(inputValue));
+    }
+  });
+
+  bench("standard · Valibot", () => {
+    for (let i = 0; i < DIRECT_ITERATIONS; i++) {
+      do_not_optimize(valibotSchema["~standard"].validate(inputValue));
+    }
+  });
+});
+
+// ------------------------------------------- Hono sValidator end-to-end
+const umtListSchema = arrayOf(umtSchema);
+const zodListSchema = z.array(zodSchema);
+const valibotListSchema = vbArray(valibotSchema);
+const umtApp = new Hono().post("/u", sValidator("json", umtListSchema), (c) =>
+  c.json({ count: c.req.valid("json").length }),
+);
+const zodApp = new Hono().post("/u", sValidator("json", zodListSchema), (c) =>
+  c.json({ count: c.req.valid("json").length }),
+);
+const valibotApp = new Hono().post(
+  "/u",
+  sValidator("json", valibotListSchema),
+  (c) => c.json({ count: c.req.valid("json").length }),
+);
+const requestInit = {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(Array.from({ length: 100 }, () => inputValue)),
+};
+
+summary(() => {
+  bench("hono · UMT", async () => {
+    do_not_optimize(await umtApp.request("/u", requestInit));
+  });
+
+  bench("hono · Zod", async () => {
+    do_not_optimize(await zodApp.request("/u", requestInit));
+  });
+
+  bench("hono · Valibot", async () => {
+    do_not_optimize(await valibotApp.request("/u", requestInit));
+  });
+});
+
+(async () => {
+  try {
+    await run();
+    console.log("Benchmark finished successfully.");
+  } catch (e) {
+    console.error("Error during benchmark execution:", e);
+  }
+})();


### PR DESCRIPTION
## Summary
This PR adds comprehensive benchmark suites comparing UMT validators against Zod and Valibot, while also optimizing the core validation logic for better performance.

## Key Changes

### New Benchmark Suites
- **validate.libraries.benchmark.ts**: Compares UMT, Zod, and Valibot on representative shapes (string, number, object, array)
- **validate.edgeCases.benchmark.ts**: Tests edge cases including fail-fast rejection, union branch selection, optional members, literal unions, and large arrays
- **validate.nested.benchmark.ts**: Stresses recursive descent with five-level-deep nested objects
- **validate.standardSchema.benchmark.ts**: Tests Standard Schema interface compliance and Hono integration

### Performance Optimizations
- **core/index.ts**: 
  - Reuse success result object to avoid repeated allocations
  - Use indexed for-loops instead of for-of for better performance
  - Cache empty options array as constant
  
- **array/arrayOf.ts**:
  - Pre-cast validator function to avoid repeated type assertions
  - Use indexed for-loop instead of for-of iteration
  
- **object/core.ts**:
  - Pre-compute object keys and validators array
  - Cache array length for loop optimization
  - Use indexed for-loop instead of for-in iteration
  
- **number/core.ts**, **string/core.ts**, **boolean/core.ts**:
  - Cache rules array and core validator function to avoid repeated function calls

## Implementation Details
All optimizations follow the same pattern: pre-compute values outside hot loops, use indexed for-loops for better V8 optimization, and avoid repeated function calls and type assertions. The benchmarks use the `mitata` library with `do_not_optimize` to prevent compiler optimizations from skewing results.

https://claude.ai/code/session_01FDfidNfumuGwgaDKcbusfK