### PR TITLE
fix: repair main CI after dayjs suite merge

### DIFF
--- a/.github/workflows/main-package-bun.yml
+++ b/.github/workflows/main-package-bun.yml
@@ -65,10 +65,14 @@ jobs:
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
       - name: Restore Dependencies Cache
+        id: cache-restore-dev-depends
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: '**/node_modules'
           key: dev-depends-${{ matrix.os }}-bun-${{ hashFiles('package/main/bun.lock') }}
+      - name: Install Dependencies
+        if: steps.cache-restore-dev-depends.outputs.cache-hit != 'true'
+        run: nix develop -c bun i
       - name: Run Lint
         run: nix develop -c bun run lint:ci
   build:
@@ -88,10 +92,14 @@ jobs:
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
       - name: Restore Dependencies Cache
+        id: cache-restore-dev-depends
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: '**/node_modules'
           key: dev-depends-${{ matrix.os }}-bun-${{ hashFiles('package/main/bun.lock') }}
+      - name: Install Dependencies
+        if: steps.cache-restore-dev-depends.outputs.cache-hit != 'true'
+        run: nix develop -c bun i
       - name: Restore Build Cache
         id: cache-restore-prod
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -133,10 +141,14 @@ jobs:
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
       - name: Restore Dependencies Cache
+        id: cache-restore-dev-depends
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: '**/node_modules'
           key: dev-depends-${{ matrix.os }}-bun-${{ hashFiles('package/main/bun.lock') }}
+      - name: Install Dependencies
+        if: steps.cache-restore-dev-depends.outputs.cache-hit != 'true'
+        run: nix develop -c bun i
       - name: Run Tests with Coverage
         run: |
           set -o pipefail

--- a/package/main/src/tests/integration/Date/dayjs-compatibility.test.ts
+++ b/package/main/src/tests/integration/Date/dayjs-compatibility.test.ts
@@ -40,6 +40,17 @@ const boundaryUnits: DateBoundaryUnit[] = [
   "year",
 ];
 
+const dayjsIsSame = (
+  left: Date,
+  right: Date,
+  unit: DateBoundaryUnit,
+): boolean => {
+  if (unit === "quarter") {
+    return dayjs(left).isSame(right, "quarter");
+  }
+  return dayjs(left).isSame(right, unit);
+};
+
 describe("dayjs compatibility for Date utilities", () => {
   describe("isSame", () => {
     const left = new Date(2025, 3, 15, 10, 30, 45, 123);
@@ -68,7 +79,7 @@ describe("dayjs compatibility for Date utilities", () => {
         [new Date(2024, 11, 31), new Date(2025, 0, 1)],
       ];
       for (const [a, b] of pairs) {
-        expect(isSame(a, b, unit)).toBe(dayjs(a).isSame(b, unit));
+        expect(isSame(a, b, unit)).toBe(dayjsIsSame(a, b, unit));
       }
     });
   });


### PR DESCRIPTION
## Summary
Main CI failed after #927 with two independent causes.

1. **Publish Wiki / TypeDoc** – `dayjs.isSame(date, unit)` overloads reject `DateBoundaryUnit` when it includes both `"week"` and `"quarter"`. Added a small helper that narrows `"quarter"` before calling dayjs.
2. **Main Package CI (Bun) lint/test** – setup installed deps, but saving the shared `node_modules` cache hit a rate limit / concurrent save. Lint and test jobs then restored a miss and ran with no `node_modules`, so `bunx eslint` / `bunx jest` failed. Those jobs now reinstall when the cache is cold.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx typedoc` succeeds
- [x] `bunx jest src/tests/integration/Date/dayjs-compatibility.test.ts --coverage=false` (58 passed)
- [ ] CI green on this PR