### PR TITLE
feat: add Date.isSame for unit-granular date equality

### DIFF
--- a/package/main/README.md
+++ b/package/main/README.md
@@ -140,6 +140,7 @@ bun add umt
 - [getTimezoneOffsetString](https://github.com/riya-amemiya/UMT/wiki/Function.getTimezoneOffsetString)
 - [isBusinessDay](https://github.com/riya-amemiya/UMT/wiki/Function.isBusinessDay)
 - [isLeapYear](https://github.com/riya-amemiya/UMT/wiki/Function.isLeapYear)
+- [isSame](https://github.com/riya-amemiya/UMT/wiki/Function.isSame)
 - [isSameDay](https://github.com/riya-amemiya/UMT/wiki/Function.isSameDay)
 - [isWeekend](https://github.com/riya-amemiya/UMT/wiki/Function.isWeekend)
 - [newDateInt](https://github.com/riya-amemiya/UMT/wiki/Function.newDateInt)

--- a/package/main/src/Date/index.ts
+++ b/package/main/src/Date/index.ts
@@ -11,6 +11,7 @@ export * from "./getDay";
 export * from "./getTimezoneOffsetString";
 export * from "./isBusinessDay";
 export * from "./isLeapYear";
+export * from "./isSame";
 export * from "./isSameDay";
 export * from "./isWeekend";
 export * from "./new";

--- a/package/main/src/Date/isSame.ts
+++ b/package/main/src/Date/isSame.ts
@@ -1,0 +1,27 @@
+import { startOf, type DateBoundaryUnit } from "./startOf";
+
+/**
+ * Returns true when two dates are the same at the given unit granularity.
+ * Without a unit, compares exact timestamps (millisecond precision).
+ * With a unit, both dates are truncated with `startOf` before comparison.
+ * Week boundaries follow Sunday-start local time, matching `startOf`.
+ *
+ * @param {Date} left - First date
+ * @param {Date} right - Second date
+ * @param {DateBoundaryUnit} [unit] - Granularity; omit for exact equality
+ * @returns {boolean} True when the dates match at the given granularity
+ * @example
+ * isSame(new Date(2025, 3, 15, 1), new Date(2025, 3, 15, 23), "day"); // true
+ * isSame(new Date(2025, 3, 15), new Date(2025, 4, 15), "month"); // false
+ * isSame(new Date(2025, 0, 1), new Date(2025, 0, 1)); // true
+ */
+export const isSame = (
+  left: Date,
+  right: Date,
+  unit?: DateBoundaryUnit,
+): boolean => {
+  if (unit === undefined) {
+    return left.getTime() === right.getTime();
+  }
+  return startOf(left, unit).getTime() === startOf(right, unit).getTime();
+};

--- a/package/main/src/tests/unit/Date/isSame.test.ts
+++ b/package/main/src/tests/unit/Date/isSame.test.ts
@@ -1,0 +1,127 @@
+import { isSame } from "@/Date/isSame";
+
+describe("isSame", () => {
+  it("returns true for identical timestamps without unit", () => {
+    const date = new Date(2025, 3, 15, 10, 30, 45, 123);
+    expect(isSame(date, new Date(date.getTime()))).toBe(true);
+  });
+
+  it("returns false for different milliseconds without unit", () => {
+    expect(
+      isSame(
+        new Date(2025, 3, 15, 10, 30, 45, 123),
+        new Date(2025, 3, 15, 10, 30, 45, 124),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for same second ignoring milliseconds", () => {
+    expect(
+      isSame(
+        new Date(2025, 3, 15, 10, 30, 45, 0),
+        new Date(2025, 3, 15, 10, 30, 45, 999),
+        "second",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for different seconds", () => {
+    expect(
+      isSame(
+        new Date(2025, 3, 15, 10, 30, 45),
+        new Date(2025, 3, 15, 10, 30, 46),
+        "second",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for same minute ignoring seconds", () => {
+    expect(
+      isSame(
+        new Date(2025, 3, 15, 10, 30, 0),
+        new Date(2025, 3, 15, 10, 30, 59),
+        "minute",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for same hour ignoring minutes", () => {
+    expect(
+      isSame(
+        new Date(2025, 3, 15, 10, 0),
+        new Date(2025, 3, 15, 10, 59),
+        "hour",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for same day with different times", () => {
+    expect(
+      isSame(new Date(2025, 3, 15, 1, 0), new Date(2025, 3, 15, 23, 59), "day"),
+    ).toBe(true);
+  });
+
+  it("returns false for adjacent days", () => {
+    expect(isSame(new Date(2025, 3, 15), new Date(2025, 3, 16), "day")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for same week Sunday-start", () => {
+    // 2025-04-13 is Sunday, 2025-04-19 is Saturday
+    expect(isSame(new Date(2025, 3, 13), new Date(2025, 3, 19), "week")).toBe(
+      true,
+    );
+  });
+
+  it("returns false across week boundary", () => {
+    // 2025-04-19 Saturday, 2025-04-20 Sunday
+    expect(isSame(new Date(2025, 3, 19), new Date(2025, 3, 20), "week")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for same month with different days", () => {
+    expect(isSame(new Date(2025, 3, 1), new Date(2025, 3, 30), "month")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for different months", () => {
+    expect(isSame(new Date(2025, 3, 15), new Date(2025, 4, 15), "month")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for same quarter", () => {
+    // Q2: Apr-Jun
+    expect(isSame(new Date(2025, 3, 1), new Date(2025, 5, 30), "quarter")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for different quarters", () => {
+    // Mar is Q1, Apr is Q2
+    expect(isSame(new Date(2025, 2, 31), new Date(2025, 3, 1), "quarter")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for same year with different months", () => {
+    expect(isSame(new Date(2025, 0, 1), new Date(2025, 11, 31), "year")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for different years", () => {
+    expect(isSame(new Date(2024, 3, 15), new Date(2025, 3, 15), "year")).toBe(
+      false,
+    );
+  });
+
+  it("matches isSameDay semantics when unit is day", () => {
+    const left = new Date(2025, 3, 15, 1, 0);
+    const right = new Date(2025, 3, 15, 23, 59);
+    expect(isSame(left, right, "day")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isSame(left, right, unit?)` to the Date module
- Without `unit`, compares exact timestamps (millisecond precision)
- With `DateBoundaryUnit`, truncates both sides via `startOf` before comparing (Sunday-start weeks, same as existing `startOf`)
- Unit tests cover all boundary units; `isSame(..., "day")` aligns with `isSameDay` semantics
- README Date section lists the new export

## Stack
This is base PR 1/2. A follow-up PR adds dayjs compatibility checks for Date utilities (including `isSame`).

## Test plan
- [x] `bunx jest src/tests/unit/Date/isSame.test.ts --coverage=false`
- [x] Biome format on touched files
- [ ] CI green